### PR TITLE
Add opt-in anonymous launch ping telemetry

### DIFF
--- a/cloudflare/ping-worker/README.md
+++ b/cloudflare/ping-worker/README.md
@@ -1,0 +1,47 @@
+# bowser-ping
+
+Collector for Bowser's opt-in, anonymous launch ping (Settings → "Help
+improve Bowser"). Receives `POST /ping` with `{version, platform, arch}`
+and tallies counts in Workers KV. `GET /stats` (bearer-token gated) returns
+the current totals.
+
+## Deploy
+
+Requires a Cloudflare account and `wrangler` (installed on demand via `npx`,
+no need to add it as a repo dependency).
+
+```
+cd cloudflare/ping-worker
+npx wrangler login                              # opens a browser to authorize
+npx wrangler kv namespace create PINGS          # copy the returned id into wrangler.toml
+npx wrangler secret put STATS_TOKEN             # pick any long random string, save it somewhere safe
+npx wrangler deploy
+```
+
+`wrangler deploy` prints the live URL, something like
+`https://bowser-ping.<your-subdomain>.workers.dev`. Update
+`PING_ENDPOINT` in `src/main/telemetry.js` (in the repo root) to
+`<that-url>/ping`.
+
+To attach it to `api.getbowser.com` instead of the `workers.dev`
+subdomain, add a route in the Cloudflare dashboard (Workers & Pages →
+bowser-ping → Settings → Triggers → Custom Domains) once
+`getbowser.com`'s DNS is on Cloudflare.
+
+## Checking the numbers
+
+```
+curl -H "Authorization: Bearer <STATS_TOKEN>" https://<worker-url>/stats
+```
+
+Returns JSON like:
+
+```json
+{
+  "total": 42,
+  "day:2026-07-05": 3,
+  "version:0.9.1": 40,
+  "version:0.9.0": 2,
+  "platform:darwin": 42
+}
+```

--- a/cloudflare/ping-worker/src/index.js
+++ b/cloudflare/ping-worker/src/index.js
@@ -1,0 +1,63 @@
+// Collector for Bowser's opt-in launch ping (see src/main/telemetry.js in
+// the main repo). Tallies anonymous counts in Workers KV — no IPs, no
+// persistent ids, no browsing data are ever stored.
+
+const ALLOWED_PLATFORMS = new Set(['darwin', 'win32', 'linux']);
+
+// Not atomic (KV has no increment primitive) — a handful of concurrent
+// pings can undercount by a request or two. Fine here: nothing downstream
+// needs an exact number, only the aggregate trend.
+async function bump(kv, key) {
+  const current = parseInt((await kv.get(key)) ?? '0', 10);
+  await kv.put(key, String(current + 1));
+}
+
+function todayKey() {
+  return `day:${new Date().toISOString().slice(0, 10)}`;
+}
+
+async function handlePing(request, env) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('bad request', { status: 400 });
+  }
+
+  const version = typeof body.version === 'string' ? body.version.slice(0, 32) : 'unknown';
+  const platform = ALLOWED_PLATFORMS.has(body.platform) ? body.platform : 'unknown';
+
+  await Promise.all([
+    bump(env.PINGS, 'total'),
+    bump(env.PINGS, todayKey()),
+    bump(env.PINGS, `version:${version}`),
+    bump(env.PINGS, `platform:${platform}`),
+  ]);
+
+  return new Response(null, { status: 204 });
+}
+
+// GET /stats — bearer-token-gated readout so the counts are visible
+// without opening the Cloudflare dashboard's KV browser.
+async function handleStats(request, env) {
+  if (request.headers.get('Authorization') !== `Bearer ${env.STATS_TOKEN}`) {
+    return new Response('unauthorized', { status: 401 });
+  }
+  const { keys } = await env.PINGS.list();
+  const stats = {};
+  for (const { name } of keys) {
+    stats[name] = parseInt((await env.PINGS.get(name)) ?? '0', 10);
+  }
+  return new Response(JSON.stringify(stats, null, 2), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (request.method === 'POST' && url.pathname === '/ping') return handlePing(request, env);
+    if (request.method === 'GET' && url.pathname === '/stats') return handleStats(request, env);
+    return new Response('not found', { status: 404 });
+  },
+};

