### PR TITLE
Drop nonexistent .blockmap from the Linux AppImage asset list

### DIFF
--- a/.github/workflows/release-windows-linux.yml
+++ b/.github/workflows/release-windows-linux.yml
@@ -99,7 +99,9 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           PRODUCT_NAME=$(node -p "require('./package.json').productName")
-          for f in "dist/$PRODUCT_NAME-$VERSION.AppImage" "dist/$PRODUCT_NAME-$VERSION.AppImage.blockmap" "dist/latest-linux.yml"; do
+          # No separate .blockmap here: for AppImage, electron-builder embeds
+          # the block map inside the AppImage itself (mac/win emit separate files).
+          for f in "dist/$PRODUCT_NAME-$VERSION.AppImage" "dist/latest-linux.yml"; do
             [ -f "$f" ] || { echo "Expected build artifact missing: $f" >&2; exit 1; }
           done
 
@@ -111,6 +113,5 @@ jobs:
           PRODUCT_NAME=$(node -p "require('./package.json').productName")
           gh release upload "${{ inputs.tag }}" \
             "dist/$PRODUCT_NAME-$VERSION.AppImage" \
-            "dist/$PRODUCT_NAME-$VERSION.AppImage.blockmap" \
             "dist/latest-linux.yml" \
             --repo "${{ github.repository }}" --clobber


### PR DESCRIPTION
## Summary
Second dispatch of `release-windows-linux.yml` against `v0.9.6`: the AppImage filename fix from #5 worked, but the Linux verify step then failed on `Blanc-0.9.6.AppImage.blockmap`. Per the build log (`• building embedded block map file=dist/Blanc-0.9.6.AppImage`), electron-builder **embeds** the block map inside the AppImage for this target — separate `.blockmap` files only exist for mac zip/dmg and Windows NSIS. The verify/upload lists were demanding a file that never exists on Linux.

## Test plan
- [x] YAML re-validated
- [ ] Re-dispatch against `v0.9.6`; linux job should now pass (windows was already in progress on the corrected path last run)

https://claude.ai/code/session_01R8Vnzp2kRBnKoKuNofg93K

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8Vnzp2kRBnKoKuNofg93K)_