### PR TITLE
Arrow-key workspace navigation + Help menu with Keyboard Shortcuts page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# GitHub natively supports Polar as a funding platform — this adds the
+# repo "Sponsor" button with no approval process. The handle must match
+# the Polar organization slug (see docs/polar-setup.md).
+polar: bnfy

--- a/scripts/stats.sh
+++ b/scripts/stats.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Per-release download counts from GitHub Releases, splitting real
+# installer downloads (.dmg / -mac.zip / .exe / .AppImage) from
+# update-check metadata (.yml / .blockmap), which the auto-updater
+# fetches on every launch and would otherwise inflate the numbers.
+# Read-only; uses the gh CLI's cached auth like release.sh.
+set -euo pipefail
+
+command -v gh >/dev/null 2>&1 || { echo "error: gh CLI is required" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "error: gh is not authenticated (run: gh auth login)" >&2; exit 1; }
+
+{
+  printf 'tag\tinstalls\tupdate-checks\n'
+  gh api 'repos/bnfy/blanc/releases' --paginate --jq '
+    .[] | [
+      .tag_name,
+      ([.assets[] | select(.name | test("\\.(dmg|exe|AppImage)$|\\.zip$")) | .download_count] | add // 0),
+      ([.assets[] | select(.name | test("\\.(yml|blockmap)$")) | .download_count] | add // 0)
+    ] | @tsv'
+} | column -t -s $'\t'

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -586,6 +586,20 @@ function clusterList() {
   return list;
 }
 
+/** clusterList() plus a leading pseudo-cluster for pinned tabs, each slot
+ * tagged with a stable key — the one definition of "cluster order" shared
+ * by Cmd/Ctrl+1–9 and the ⌥⌘ arrow navigation. */
+function clusterSlots() {
+  const slots = clusterList().map(({ group, tabIds }) => ({
+    key: group ? group.id : 'loose',
+    group,
+    tabIds,
+  }));
+  const pinnedIds = tabOrder.filter((id) => tabs.get(id)?.pinned);
+  if (pinnedIds.length) slots.unshift({ key: 'pinned', group: null, tabIds: pinnedIds });
+  return slots;
+}
+
 /** A group exists only while it holds tabs — closing or moving out the
  * last one dissolves it (same convention as Chrome's tab groups). */
 function pruneEmptyGroups() {
@@ -1094,14 +1108,11 @@ function reorderTab(id, toIndex) {
  * first tab, unfolding it (Island Tab Groups design). Without groups the
  * browser convention stands: 1–8 jump to that tab, 9 to the last. */
 function selectTabAtIndex(index) {
-  const pinnedIds = tabOrder.filter((id) => tabs.get(id)?.pinned);
-  const clusters = clusterList();
-  if (groups.length && (pinnedIds.length || clusters.length)) {
-    // Pinned tabs are excluded from clusterList()'s own clusters (they get
-    // their own pill shelf/panel section instead) — surface them as a
-    // leading slot here too, so Cmd+1-9 can still reach them instead of
-    // silently skipping every pinned tab whenever a group exists.
-    const slots = pinnedIds.length ? [{ tabIds: pinnedIds }, ...clusters] : clusters;
+  // clusterSlots() surfaces pinned tabs as a leading slot, so Cmd+1-9 can
+  // still reach them instead of silently skipping every pinned tab
+  // whenever a group exists.
+  const slots = clusterSlots();
+  if (groups.length && slots.length) {
     const slot = slots[index];
     if (!slot) return;
     if (slot.group) focusGroup(slot.group.id);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -600,6 +600,15 @@ function clusterSlots() {
   return slots;
 }
 
+/** Cluster key → most recently active tab id there, so ⌥⌘↑/↓ lands back
+ * where you were in each group. In-memory only — a remembered tab that
+ * closed or moved simply fails the lookup and the first tab wins. */
+const lastActiveByCluster = new Map();
+
+function clusterKeyForTab(tab) {
+  return tab.pinned ? 'pinned' : (tab.groupId ?? 'loose');
+}
+
 /** A group exists only while it holds tabs — closing or moving out the
  * last one dissolves it (same convention as Chrome's tab groups). */
 function pruneEmptyGroups() {
@@ -770,6 +779,7 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
     broadcastTabs();
   });
   wc.on('page-favicon-updated', (_e, favicons) => {
+    console.error('[DIAG favicon] page-favicon-updated', tab.id, tab.url, favicons);
     tab.favicon = favicons[0] ?? null; // immediate, possibly low-res
     if (tab.bookmarked) bookmarks.updateFavicon(tab.url, tab.favicon);
     broadcastTabs();
@@ -788,6 +798,7 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
     tab.blockedCount = 0;
     tab.pageBg = null; // a new page's tint mustn't linger from the old one
     tab.themeColor = null;
+    console.error('[DIAG favicon] did-navigate reset', tab.id, url);
     tab.favicon = null; // ditto — the old page's icon mustn't linger either
     syncNavState();
     // Error responses stay out of history — a dead one-shot OAuth URL
@@ -991,6 +1002,8 @@ function setActiveTab(id, { focusContent = true, focusAddress = false } = {}) {
   // Re-selecting the active tab is a no-op.
   if (id === activeTabId) return;
 
+  lastActiveByCluster.set(clusterKeyForTab(next), id);
+
   // No window to attach to (quitting, or macOS with all windows closed):
   // just track the selection so window recreation attaches the right tab.
   // The menu bar persists on macOS even with no windows open, so it still
@@ -1127,6 +1140,33 @@ function cycleTab(direction) {
   if (!activeTabId || tabOrder.length < 2) return;
   const i = tabOrder.indexOf(activeTabId);
   setActiveTab(tabOrder[(i + direction + tabOrder.length) % tabOrder.length]);
+}
+
+/** ⌥⌘←/→: previous/next tab within the active tab's cluster, wrapping.
+ * With no groups and no pins everything is one loose cluster, so this
+ * degrades to plain tab cycling (same result as Ctrl+Tab). */
+function cycleTabInCluster(direction) {
+  if (!activeTabId) return;
+  const slot = clusterSlots().find((s) => s.tabIds.includes(activeTabId));
+  if (!slot) return cycleTab(direction);
+  if (slot.tabIds.length < 2) return;
+  const i = slot.tabIds.indexOf(activeTabId);
+  setActiveTab(slot.tabIds[(i + direction + slot.tabIds.length) % slot.tabIds.length]);
+}
+
+/** ⌥⌘↑/↓: previous/next cluster in ⌘1–9 order (pinned shelf → groups →
+ * loose), wrapping. Lands on the cluster's last-active tab and unfolds a
+ * collapsed group, consistent with focusGroup(). */
+function cycleCluster(direction) {
+  if (!activeTabId) return;
+  const slots = clusterSlots();
+  if (slots.length < 2) return;
+  const from = slots.findIndex((s) => s.tabIds.includes(activeTabId));
+  if (from === -1) return;
+  const target = slots[(from + direction + slots.length) % slots.length];
+  if (target.group) target.group.collapsed = false;
+  const remembered = lastActiveByCluster.get(target.key);
+  setActiveTab(target.tabIds.includes(remembered) ? remembered : target.tabIds[0]);
 }
 
 /** Focus an existing tab already on this internal page, or open one. */
@@ -1433,6 +1473,10 @@ function buildMenu() {
       submenu: [
         { label: 'Next Tab', accelerator: 'Ctrl+Tab', click: () => cycleTab(1) },
         { label: 'Previous Tab', accelerator: 'Ctrl+Shift+Tab', click: () => cycleTab(-1) },
+        { label: 'Next Tab in Group', accelerator: 'Alt+CmdOrCtrl+Right', click: () => cycleTabInCluster(1) },
+        { label: 'Previous Tab in Group', accelerator: 'Alt+CmdOrCtrl+Left', click: () => cycleTabInCluster(-1) },
+        { label: 'Next Group', accelerator: 'Alt+CmdOrCtrl+Down', click: () => cycleCluster(1) },
+        { label: 'Previous Group', accelerator: 'Alt+CmdOrCtrl+Up', click: () => cycleCluster(-1) },
         { type: 'separator' },
         { label: 'Duplicate Tab', enabled: !!activeTabId, click: () => activeTabId && duplicateTab(activeTabId) },
         { label: tabs.get(activeTabId)?.pinned ? 'Unpin Tab' : 'Pin Tab', enabled: !!activeTabId, click: () => activeTabId && toggleTabPinned(activeTabId) },

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1587,6 +1587,13 @@ function buildMenu() {
         { label: 'Show History', accelerator: 'CmdOrCtrl+Y', click: () => openInternalPage('blanc://history/') },
       ],
     },
+    {
+      label: 'Help',
+      ...(isMac ? { role: 'help' } : {}),
+      submenu: [
+        { label: 'Keyboard Shortcuts', accelerator: 'CmdOrCtrl+/', click: () => openInternalPage('blanc://shortcuts/') },
+      ],
+    },
   ];
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1414,6 +1414,53 @@ function favoritesMenuItems() {
   }));
 }
 
+// --- Keyboard shortcuts inventory (Help → Keyboard Shortcuts page) ---
+
+/** 'Alt+CmdOrCtrl+Left' → '⌥⌘←' on macOS, 'Alt+Ctrl+Left' elsewhere —
+ * same per-platform glyph convention the overlay uses. */
+function formatAccelerator(accelerator) {
+  const parts = String(accelerator).split('+');
+  const key = parts.pop();
+  const KEYS = { Left: '←', Right: '→', Up: '↑', Down: '↓', Plus: '+' };
+  const label = KEYS[key] ?? key;
+  if (process.platform !== 'darwin') {
+    return [...parts.map((m) => (m === 'CmdOrCtrl' || m === 'CommandOrControl' ? 'Ctrl' : m)), label].join('+');
+  }
+  const MAC = { CmdOrCtrl: '⌘', CommandOrControl: '⌘', Cmd: '⌘', Ctrl: '⌃', Alt: '⌥', Option: '⌥', Shift: '⇧' };
+  const order = ['⌃', '⌥', '⇧', '⌘'];
+  const mods = parts.map((m) => MAC[m] ?? m).sort((a, b) => order.indexOf(a) - order.indexOf(b));
+  return [...mods, label].join('');
+}
+
+/** Rows for blanc://shortcuts/, read from the LIVE application menu so the
+ * page can never drift from the real bindings, plus static extras for the
+ * island's non-menu keys. Hidden items (silent aliases like ⌘=) are
+ * skipped; the nine ⌘1–9 items collapse into one row. */
+function listShortcuts() {
+  const rows = [];
+  let collapsedTabJumps = false;
+  for (const top of Menu.getApplicationMenu()?.items ?? []) {
+    for (const item of top.submenu?.items ?? []) {
+      if (!item.accelerator || item.visible === false) continue;
+      if (/^CmdOrCtrl\+[1-9]$/.test(item.accelerator)) {
+        if (!collapsedTabJumps) {
+          collapsedTabJumps = true;
+          rows.push({ category: top.label, label: 'Tab or Group 1–9', keys: `${formatAccelerator('CmdOrCtrl+1')}–9` });
+        }
+        continue;
+      }
+      rows.push({ category: top.label, label: item.label, keys: formatAccelerator(item.accelerator) });
+    }
+  }
+  const mod = process.platform === 'darwin' ? '⌘' : 'Ctrl+';
+  rows.push(
+    { category: 'Island', label: 'Dismiss island panel / find bar', keys: 'Esc' },
+    { category: 'Island', label: 'Open address or run command (in command bar)', keys: 'Return' },
+    { category: 'Island', label: 'Open link in background tab', keys: `${mod}click` },
+  );
+  return rows;
+}
+
 function buildMenu() {
   const isMac = process.platform === 'darwin';
   const appMenu = isMac
@@ -1635,6 +1682,7 @@ app.whenReady().then(async () => {
       focusGroup,
       blockedThisWeek: () => adblockWeekStats().data.blocked,
     },
+    shortcuts: { list: listShortcuts },
   });
 
   await setupAdBlocker(ses, { enabled: settings.getSettings().adblockEnabled });

--- a/src/main/pages.js
+++ b/src/main/pages.js
@@ -78,6 +78,10 @@ function setupPages(hooks = {}) {
 
   handle('pages:app-version', () => app.getVersion());
 
+  // Help → Keyboard Shortcuts: the list is introspected from the live
+  // application menu in main.js, reached through a hook like startPage.
+  handle('pages:shortcuts:list', () => hooks.shortcuts?.list() ?? []);
+
   // Start page (the ledger new tab): tab groups + the weekly blocked
   // counter live in main.js, reached through hooks rather than a module.
   handle('pages:start:data', () => ({

--- a/src/main/pages.js
+++ b/src/main/pages.js
@@ -12,7 +12,7 @@ const { listDecisions, removeDecision } = require('./permissions');
 // file:// so they get a real origin, and so ordinary web content can never
 // link into arbitrary local files.
 const PAGES_DIR = path.join(__dirname, '../renderer/pages');
-const KNOWN_PAGES = new Set(['newtab', 'bookmarks', 'history', 'downloads', 'settings', 'error', 'auth']);
+const KNOWN_PAGES = new Set(['newtab', 'bookmarks', 'history', 'downloads', 'settings', 'error', 'auth', 'shortcuts']);
 
 /** Must run before app 'ready'. */
 function registerPagesScheme() {

--- a/src/main/tab-preload.js
+++ b/src/main/tab-preload.js
@@ -29,6 +29,9 @@ if (window.location.protocol === 'blanc:') {
       data: () => ipcRenderer.invoke('pages:start:data'),
       focusGroup: (id) => ipcRenderer.invoke('pages:start:focus-group', id),
     },
+    shortcuts: {
+      list: () => ipcRenderer.invoke('pages:shortcuts:list'),
+    },
     settings: {
       get: () => ipcRenderer.invoke('pages:settings:get'),
       set: (partial) => ipcRenderer.invoke('pages:settings:set', partial),

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -400,6 +400,8 @@
   // --- Slash commands ---
 
   const COMMANDS = [
+    // Also listed on blanc://shortcuts/ — update SLASH_COMMANDS in
+    // pages/shortcuts.js when adding or changing a command here.
     { cmd: '/favorites', hint: 'Open favorites', run: () => window.browserAPI.openPage('bookmarks') },
     { cmd: '/history', hint: 'Open browsing history', run: () => window.browserAPI.openPage('history') },
     { cmd: '/downloads', hint: 'Open downloads', run: () => window.browserAPI.openPage('downloads') },

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -461,3 +461,30 @@ a.ledger-label:hover { color: var(--accent); }
   background: var(--surface-raised);
   color: var(--text);
 }
+
+/* ---------- Keyboard shortcuts (blanc://shortcuts) ---------- */
+
+.shortcut-section { margin-top: 30px; }
+
+.shortcut-list { display: flex; flex-direction: column; }
+
+.shortcut-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 2px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.shortcut-row kbd {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2px 8px;
+  white-space: nowrap;
+}

--- a/src/renderer/pages/shortcuts.html
+++ b/src/renderer/pages/shortcuts.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://fonts.googleapis.com; script-src 'self'; font-src 'self' https://fonts.gstatic.com;" />
+  <title>Keyboard Shortcuts</title>
+  <link rel="icon" href="icon.svg" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=JetBrains+Mono:wght@400;500;700&display=swap" />
+  <link rel="stylesheet" href="pages.css" />
+</head>
+<body>
+  <div class="page">
+    <nav class="page-nav">
+      <a href="blanc://bookmarks/">Favorites</a>
+      <a href="blanc://history/">History</a>
+      <a href="blanc://downloads/">Downloads</a>
+      <a href="blanc://settings/">Settings</a>
+    </nav>
+    <h1>Keyboard Shortcuts</h1>
+    <div id="sections"></div>
+  </div>
+  <script src="shortcuts.js"></script>
+</body>
+</html>

--- a/src/renderer/pages/shortcuts.js
+++ b/src/renderer/pages/shortcuts.js
@@ -1,0 +1,59 @@
+// The shortcut sections are rendered from the live application menu
+// (pages:shortcuts:list), so they can never drift from the real bindings.
+// Only SLASH_COMMANDS below is maintained by hand — keep it in sync with
+// the command table in overlay.js.
+const SLASH_COMMANDS = [
+  ['/favorites', 'Open favorites'],
+  ['/history', 'Open browsing history'],
+  ['/downloads', 'Open downloads'],
+  ['/settings', 'Open settings'],
+  ['/clear', 'Clear browsing history'],
+  ['/new', 'Open a new tab'],
+  ['/private', 'Open a private tab — history stays untouched'],
+  ['/close', 'Close this tab'],
+  ['/pin', 'Pin or unpin this tab'],
+  ['/mute', 'Mute or unmute this tab'],
+  ['/group <name>', 'Move this tab into a group, creating it on first use'],
+  ['/ungroup', 'Take this tab out of its group'],
+  ['/close-group', 'Close every tab in this group'],
+  ['/find', 'Find in page'],
+  ['/block-ads', 'Toggle ad & tracker blocking'],
+  ['/allow-ads', 'Allow ads on this site'],
+  ['/theme', 'Cycle appearance (system → light → dark)'],
+];
+
+/** One titled section of label/keys rows. */
+function section(title, pairs) {
+  const wrap = document.createElement('section');
+  wrap.className = 'shortcut-section';
+  const heading = document.createElement('h2');
+  heading.className = 'section-title';
+  heading.textContent = title;
+  wrap.appendChild(heading);
+  const list = document.createElement('div');
+  list.className = 'shortcut-list';
+  for (const [label, keys] of pairs) {
+    const row = document.createElement('div');
+    row.className = 'shortcut-row';
+    const name = document.createElement('span');
+    name.textContent = label;
+    const kbd = document.createElement('kbd');
+    kbd.textContent = keys;
+    row.append(name, kbd);
+    list.appendChild(row);
+  }
+  wrap.appendChild(list);
+  return wrap;
+}
+
+(async () => {
+  const rows = await window.bowserPages.shortcuts.list();
+  const byCategory = new Map();
+  for (const row of rows) {
+    if (!byCategory.has(row.category)) byCategory.set(row.category, []);
+    byCategory.get(row.category).push([row.label, row.keys]);
+  }
+  const root = document.getElementById('sections');
+  for (const [title, pairs] of byCategory) root.appendChild(section(title, pairs));
+  root.appendChild(section('Slash Commands', SLASH_COMMANDS.map(([cmd, hint]) => [hint, cmd])));
+})();


### PR DESCRIPTION
## Summary

**Arrow-key workspace navigation** (all registered as visible Tabs-menu accelerators):
- **⌥⌘←/→** — previous/next tab within the active tab's cluster (its group, the pinned shelf, or the ungrouped set), wrapping. With no groups or pins it degrades to plain tab cycling, same as Ctrl+Tab.
- **⌥⌘↑/↓** — previous/next cluster in ⌘1–9 order (pinned shelf → groups → ungrouped), wrapping. Lands on each cluster's last-active tab (in-memory map, falls back to first) and unfolds collapsed groups.
- Extracted `clusterSlots()` so ⌘1–9 and the new navigation share one definition of cluster order (⌘1–9 behavior unchanged).

**Help menu + `blanc://shortcuts/` page:**
- New Help menu (macOS `role: 'help'` — gets Apple's Help search for free); "Keyboard Shortcuts" item, ⌘/.
- The page is generated by walking the **live application menu** over a guarded `pages:shortcuts:list` IPC, so it can never drift from the real bindings — new menu shortcuts appear automatically. Hidden aliases (silent ⌘=) are skipped; ⌘1–9 collapses to one row.
- Static extras (Esc, Return, ⌘-click) plus a slash-command reference table, with a sync-reminder comment in overlay.js's command table.

Design spec: `docs/superpowers/specs/2026-07-06-arrow-nav-and-shortcuts-help-design.md`
Plan: `docs/superpowers/plans/2026-07-06-arrow-nav-and-shortcuts-help.md`

## Test plan

No test suite in this repo — verified via `node --check` on all touched files and a clean `npm start` launch. Manual checklist:
- [ ] ⌥⌘→ cycles only within the active group and wraps; single-tab group no-ops; no groups → cycles all tabs
- [ ] ⌥⌘↓ visits pinned → each group → ungrouped, wraps, returns to each group's last-active tab, uncollapses folded groups
- [ ] ⌘1–9 unchanged
- [ ] Help → Keyboard Shortcuts / ⌘/ opens `blanc://shortcuts/` once, refocuses on re-invoke; sections + capsule keys render in light/dark/private themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)