--- a/cloudflare/ping-worker/wrangler.toml
+++ b/cloudflare/ping-worker/wrangler.toml
@@ -1,0 +1,11 @@
+name = "bowser-ping"
+main = "src/index.js"
+compatibility_date = "2026-07-01"
+
+# Created by `wrangler kv namespace create PINGS` — paste the returned id below.
+kv_namespaces = [
+  { binding = "PINGS", id = "REPLACE_WITH_KV_NAMESPACE_ID" }
+]
+
+# STATS_TOKEN is a secret, not a var — set it with:
+#   wrangler secret put STATS_TOKEN

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -6,6 +6,7 @@ const { setupAdBlocker, setAdBlockEnabled, getBlocker } = require('./adblock');
 const { registerPagesScheme, setupPages } = require('./pages');
 const { setupPermissionPolicy, setPermissionPrompter } = require('./permissions');
 const { setupAutoUpdater, checkForUpdatesManually } = require('./updater');
+const { sendLaunchPing } = require('./telemetry');
 const { setupDownloads } = require('./downloads');
 const { attachContextMenu } = require('./context-menu');
 const { promptForCredentials } = require('./auth-dialog');
@@ -1173,6 +1174,7 @@ app.whenReady().then(async () => {
 
   applyTheme();
   applyAppIcon();
+  if (settings.getSettings().usagePing) sendLaunchPing();
   nativeTheme.on('updated', () => {
     if (win && !win.isDestroyed()) win.setBackgroundColor(chromeBackgroundColor());
   });

--- a/src/main/settings.js
+++ b/src/main/settings.js
@@ -21,6 +21,8 @@ const DEFAULTS = {
   appIcon: 'default',
   // Lowercased hostnames, no protocol/path/www. prefix.
   adblockExceptions: [],
+  // Opt-in, anonymous "app launched" ping — see main/telemetry.js. Off by default.
+  usagePing: false,
 };
 
 let store = null;
@@ -42,6 +44,7 @@ function setSettings(partial) {
     clean.searchEngine = partial.searchEngine;
   }
   if (typeof partial.adblockEnabled === 'boolean') clean.adblockEnabled = partial.adblockEnabled;
+  if (typeof partial.usagePing === 'boolean') clean.usagePing = partial.usagePing;
   if (typeof partial.homePage === 'string') clean.homePage = partial.homePage.trim();
   if (THEMES.includes(partial.theme)) clean.theme = partial.theme;
   if (APP_ICONS.includes(partial.appIcon)) clean.appIcon = partial.appIcon;

--- a/src/main/telemetry.js
+++ b/src/main/telemetry.js
@@ -1,0 +1,29 @@
+const { app, net } = require('electron');
+
+// TODO: no backend exists yet — point this at the real collector before
+// shipping. Expected to accept a JSON POST and return any 2xx.
+const PING_ENDPOINT = 'https://api.getbowser.com/ping';
+
+// Opt-in only (Settings → usagePing, off by default). Fire-and-forget: a
+// failed or blocked ping must never affect startup or show the user
+// anything. Anonymous — no persistent id, just enough to bucket by
+// version/platform.
+function sendLaunchPing() {
+  if (!app.isPackaged) return; // dev runs shouldn't inflate counts
+
+  const payload = JSON.stringify({
+    version: app.getVersion(),
+    platform: process.platform,
+    arch: process.arch,
+  });
+
+  net.fetch(PING_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: payload,
+  }).catch((err) => {
+    console.warn('[telemetry] launch ping failed:', err.message);
+  });
+}
+
+module.exports = { sendLaunchPing };

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -74,6 +74,17 @@
       <input id="homePage" type="url" placeholder="bowser://newtab/" />
     </div>
 
+    <div class="setting">
+      <div class="label">
+        <span>Help improve Bowser</span>
+        <span class="hint">Sends an anonymous ping (app version, OS) when Bowser launches. No browsing data, no id.</span>
+      </div>
+      <label class="toggle">
+        <input id="usagePing" type="checkbox" />
+        <span class="track"></span>
+      </label>
+    </div>
+
     <h1 class="section-title">Ad-block exceptions</h1>
     <p class="section-hint">
       Sites listed here load with ad-blocking turned off, e.g. for sites that break under it.

--- a/src/renderer/pages/settings.js
+++ b/src/renderer/pages/settings.js
@@ -3,6 +3,7 @@
   const searchEngine = document.getElementById('searchEngine');
   const adblockEnabled = document.getElementById('adblockEnabled');
   const homePage = document.getElementById('homePage');
+  const usagePing = document.getElementById('usagePing');
 
   const { settings, searchEngines } = await window.bowserPages.settings.get();
 
@@ -16,6 +17,7 @@
   searchEngine.value = settings.searchEngine;
   adblockEnabled.checked = settings.adblockEnabled;
   homePage.value = settings.homePage;
+  usagePing.checked = settings.usagePing;
 
   theme.addEventListener('change', () =>
     window.bowserPages.settings.set({ theme: theme.value }));
@@ -25,6 +27,8 @@
     window.bowserPages.settings.set({ adblockEnabled: adblockEnabled.checked }));
   homePage.addEventListener('change', () =>
     window.bowserPages.settings.set({ homePage: homePage.value }));
