### PR TITLE
feat(adblock): support $domain= in the WKContentRuleList converter

### DIFF
--- a/adblock/build.mjs
+++ b/adblock/build.mjs
@@ -54,6 +54,13 @@ function parseFilter(raw) {
     const opts = optStr.split(',');
     for (const opt of opts) {
       const o = opt.trim().toLowerCase();
+      if (o.startsWith('domain=')) {
+        const domain = parseDomainOption(o.slice('domain='.length));
+        if (!domain) { skipped.unsupported++; return null; }
+        if (domain.ifDomain) options.ifDomain = domain.ifDomain;
+        else options.unlessDomain = domain.unlessDomain;
+        continue;
+      }
       if (!SUPPORTED_OPTIONS.has(o)) {
         skipped.unsupported++;
         return null;
@@ -83,11 +90,42 @@ function parseFilter(raw) {
   if (options.thirdParty) trigger['load-type'] = ['third-party'];
   else if (options.firstParty) trigger['load-type'] = ['first-party'];
   if (options.resourceTypes?.length) trigger['resource-type'] = options.resourceTypes;
+  if (options.ifDomain?.length) trigger['if-domain'] = options.ifDomain;
+  else if (options.unlessDomain?.length) trigger['unless-domain'] = options.unlessDomain;
 
   return {
     rule: { trigger, action: { type: isException ? 'ignore-previous-rules' : 'block' } },
     isException,
   };
+}
+
+// ABP's $domain=a.com|~b.com scopes a rule to (or away from) page domains. It
+// maps to WKContentRuleList's if-domain / unless-domain: a leading `*` makes an
+// entry match the domain and its subdomains, mirroring ABP's subdomain-inclusive
+// semantics. WebKit can't mix inclusion and exclusion in one trigger, so a rule
+// that lists both is left unsupported rather than silently narrowed.
+function parseDomainOption(value) {
+  const include = [];
+  const exclude = [];
+  for (const entry of value.split('|')) {
+    let d = entry.trim();
+    if (!d) continue;
+    const negated = d.startsWith('~');
+    if (negated) d = d.slice(1);
+    // WebKit rejects the whole compiled list if any if/unless-domain entry
+    // isn't a plain hostname, so skip rules carrying e.g. IPv6 literals
+    // ([::1]) or IDNs that aren't already punycode.
+    if (!isHostname(d)) return null;
+    (negated ? exclude : include).push('*' + d);
+  }
+  if (include.length && exclude.length) return null;
+  if (include.length) return { ifDomain: include };
+  if (exclude.length) return { unlessDomain: exclude };
+  return null;
+}
+
+function isHostname(d) {
+  return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/.test(d);
 }
 
 function patternToRegex(pattern) {

--- a/adblock/generated/blocklist.meta.json
+++ b/adblock/generated/blocklist.meta.json
@@ -1,5 +1,5 @@
 {
-  "version": "752e2a31",
-  "ruleCount": 107334,
+  "version": "3db734c6",
+  "ruleCount": 108342,
   "sourceDate": "2026-07-09"
 }

--- a/spec/blocking-backends.md
+++ b/spec/blocking-backends.md
@@ -59,7 +59,10 @@ WebKit-version-dependent). EasyList + EasyPrivacy exceed that. But **multiple
 compiled lists can be attached to one web view**, so the pipeline:
 
 1. Converts network filters to `{ "trigger": { "url-filter", "resource-type",
-   "load-type": ["third-party"] }, "action": { "type": "block" } }`.
+   "load-type": ["third-party"], "if-domain"/"unless-domain" }, "action":
+   { "type": "block" } }` — `$domain=a.com|~b.com` maps to `if-domain`/
+   `unless-domain`, each entry `*`-prefixed so it matches subdomains too, the
+   way ABP's `$domain=` does.
 2. **Partitions** into several lists each under the cap, ordered by value:
    network-blocking (ads, then tracking) first, cosmetic (`css-display-none`)
    last.

--- a/test/unit/adblock-youtube.test.js
+++ b/test/unit/adblock-youtube.test.js
@@ -93,3 +93,27 @@ test('WebKit blocklist contains YouTube ad-blocking rules', () => {
     'blocklist should contain an ads stats rule for youtube.com'
   );
 });
+
+test('WebKit blocklist carries the domain-scoped get_midroll rule', () => {
+  // get_midroll_ is a $domain=youtube.com rule in EasyList. The desktop engine
+  // blocks it (asserted above), so the WebKit backend must too — via an
+  // if-domain trigger, since build.mjs can't express $domain= any other way.
+  const rules = JSON.parse(
+    fs.readFileSync(path.join(GENERATED, 'blocklist.json'), 'utf8')
+  );
+
+  const midroll = rules.filter(
+    (r) =>
+      r.action.type === 'block' &&
+      /youtube\\\.com\/get_midroll_/.test(r.trigger['url-filter'])
+  );
+
+  assert.ok(
+    midroll.length > 0,
+    'blocklist should contain a get_midroll rule for youtube.com'
+  );
+  assert.ok(
+    midroll.every((r) => r.trigger['if-domain']?.includes('*youtube.com')),
+    'get_midroll rules should be scoped to youtube.com via if-domain'
+  );
+});


### PR DESCRIPTION
## Why

The M5 EasyList→Safari converter (`adblock/build.mjs`) silently dropped **every** `$domain=` rule, because `domain` wasn't in `SUPPORTED_OPTIONS` — any rule carrying it hit the `unsupported` bucket and returned `null`.

That opened a real cross-engine parity gap, surfaced by the review of #20: EasyList blocks YouTube's mid-roll ad endpoint with `||www.youtube.com/get_midroll_$domain=youtube.com`. The **desktop** engine blocks it (and `test/unit/adblock-youtube.test.js` asserts so), but the **iOS/WebKit** blocklist didn't carry the rule at all — so iOS users wouldn't block that endpoint, and nothing in CI noticed.

## What

- Map ABP `$domain=a.com|~b.com` → WKContentRuleList `if-domain` / `unless-domain`. Each entry is `*`-prefixed so it matches subdomains, mirroring ABP's subdomain-inclusive `$domain=` semantics (`youtube.com` → `*youtube.com`, matching `www.`/`m.` too).
- **Correctness guards** (WebKit rejects the *entire* compiled list if any rule is malformed, so this is deliberately conservative):
  - A rule that mixes inclusion and exclusion (unrepresentable in one trigger) is left unsupported rather than silently narrowed.
  - Domain entries that aren't plain hostnames — e.g. IPv6 literals like `[::1]` that appear in a few EasyList exclusions, or non-punycode IDNs — are rejected, skipping the whole rule instead of emitting an entry WebKit would choke on.
- Regenerated `blocklist.json`: **107,334 → 108,342 rules** (+1,008, still well under the ~150k WebKit cap). 870 `if-domain` + 138 `unless-domain` triggers, **0 malformed** (validated).
- Added a regression test asserting the `get_midroll` rule is present and scoped via `if-domain: ["*youtube.com"]` (fails against the old blocklist, which had zero YouTube `get_midroll` rules).
- Updated `spec/blocking-backends.md` step 1 to document the new trigger fields.

## Verification
- `npm run test:unit` → 21/21 pass (incl. the new midroll test)
- Programmatic validation of the regenerated list: every `if-domain`/`unless-domain` entry is a well-formed hostname; no trigger mixes the two.

## Notes
- Independent of #20 (the CI hotfix) — this branches from `main` and touches disjoint regions of the shared test file, so they don't conflict; whichever lands second is a trivial rebase.
- Still open from the #20 review, not addressed here: there's no `adblock:check` drift guard tying `blocklist.json` to its sources the way tokens/settings/copy have. Happy to add that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015AeYNGMhKCDKhPMBzFaiyr)_