### PR TITLE
Fix Windows/Linux release workflow: real filenames, cert-profile gate

### DIFF
--- a/.github/workflows/release-windows-linux.yml
+++ b/.github/workflows/release-windows-linux.yml
@@ -42,7 +42,7 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
-          if [ -n "$AZURE_CLIENT_ID" ] && [ -n "$AZURE_CODE_SIGNING_ACCOUNT" ]; then
+          if [ -n "$AZURE_CLIENT_ID" ] && [ -n "$AZURE_CODE_SIGNING_ACCOUNT" ] && [ -n "$AZURE_CERT_PROFILE" ]; then
             echo "==> Signing via Azure Trusted Signing ($AZURE_CODE_SIGNING_ACCOUNT/$AZURE_CERT_PROFILE)"
             npx electron-builder --win --publish never \
               --config.win.azureSignOptions.publisherName="$AZURE_PUBLISHER_NAME" \
@@ -53,7 +53,7 @@ jobs:
             echo "==> Signing via CSC_LINK (traditional Authenticode cert)"
             npx electron-builder --win --publish never
           else
-            echo "::warning::No Windows signing configured (neither AZURE_CLIENT_ID/AZURE_CODE_SIGNING_ACCOUNT_NAME nor CSC_LINK are set) — building an UNSIGNED installer. Users will see a SmartScreen 'unknown publisher' warning."
+            echo "::warning::No Windows signing configured (need AZURE_CLIENT_ID+AZURE_CODE_SIGNING_ACCOUNT_NAME+AZURE_CERTIFICATE_PROFILE_NAME, or CSC_LINK) — building an UNSIGNED installer. Users will see a SmartScreen 'unknown publisher' warning."
             npx electron-builder --win --publish never
           fi
 
@@ -99,7 +99,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           PRODUCT_NAME=$(node -p "require('./package.json').productName")
-          for f in "dist/$PRODUCT_NAME-$VERSION-x86_64.AppImage" "dist/$PRODUCT_NAME-$VERSION-x86_64.AppImage.blockmap" "dist/latest-linux.yml"; do
+          for f in "dist/$PRODUCT_NAME-$VERSION.AppImage" "dist/$PRODUCT_NAME-$VERSION.AppImage.blockmap" "dist/latest-linux.yml"; do
             [ -f "$f" ] || { echo "Expected build artifact missing: $f" >&2; exit 1; }
           done
 
@@ -110,7 +110,7 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           PRODUCT_NAME=$(node -p "require('./package.json').productName")
           gh release upload "${{ inputs.tag }}" \
-            "dist/$PRODUCT_NAME-$VERSION-x86_64.AppImage" \
-            "dist/$PRODUCT_NAME-$VERSION-x86_64.AppImage.blockmap" \
+            "dist/$PRODUCT_NAME-$VERSION.AppImage" \
+            "dist/$PRODUCT_NAME-$VERSION.AppImage.blockmap" \
             "dist/latest-linux.yml" \
             --repo "${{ github.repository }}" --clobber


### PR DESCRIPTION
## Summary
The first live dispatch of `release-windows-linux.yml` (against `v0.9.6`) failed both jobs. Both failures are fixed here, verified against the actual CI logs rather than re-guessed:

- **linux**: the build itself succeeded, but electron-builder names the AppImage *without* an arch suffix when building only the default arch — it produced `Blanc-0.9.6.AppImage`, not `Blanc-0.9.6-x86_64.AppImage` as the verify/upload steps assumed. Fixed to match reality.
- **windows**: the build failed outright. The Azure-signing branch only checked `AZURE_CLIENT_ID` and `AZURE_CODE_SIGNING_ACCOUNT_NAME` before attempting to sign — not `AZURE_CERTIFICATE_PROFILE_NAME`. With the client/account already configured but no certificate profile yet (identity validation still pending), it tried to sign with an empty `certificateProfileName`, and PowerShell's `Invoke-TrustedSigning` correctly rejected that instead of falling through to the unsigned build path.

## Test plan
- [x] YAML re-validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Re-dispatch `release-windows-linux.yml` against `v0.9.6` after merge and confirm both jobs go green, producing an unsigned `.exe`/`.AppImage` on the release (expected outcome until the Azure certificate profile exists)

https://claude.ai/code/session_01R8Vnzp2kRBnKoKuNofg93K

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8Vnzp2kRBnKoKuNofg93K)_