+  usagePing.addEventListener('change', () =>
+    window.bowserPages.settings.set({ usagePing: usagePing.checked }));
 
   // --- Default browser (live OS state, nothing stored) ---
   const defaultBrowserSetting = document.getElementById('defaultBrowserSetting');


### PR DESCRIPTION
Adds an opt-in, anonymous telemetry system to track Bowser launch events by version and platform, with no persistent IDs or browsing data collected.

## Summary

This change implements a complete telemetry pipeline: a Cloudflare Workers backend that collects and aggregates anonymous launch pings, a settings UI toggle for users to opt in, and the client-side code to send pings on app launch.

## Key changes

- **Cloudflare Workers backend** (`cloudflare/ping-worker/`): New worker that accepts `POST /ping` with `{version, platform, arch}` and tallies counts in Workers KV by total, daily, version, and platform. Includes a bearer-token-gated `GET /stats` endpoint for checking aggregates without opening the Cloudflare dashboard.

- **Settings UI** (`src/renderer/pages/settings.html` and `settings.js`): Added "Help improve Bowser" toggle in Settings with explanatory hint text. Wired to the new `usagePing` setting.

- **Settings storage** (`src/main/settings.js`): Added `usagePing` boolean setting (defaults to `false`, opt-in only).

- **Telemetry client** (`src/main/telemetry.js`): New module with `sendLaunchPing()` that fires a fire-and-forget POST to the collector endpoint with app version, platform, and arch. Skips sending in dev builds and silently catches/logs any network errors.

- **Main process integration** (`src/main/main.js`): Calls `sendLaunchPing()` on app ready if the user has opted in.

## Implementation notes

- **Privacy-first**: No persistent IDs, no IP logging, no browsing data — only version/platform/arch bucketing for trend analysis.
- **Fire-and-forget**: Failed or blocked pings never affect startup or show the user anything.
- **Non-atomic KV updates**: The worker acknowledges that concurrent pings may undercount by a request or two, which is acceptable for aggregate trend tracking.
- **Dev builds excluded**: `sendLaunchPing()` returns early if `app.isPackaged` is false to avoid inflating counts during development.

https://claude.ai/code/session_01Bvp51X5H4vUJEgXCDsSXc6