### PR TITLE
ci: fix substrate job failing on the adblock-youtube unit test

### DIFF
--- a/.github/workflows/parity-guards.yml
+++ b/.github/workflows/parity-guards.yml
@@ -39,7 +39,6 @@ jobs:
     # Dry-run only — no app is launched, so the Electron binary isn't downloaded.
     runs-on: ubuntu-latest
     env:
-      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/parity-guards.yml
+++ b/.github/workflows/parity-guards.yml
@@ -14,19 +14,23 @@ permissions:
 
 jobs:
   substrate:
-    # Pure-Node drift guards — the build.mjs checkers use only node builtins, so
-    # no dependency install is needed. Fast and hard to break.
     runs-on: ubuntu-latest
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
       - name: tokens / settings / copy match their sources
+        # Drift guards — the build.mjs checkers use only node builtins,
+        # no dependency install needed for this step.
         run: |
           node tokens/build.mjs --check
           node settings-schema/build.mjs --check
           node copy/build.mjs --check
+      - run: npm ci
       - name: Unit regression tests
         run: npm run test:unit
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@cucumber/cucumber": "^11.0.0",
+        "@ghostery/adblocker": "^2.18.1",
         "electron": "^43.1.0",
         "electron-builder": "^26.0.12",
         "playwright": "^1.49.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "private": true,
   "devDependencies": {
     "@cucumber/cucumber": "^11.0.0",
+    "@ghostery/adblocker": "^2.18.1",
     "electron": "^43.1.0",
     "electron-builder": "^26.0.12",
     "playwright": "^1.49.0"

--- a/test/unit/adblock-youtube.test.js
+++ b/test/unit/adblock-youtube.test.js
@@ -7,10 +7,15 @@ const { FiltersEngine, Request } = require('@ghostery/adblocker');
 const SOURCES = path.resolve(__dirname, '../../adblock/sources');
 const GENERATED = path.resolve(__dirname, '../../adblock/generated');
 
+// Parsing the combined EasyList + EasyPrivacy sources costs ~500-800ms, so
+// build the engine once and share it across every test in this file.
+let cachedEngine;
 function loadEngine() {
+  if (cachedEngine) return cachedEngine;
   const easylist = fs.readFileSync(path.join(SOURCES, 'easylist.txt'), 'utf8');
   const easyprivacy = fs.readFileSync(path.join(SOURCES, 'easyprivacy.txt'), 'utf8');
-  return FiltersEngine.parse(easylist + '\n' + easyprivacy);
+  cachedEngine = FiltersEngine.parse(easylist + '\n' + easyprivacy);
+  return cachedEngine;
 }
 
 function match(engine, url, type = 'xmlhttprequest') {
@@ -65,10 +70,12 @@ test('WebKit blocklist contains YouTube ad-blocking rules', () => {
     fs.readFileSync(path.join(GENERATED, 'blocklist.json'), 'utf8')
   );
 
+  // build.mjs escapes the domain dot, so url-filters carry the literal
+  // substring `youtube\.com` (backslash + dot).
   const youtubeBlocks = rules.filter(
     (r) =>
       r.action.type === 'block' &&
-      /youtube\\?\.com/.test(r.trigger['url-filter'])
+      /youtube\\\.com/.test(r.trigger['url-filter'])
   );
 
   const patterns = youtubeBlocks.map((r) => r.trigger['url-filter']);


### PR DESCRIPTION
## Why

`main` is currently red. PR #19 added `test/unit/adblock-youtube.test.js`, which `require()`s `@ghostery/adblocker`, but the Parity-guards **substrate** job was designed to run `npm run test:unit` *without* installing dependencies ("Pure-Node drift guards… no dependency install is needed"). So the new test fails with `Cannot find module '@ghostery/adblocker'`, and every push to `main` now fails the substrate check.

## What

**Unbreak the job** (`3a8646f`)
- Add `npm ci` to the substrate job, *after* the tokens/settings/copy drift checks (those genuinely use only node builtins, so they still run install-free and fail fast) and before `npm run test:unit`.
- Add `cache: npm` to match the sibling jobs.

**Hardening surfaced while fixing it** (`139051a`)
- **Declare `@ghostery/adblocker` as a direct devDependency.** The test was relying on it being hoisted as a transitive dep of `@ghostery/adblocker-electron` — a phantom dependency that a lockfile regen or a non-hoisting installer could break. It must import the *base* package (not `adblocker-electron`, which loads `electron` and triggers a lazy binary download under plain `node --test`), so declaring the base package directly is the correct fix.
- **Memoize the parsed `FiltersEngine`.** The ~500–800ms EasyList + EasyPrivacy parse ran once per test; sharing it drops the unit-suite runtime from ~2.1s to ~1.2s.
- **Clarify the blocklist regex.** `/youtube\\?\.com/` made the escaping backslash optional (dead permissiveness); replaced with a precise match for the escaped `youtube\.com` substring `build.mjs` emits, with a comment.
- **Drop `ELECTRON_SKIP_BINARY_DOWNLOAD`** from the acceptance-wiring job — it's a no-op since Electron v42 (the postinstall download it gated was replaced with a lazy on-launch download that never reads it).

## Verification
- `npm run test:unit` → 20/20 pass
- `npm run substrate:check` → all three drift checks OK
- `package-lock.json` diff is a single added line (no dependency-tree churn)

## Known gaps left for a follow-up (not fixed here to keep this focused)
- **Cross-engine parity:** the desktop engine blocks YouTube `get_midroll` (asserted by test 1), but `build.mjs` silently drops that rule from the WebKit/iOS blocklist because its `$domain=` option isn't in the minimal M5 converter's supported set. Adding `$domain=`→`if-domain` support is a real iOS-backend feature (and regenerates the 2 MB blocklist), so it's out of scope here.
- **No drift guard on `adblock/generated/blocklist.json`:** unlike tokens/settings/copy, `build.mjs` has no `--check` mode, so the blocklist can go stale versus its sources without CI noticing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015AeYNGMhKCDKhPMBzFaiyr)_