### PR TITLE
Harden ping worker against transient KV failures; enable Workers Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,6 @@ This app was renamed from "Bowser" to Blanc — the code, package identity,
 and visual assets are done, but a few infra steps are deliberately not yet
 live:
 
-- The Cloudflare ping-worker source is renamed to `blanc-ping`
-  (`cloudflare/ping-worker/`), but it hasn't been redeployed — the old
-  `bowser-ping` Worker is still the one actually running.
 - The marketing site (`site/`) is live on the Cloudflare Pages project
   `blancbrowser` (direct upload: `npx wrangler pages deploy site
   --project-name=blancbrowser`), which serves `blancbrowser.com` and

--- a/cloudflare/ping-worker/src/index.js
+++ b/cloudflare/ping-worker/src/index.js
@@ -46,14 +46,19 @@ async function handlePing(request, env, ctx) {
   const platform = ALLOWED_PLATFORMS.has(body.platform) ? body.platform : 'unknown';
   const arch = typeof body.arch === 'string' ? body.arch.slice(0, 16) : 'unknown';
 
+  // GA mirror is queued before the KV writes so a KV failure can't cost
+  // the launch event too.
+  ctx.waitUntil(forwardToGA(env, { version, platform, arch }));
+
+  // KV get/put can throw transiently; the counts are best-effort anyway
+  // (see bump()), so log and still 204 rather than turning a blip into a
+  // dropped ping — the client (src/main/telemetry.js) never retries.
   await Promise.all([
     bump(env.PINGS, 'total'),
     bump(env.PINGS, todayKey()),
     bump(env.PINGS, `version:${version}`),
     bump(env.PINGS, `platform:${platform}`),
-  ]);
-
-  ctx.waitUntil(forwardToGA(env, { version, platform, arch }));
+  ]).catch((err) => console.error('KV bump failed:', err.message));
 
   return new Response(null, { status: 204 });
 }

--- a/cloudflare/ping-worker/wrangler.toml
+++ b/cloudflare/ping-worker/wrangler.toml
@@ -9,3 +9,9 @@ kv_namespaces = [
 
 # STATS_TOKEN is a secret, not a var — set it with:
 #   wrangler secret put STATS_TOKEN
+
+# Workers Logs — keeps a searchable history of invocations/exceptions in the
+# dashboard, so a runtime 500 can be diagnosed after the fact instead of
+# only while `wrangler tail` happens to be attached.
+[observability]
+enabled = true


### PR DESCRIPTION
## Summary
- A transient KV `get`/`put` exception in the `/ping` handler bubbled up unhandled and returned a 500, silently losing the launch ping (the client in `src/main/telemetry.js` is fire-and-forget with no retry). The GA4 mirror is now queued *before* the KV writes, and KV bump failures are caught and logged while still returning 204 — the counts are best-effort by design.
- Enabled `[observability]` in `wrangler.toml` so future runtime exceptions are captured in the dashboard's Workers Logs instead of being visible only while `wrangler tail` happens to be attached (the original 500 left no trace to diagnose).
- Removed the stale README bullet claiming the old `bowser-ping` worker is still the deployed one — `blanc-ping` is live (verified: probe → 204, KV counters incrementing, `bowser-ping` returns 404).

## Test plan
- [x] Deployed to Cloudflare (`npx wrangler deploy`, version `25d55811`) with the `PINGS` KV binding intact
- [x] `POST /ping` with valid JSON → 204, KV counters increment (`total` 8→9)
- [x] `POST /ping` with invalid JSON → 400
- [x] `GET /stats` without bearer token → 401; other routes → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)