### PR TITLE
Fix Google sign-in "browser may not be secure" by matching Chrome browser signals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,7 +1,6 @@
 const { app, BrowserWindow, WebContentsView, session, ipcMain, Menu, nativeTheme, nativeImage, dialog, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
-const os = require('os');
 const crypto = require('crypto');
 const { pathToFileURL } = require('url');
 const { setupAdBlocker, setAdBlockEnabled, getBlocker } = require('./adblock');
@@ -204,8 +203,16 @@ function chromeClientHintBitness() {
 }
 
 function chromeClientHintPlatformVersion() {
-  if (process.platform === 'darwin') return os.release();
-  return '';
+  // Chrome's client hint carries the macOS *product* version (e.g. "26.0.0"),
+  // not the Darwin kernel version os.release() returns. Electron's
+  // process.getSystemVersion() is the product-version accessor (documented as
+  // returning the OS version rather than the kernel version, unlike
+  // os.release()); pad to Chrome's X.Y.Z shape. Windows/Linux desktop Chrome
+  // send an empty value here.
+  if (process.platform !== 'darwin') return '';
+  const parts = process.getSystemVersion().split('.');
+  while (parts.length < 3) parts.push('0');
+  return parts.slice(0, 3).join('.');
 }
 
 // Strip Electron/app tokens and use Chrome's reduced UA form so sites see
@@ -1867,7 +1874,10 @@ app.whenReady().then(async () => {
     ses.webRequest.onBeforeSendHeaders({ urls: ['<all_urls>'] }, (details, callback) => {
       const h = details.requestHeaders;
       setHeader(h, 'sec-ch-ua', chUa, { add: true });
-      setHeader(h, 'sec-ch-ua-full-version-list', chUaFull, { add: true });
+      // High-entropy hint: only rewrite it when Chromium already decided to
+      // send it (i.e. the server negotiated it via Accept-CH), matching real
+      // Chrome — don't force it onto every request like the low-entropy hints.
+      setHeader(h, 'sec-ch-ua-full-version-list', chUaFull);
       setHeader(h, 'sec-ch-ua-platform', `"${chromeClientHintPlatform()}"`);
       setHeader(h, 'sec-ch-ua-platform-version', `"${chromeClientHintPlatformVersion()}"`);
       setHeader(h, 'sec-ch-ua-arch', `"${chromeClientHintArchitecture()}"`);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, WebContentsView, session, ipcMain, Menu, nativeTheme, nativeImage, dialog, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const crypto = require('crypto');
 const { pathToFileURL } = require('url');
 const { setupAdBlocker, setAdBlockEnabled, getBlocker } = require('./adblock');
@@ -171,11 +172,45 @@ app.on('open-file', (event, filePath) => {
 // Must happen before app 'ready'.
 registerPagesScheme();
 
-// Strip the app and Electron tokens from the UA so sites treat us as a
-// plain Chrome build.
-app.userAgentFallback = app.userAgentFallback
-  .replace(/\sblanc\/[\d.]+/i, '')
-  .replace(/\sElectron\/[\d.]+/, '');
+const chromeMajor = process.versions.chrome?.split('.')[0];
+const chromeFull = process.versions.chrome;
+const chromeReducedVersion = chromeMajor ? `${chromeMajor}.0.0.0` : null;
+
+function chromeLikeUserAgent(ua) {
+  let next = ua
+    .replace(/\sblanc\/[\d.]+/i, '')
+    .replace(/\sElectron\/[\d.]+/, '');
+  if (chromeReducedVersion) {
+    next = next.replace(/Chrome\/[\d.]+/, `Chrome/${chromeReducedVersion}`);
+  }
+  return next;
+}
+
+function chromeClientHintPlatform() {
+  if (process.platform === 'darwin') return 'macOS';
+  if (process.platform === 'win32') return 'Windows';
+  if (process.platform === 'linux') return 'Linux';
+  return process.platform;
+}
+
+function chromeClientHintArchitecture() {
+  if (process.arch === 'arm64') return 'arm';
+  if (process.arch === 'x64' || process.arch === 'ia32') return 'x86';
+  return process.arch;
+}
+
+function chromeClientHintBitness() {
+  return process.arch.includes('64') ? '64' : '32';
+}
+
+function chromeClientHintPlatformVersion() {
+  if (process.platform === 'darwin') return os.release();
+  return '';
+}
+
+// Strip Electron/app tokens and use Chrome's reduced UA form so sites see
+// the same low-entropy UA shape as desktop Chrome.
+app.userAgentFallback = chromeLikeUserAgent(app.userAgentFallback);
 
 // Hide the FedCM API. Must happen before app 'ready', and silently no-ops
 // if Chromium ever retires the "FedCm" feature name (an Electron bump that
@@ -205,26 +240,28 @@ app.commandLine.appendSwitch(
 // lightweight, invisible (no infobar in Electron), and coexists with
 // DevTools. Must be registered before app 'ready' so the very first
 // webContents (the chrome window) is caught.
-const chromeMajor = process.versions.chrome?.split('.')[0];
-const chromeFull = process.versions.chrome;
 if (chromeMajor) {
+  const greaseBrand = { brand: 'Not;A=Brand', version: '8' };
+  const chromeBrands = [
+    greaseBrand,
+    { brand: 'Chromium', version: chromeMajor },
+    { brand: 'Google Chrome', version: chromeMajor },
+  ];
+  const chromeFullVersionList = [
+    { brand: greaseBrand.brand, version: `${greaseBrand.version}.0.0.0` },
+    { brand: 'Chromium', version: chromeFull },
+    { brand: 'Google Chrome', version: chromeFull },
+  ];
   const uaMetadata = {
-    brands: [
-      { brand: 'Chromium', version: chromeMajor },
-      { brand: 'Google Chrome', version: chromeMajor },
-      { brand: 'Not)A;Brand', version: '99' },
-    ],
-    fullVersionList: [
-      { brand: 'Chromium', version: chromeFull },
-      { brand: 'Google Chrome', version: chromeFull },
-      { brand: 'Not)A;Brand', version: '99.0.0.0' },
-    ],
-    platform: process.platform === 'darwin' ? 'macOS' :
-              process.platform === 'win32' ? 'Windows' : 'Linux',
-    platformVersion: '',
-    architecture: process.arch === 'x64' ? 'x86' : process.arch,
+    brands: chromeBrands,
+    fullVersionList: chromeFullVersionList,
+    platform: chromeClientHintPlatform(),
+    platformVersion: chromeClientHintPlatformVersion(),
+    architecture: chromeClientHintArchitecture(),
+    bitness: chromeClientHintBitness(),
     model: '',
     mobile: false,
+    wow64: false,
   };
   app.on('web-contents-created', (_event, wc) => {
     try { wc.debugger.attach('1.3'); } catch { return; }
@@ -1016,6 +1053,7 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
           overrideBrowserWindowOptions: {
             autoHideMenuBar: true,
             webPreferences: {
+              preload: path.join(__dirname, 'tab-preload.js'),
               contextIsolation: true,
               nodeIntegration: false,
               sandbox: true,
@@ -1820,16 +1858,23 @@ app.whenReady().then(async () => {
   // feature also needs onBeforeSendHeaders, compose inside this handler
   // rather than registering a second one.
   if (chromeMajor) {
-    const chUa = `"Chromium";v="${chromeMajor}", "Google Chrome";v="${chromeMajor}", "Not)A;Brand";v="99"`;
-    const chUaFull = `"Chromium";v="${chromeFull}", "Google Chrome";v="${chromeFull}", "Not)A;Brand";v="99.0.0.0"`;
+    const chUa = `"Not;A=Brand";v="8", "Chromium";v="${chromeMajor}", "Google Chrome";v="${chromeMajor}"`;
+    const chUaFull = `"Not;A=Brand";v="8.0.0.0", "Chromium";v="${chromeFull}", "Google Chrome";v="${chromeFull}"`;
+    const setHeader = (headers, name, value, { add = false } = {}) => {
+      const existing = Object.keys(headers).find((key) => key.toLowerCase() === name);
+      if (existing || add) headers[existing || name] = value;
+    };
     ses.webRequest.onBeforeSendHeaders({ urls: ['<all_urls>'] }, (details, callback) => {
       const h = details.requestHeaders;
-      if (!h['sec-ch-ua'] || !h['sec-ch-ua'].includes('Google Chrome')) {
-        h['sec-ch-ua'] = chUa;
-      }
-      if (!h['sec-ch-ua-full-version-list'] || !h['sec-ch-ua-full-version-list'].includes('Google Chrome')) {
-        h['sec-ch-ua-full-version-list'] = chUaFull;
-      }
+      setHeader(h, 'sec-ch-ua', chUa, { add: true });
+      setHeader(h, 'sec-ch-ua-full-version-list', chUaFull, { add: true });
+      setHeader(h, 'sec-ch-ua-platform', `"${chromeClientHintPlatform()}"`);
+      setHeader(h, 'sec-ch-ua-platform-version', `"${chromeClientHintPlatformVersion()}"`);
+      setHeader(h, 'sec-ch-ua-arch', `"${chromeClientHintArchitecture()}"`);
+      setHeader(h, 'sec-ch-ua-bitness', `"${chromeClientHintBitness()}"`);
+      setHeader(h, 'sec-ch-ua-model', '""');
+      setHeader(h, 'sec-ch-ua-mobile', '?0');
+      setHeader(h, 'sec-ch-ua-wow64', '?0');
       callback({ requestHeaders: h });
     });
   }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -180,7 +180,7 @@ app.userAgentFallback = app.userAgentFallback
 // Hide the FedCM API. Must happen before app 'ready', and silently no-ops
 // if Chromium ever retires the "FedCm" feature name (an Electron bump that
 // brings back Google-login 400s should recheck here first — also see the
-// Sec-CH-UA client-hints patch in app.whenReady below). Chromium ships
+// CDP client-hints override and onBeforeSendHeaders fallback below). Chromium ships
 // the JS surface (IdentityCredential) but Electron has no account-chooser
 // UI behind it, so FedCM calls can only ever fail with "Error retrieving
 // a token". Google Identity Services feature-detects the API, commits to
@@ -196,6 +196,45 @@ app.commandLine.appendSwitch(
   'disable-features',
   priorDisabledFeatures ? `${priorDisabledFeatures},FedCm` : 'FedCm'
 );
+
+// Override client-hints branding at the Chromium level via CDP so both HTTP
+// Sec-CH-UA headers AND navigator.userAgentData.brands report Chrome.
+// Google Identity Services checks brands client-side before opening the
+// OAuth popup; onBeforeSendHeaders only patches HTTP headers and can't
+// reach the JS-visible API under contextIsolation. The debugger session is
+// lightweight, invisible (no infobar in Electron), and coexists with
+// DevTools. Must be registered before app 'ready' so the very first
+// webContents (the chrome window) is caught.
+const chromeMajor = process.versions.chrome?.split('.')[0];
+const chromeFull = process.versions.chrome;
+if (chromeMajor) {
+  const uaMetadata = {
+    brands: [
+      { brand: 'Chromium', version: chromeMajor },
+      { brand: 'Google Chrome', version: chromeMajor },
+      { brand: 'Not)A;Brand', version: '99' },
+    ],
+    fullVersionList: [
+      { brand: 'Chromium', version: chromeFull },
+      { brand: 'Google Chrome', version: chromeFull },
+      { brand: 'Not)A;Brand', version: '99.0.0.0' },
+    ],
+    platform: process.platform === 'darwin' ? 'macOS' :
+              process.platform === 'win32' ? 'Windows' : 'Linux',
+    platformVersion: '',
+    architecture: process.arch === 'x64' ? 'x86' : process.arch,
+    model: '',
+    mobile: false,
+  };
+  app.on('web-contents-created', (_event, wc) => {
+    try { wc.debugger.attach('1.3'); } catch { return; }
+    wc.debugger.sendCommand('Emulation.setUserAgentOverride', {
+      userAgent: app.userAgentFallback,
+      userAgentMetadata: uaMetadata,
+    }).catch(() => {});
+    wc.debugger.on('detach', () => {});
+  });
+}
 
 /** @type {BrowserWindow | null} */
 let win = null;
@@ -1770,27 +1809,26 @@ function createMainWindow() {
 app.whenReady().then(async () => {
   const ses = session.defaultSession;
 
-  // Patch Sec-CH-UA client hints to include the Chrome brand — the
-  // client-hints companion to the userAgentFallback stripping above (and
-  // the FedCm disable). Electron's Chromium sends "Chromium" without
-  // "Google Chrome", and Google's OAuth endpoints reject that with "This
-  // browser or app may not be secure". Chromium populates these header
-  // names in lowercase (services/network/public/cpp/client_hints.cc), and
-  // Electron's net_converter passes them through without case-normalizing.
-  // Electron only allows ONE listener per webRequest event per session
-  // (same constraint adblock.js documents for onBeforeRequest) — if a
-  // future feature also needs onBeforeSendHeaders, compose inside this
-  // handler rather than registering a second one.
-  const chromeMajor = process.versions.chrome?.split('.')[0];
+  // Fallback: patch Sec-CH-UA HTTP headers for webContents where the CDP
+  // debugger couldn't attach (e.g. already in use). The CDP override above
+  // handles both HTTP and navigator.userAgentData; this catches leftovers.
+  // Replaces the entire value to match Chrome's exact brand format, and
+  // adds the header if absent (Electron may omit it on first request to
+  // an origin before the server's Accept-CH response arrives). Electron
+  // only allows ONE listener per webRequest event per session (same
+  // constraint adblock.js documents for onBeforeRequest) — if a future
+  // feature also needs onBeforeSendHeaders, compose inside this handler
+  // rather than registering a second one.
   if (chromeMajor) {
-    const chromeFull = process.versions.chrome;
+    const chUa = `"Chromium";v="${chromeMajor}", "Google Chrome";v="${chromeMajor}", "Not)A;Brand";v="99"`;
+    const chUaFull = `"Chromium";v="${chromeFull}", "Google Chrome";v="${chromeFull}", "Not)A;Brand";v="99.0.0.0"`;
     ses.webRequest.onBeforeSendHeaders({ urls: ['<all_urls>'] }, (details, callback) => {
       const h = details.requestHeaders;
-      if (h['sec-ch-ua'] && !h['sec-ch-ua'].includes('Google Chrome')) {
-        h['sec-ch-ua'] += `, "Google Chrome";v="${chromeMajor}"`;
+      if (!h['sec-ch-ua'] || !h['sec-ch-ua'].includes('Google Chrome')) {
+        h['sec-ch-ua'] = chUa;
       }
-      if (h['sec-ch-ua-full-version-list'] && !h['sec-ch-ua-full-version-list'].includes('Google Chrome')) {
-        h['sec-ch-ua-full-version-list'] += `, "Google Chrome";v="${chromeFull}"`;
+      if (!h['sec-ch-ua-full-version-list'] || !h['sec-ch-ua-full-version-list'].includes('Google Chrome')) {
+        h['sec-ch-ua-full-version-list'] = chUaFull;
       }
       callback({ requestHeaders: h });
     });

--- a/src/main/tab-preload.js
+++ b/src/main/tab-preload.js
@@ -1,9 +1,77 @@
-// Preload attached to every tab WebContentsView. Web content gets NOTHING
-// from it: the bridge is only exposed when the document is one of our own
-// blanc:// internal pages (the check re-runs on every navigation, so a
-// tab that leaves an internal page loses the API). The main process
-// additionally verifies the sender URL on every pages:* IPC call.
-const { contextBridge, ipcRenderer } = require('electron');
+// Preload attached to every tab WebContentsView and OAuth-style popup.
+// Web content gets only a small Chrome-compatibility surface (window.chrome
+// app/csi/loadTimes). The privileged IPC bridge is exposed only when the
+// document is one of our own blanc:// internal pages (the check re-runs on
+// every navigation, so a tab that leaves an internal page loses the API).
+// The main process additionally verifies the sender URL on every pages:* IPC
+// call.
+const { contextBridge, ipcRenderer, webFrame } = require('electron');
+
+webFrame.executeJavaScript(`
+(() => {
+  const define = (target, key, value) => {
+    if (target && !Object.prototype.hasOwnProperty.call(target, key)) {
+      Object.defineProperty(target, key, {
+        value,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+  };
+  window.chrome = window.chrome || {};
+  define(window.chrome, 'app', {
+    isInstalled: false,
+    InstallState: {
+      DISABLED: 'disabled',
+      INSTALLED: 'installed',
+      NOT_INSTALLED: 'not_installed',
+    },
+    RunningState: {
+      CANNOT_RUN: 'cannot_run',
+      READY_TO_RUN: 'ready_to_run',
+      RUNNING: 'running',
+    },
+    getDetails: () => null,
+    getIsInstalled: () => false,
+    installState: (callback) => {
+      if (typeof callback === 'function') setTimeout(() => callback('not_installed'), 0);
+    },
+    runningState: () => 'cannot_run',
+  });
+  define(window.chrome, 'csi', () => {
+    const timing = performance.timing || {};
+    const navigationStart = timing.navigationStart || performance.timeOrigin || Date.now();
+    return {
+      onloadT: timing.loadEventStart || 0,
+      startE: navigationStart,
+      pageT: Math.max(0, Date.now() - navigationStart),
+      tran: 15,
+    };
+  });
+  define(window.chrome, 'loadTimes', () => {
+    const timing = performance.timing || {};
+    const nav = performance.getEntriesByType?.('navigation')?.[0];
+    const navigationStart = timing.navigationStart || performance.timeOrigin || Date.now();
+    const seconds = (value) => (value || navigationStart) / 1000;
+    return {
+      requestTime: seconds(navigationStart),
+      startLoadTime: seconds(navigationStart),
+      commitLoadTime: seconds(timing.responseStart),
+      finishDocumentLoadTime: seconds(timing.domContentLoadedEventEnd),
+      finishLoadTime: seconds(timing.loadEventEnd || timing.loadEventStart),
+      firstPaintTime: 0,
+      firstPaintAfterLoadTime: 0,
+      navigationType: nav?.type || 'Other',
+      wasFetchedViaSpdy: false,
+      wasNpnNegotiated: false,
+      npnNegotiatedProtocol: 'unknown',
+      wasAlternateProtocolAvailable: false,
+      connectionInfo: 'unknown',
+    };
+  });
+})();
+`, true).catch(() => {});
 
 if (window.location.protocol === 'blanc:') {
   contextBridge.exposeInMainWorld('bowserPages', {


### PR DESCRIPTION
## Problem

Signing in with Google on sites that use Google Identity Services (e.g. Instacart) failed with **"Couldn't sign you in — This browser or app may not be secure."** Google's OAuth endpoint blocks agents it flags as embedded/insecure. Although Blanc runs full Chromium (not a `WKWebView`), its browser signals didn't match a real desktop Chrome closely enough to pass the check.

## Root cause

Three mismatches vs. desktop Chrome, spanning both HTTP headers and the JS-visible API:

- **Branding:** UA / `Sec-CH-UA` reported `Chromium` without `Google Chrome`, and `navigator.userAgentData.brands` — which GIS checks client-side before opening the popup — couldn't be reached from a preload under `contextIsolation`.
- **Malformed client hints:** `architecture` was `arm64` (real Chrome reports `arm` + `bitness:"64"`), `platformVersion` was empty, and the GREASE brand/order didn't match.
- **Missing Chrome JS surface:** detection scripts look for `window.chrome.app` / `csi` / `loadTimes`, which weren't present.

## Fix

- **Consistent Chrome identity from one source of truth.** UA string (Chrome's reduced `X.0.0.0` form), `Sec-CH-UA` headers, and `navigator.userAgentData` all derive from the real Chromium version (`process.versions.chrome`), set at the Chromium level via CDP `Emulation.setUserAgentOverride` (covers headers *and* the JS API) with an `onBeforeSendHeaders` fallback for any webContents where the debugger can't attach. Both layers emit identical values, so nothing drifts.
- **Correct, complete client hints:** `architecture:"arm"`, `bitness`, `platform`, macOS **product** version (`process.getSystemVersion()`, not the Darwin kernel version), GREASE brand/order, `wow64` — internally consistent and matching real Chrome. High-entropy hints are only rewritten once the server negotiates them via `Accept-CH`, like Chrome.
- **Chrome JS shim:** `window.chrome.app` / `csi` / `loadTimes` injected into the page's main world from the tab preload, early enough for detection scripts. Also attached to Google's `new-window` OAuth popup, with `window.opener` preserved so the popup can post back to the opener.

## Verification

- End-to-end Google sign-in on Instacart completes in a dev build (identifier screen → full account sign-in).
- `node --check` on both changed files.

## Security

The `window.chrome` shim is benign cosmetic stubs — exactly what desktop Chrome exposes to all web content, with no IPC/Node reach. The privileged `bowserPages` bridge stays gated behind `location.protocol === 'blanc:'`, so the OAuth popup receives the shim but never the bridge.

## Notes

- Version bumped to **0.13.2** (0.13.1 was the prior, non-working attempt and is already released).
- Release runs from the macOS dev machine (`npm run release`) — it needs notarization/signing credentials not present in CI.
- Two acceptance scenarios fail on this branch (pinned-tab ordering, exception-hostname normalization) — both **pre-existing and unrelated** to this change (no overlap with UA / client hints / preload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013itPobvrjR7x4CbnT11Pxk

---
_Generated by [Claude Code](https://claude.ai/code/session_013itPobvrjR7x4CbnT11Pxk)_