### PR TITLE
Patch Sec-CH-UA client hints to include Chrome brand

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1769,6 +1769,26 @@ function createMainWindow() {
 app.whenReady().then(async () => {
   const ses = session.defaultSession;
 
+  // Patch Sec-CH-UA client hints to include the Chrome brand. Electron
+  // sends "Chromium" without "Google Chrome", and Google's OAuth endpoints
+  // reject that with "This browser or app may not be secure". The UA string
+  // is already Chrome-shaped (see userAgentFallback above); this closes the
+  // same gap on the client-hints side.
+  const chromeMajor = process.versions.chrome?.split('.')[0];
+  if (chromeMajor) {
+    const chromeFull = process.versions.chrome;
+    ses.webRequest.onBeforeSendHeaders((details, callback) => {
+      const h = details.requestHeaders;
+      if (h['Sec-CH-UA'] && !h['Sec-CH-UA'].includes('Google Chrome')) {
+        h['Sec-CH-UA'] += `, "Google Chrome";v="${chromeMajor}"`;
+      }
+      if (h['Sec-CH-UA-Full-Version-List'] && !h['Sec-CH-UA-Full-Version-List'].includes('Google Chrome')) {
+        h['Sec-CH-UA-Full-Version-List'] += `, "Google Chrome";v="${chromeFull}"`;
+      }
+      callback({ requestHeaders: h });
+    });
+  }
+
   applyTheme();
   applyAppIcon();
   if (settings.getSettings().usagePing) sendLaunchPing();

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -179,7 +179,8 @@ app.userAgentFallback = app.userAgentFallback
 
 // Hide the FedCM API. Must happen before app 'ready', and silently no-ops
 // if Chromium ever retires the "FedCm" feature name (an Electron bump that
-// brings back Google-login 400s should recheck here first). Chromium ships
+// brings back Google-login 400s should recheck here first — also see the
+// Sec-CH-UA client-hints patch in app.whenReady below). Chromium ships
 // the JS surface (IdentityCredential) but Electron has no account-chooser
 // UI behind it, so FedCM calls can only ever fail with "Error retrieving
 // a token". Google Identity Services feature-detects the API, commits to
@@ -1769,21 +1770,27 @@ function createMainWindow() {
 app.whenReady().then(async () => {
   const ses = session.defaultSession;
 
-  // Patch Sec-CH-UA client hints to include the Chrome brand. Electron
-  // sends "Chromium" without "Google Chrome", and Google's OAuth endpoints
-  // reject that with "This browser or app may not be secure". The UA string
-  // is already Chrome-shaped (see userAgentFallback above); this closes the
-  // same gap on the client-hints side.
+  // Patch Sec-CH-UA client hints to include the Chrome brand — the
+  // client-hints companion to the userAgentFallback stripping above (and
+  // the FedCm disable). Electron's Chromium sends "Chromium" without
+  // "Google Chrome", and Google's OAuth endpoints reject that with "This
+  // browser or app may not be secure". Chromium populates these header
+  // names in lowercase (services/network/public/cpp/client_hints.cc), and
+  // Electron's net_converter passes them through without case-normalizing.
+  // Electron only allows ONE listener per webRequest event per session
+  // (same constraint adblock.js documents for onBeforeRequest) — if a
+  // future feature also needs onBeforeSendHeaders, compose inside this
+  // handler rather than registering a second one.
   const chromeMajor = process.versions.chrome?.split('.')[0];
   if (chromeMajor) {
     const chromeFull = process.versions.chrome;
-    ses.webRequest.onBeforeSendHeaders((details, callback) => {
+    ses.webRequest.onBeforeSendHeaders({ urls: ['<all_urls>'] }, (details, callback) => {
       const h = details.requestHeaders;
-      if (h['Sec-CH-UA'] && !h['Sec-CH-UA'].includes('Google Chrome')) {
-        h['Sec-CH-UA'] += `, "Google Chrome";v="${chromeMajor}"`;
+      if (h['sec-ch-ua'] && !h['sec-ch-ua'].includes('Google Chrome')) {
+        h['sec-ch-ua'] += `, "Google Chrome";v="${chromeMajor}"`;
       }
-      if (h['Sec-CH-UA-Full-Version-List'] && !h['Sec-CH-UA-Full-Version-List'].includes('Google Chrome')) {
-        h['Sec-CH-UA-Full-Version-List'] += `, "Google Chrome";v="${chromeFull}"`;
+      if (h['sec-ch-ua-full-version-list'] && !h['sec-ch-ua-full-version-list'].includes('Google Chrome')) {
+        h['sec-ch-ua-full-version-list'] += `, "Google Chrome";v="${chromeFull}"`;
       }
       callback({ requestHeaders: h });
     });


### PR DESCRIPTION
## Summary

Google's OAuth endpoints reject requests from browsers that don't advertise the "Google Chrome" brand in their `Sec-CH-UA` client hints headers, returning a "This browser or app may not be secure" error. Electron's Chromium sends only "Chromium" without the Google Chrome brand, causing authentication failures. This patch intercepts outgoing requests and injects the Chrome brand into the relevant client-hints headers to match what Google expects.

## Changes

- Added a `webRequest.onBeforeSendHeaders` handler in `app.whenReady()` that patches two client-hints headers:
  - `sec-ch-ua`: appends `"Google Chrome";v="<major>"` if not already present
  - `sec-ch-ua-full-version-list`: appends `"Google Chrome";v="<full-version>"` if not already present
- Updated the FedCM disable comment to reference this new patch as a companion mitigation
- Handler only registers if `process.versions.chrome` is available (graceful degradation)
- Documented the Electron constraint that only one listener per webRequest event is allowed per session

## Implementation Details

The patch extracts the Chrome major version from `process.versions.chrome` and uses it to construct the brand string. It checks for existing "Google Chrome" entries before appending to avoid duplication. The handler is intentionally composed as a single `onBeforeSendHeaders` listener to respect Electron's one-listener-per-event constraint — any future features needing this event should compose their logic within this handler rather than registering separately.

https://claude.ai/code/session_013itPobvrjR7x4CbnT11Pxk