### PR TITLE
Move new tab / private launchers into a dedicated island panel footer

### DIFF
--- a/src/renderer/overlay.html
+++ b/src/renderer/overlay.html
@@ -33,6 +33,31 @@
         </div>
       </div>
       <div id="islandList"></div>
+      <div id="islandFooter">
+        <button id="footerNewTab" class="footer-new">
+          <svg viewBox="0 0 16 16"><path d="M8 3.25v9.5M3.25 8h9.5"/></svg>
+          <span>new tab</span>
+          <span id="footerNewTabKbd" class="footer-kbd"></span>
+        </button>
+        <button id="footerNewPrivate" class="footer-new private">
+          <svg viewBox="0 0 16 16"><path d="M8 3.25v9.5M3.25 8h9.5"/></svg>
+          <span class="footer-private-label">private</span>
+          <span id="footerNewPrivateKbd" class="footer-kbd"></span>
+        </button>
+        <span class="footer-spacer"></span>
+        <button id="footerFavorites" class="footer-act" title="Favorites">
+          <svg viewBox="0 0 16 16"><path d="M8 13.25C4.6 11 2.75 8.9 2.75 6.6a2.85 2.85 0 0 1 5.25-1.54A2.85 2.85 0 0 1 13.25 6.6c0 2.3-1.85 4.4-5.25 6.65z"/></svg>
+        </button>
+        <button id="footerHistory" class="footer-act" title="History">
+          <svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="5.75"/><path d="M8 4.75V8l2.25 1.5"/></svg>
+        </button>
+        <button id="footerDownloads" class="footer-act" title="Downloads">
+          <svg viewBox="0 0 16 16"><path d="M8 2.5v6.5M5.3 6.3 8 9l2.7-2.7M3.5 12.5h9"/></svg>
+        </button>
+        <button id="footerSettings" class="footer-act" title="Settings">
+          <svg viewBox="0 0 16 16"><path d="M2.5 4.75h6M12 4.75h1.5M2.5 11.25h1.5M7.5 11.25h6"/><circle cx="10.25" cy="4.75" r="1.75"/><circle cx="5.75" cy="11.25" r="1.75"/></svg>
+        </button>
+      </div>
       <div id="islandHint"></div>
     </div>
   </div>

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -25,6 +25,12 @@
   const findPrevBtn = document.getElementById('findPrevBtn');
   const findNextBtn = document.getElementById('findNextBtn');
   const findCloseBtn = document.getElementById('findCloseBtn');
+  const footerNewTab = document.getElementById('footerNewTab');
+  const footerNewPrivate = document.getElementById('footerNewPrivate');
+  const footerFavorites = document.getElementById('footerFavorites');
+  const footerHistory = document.getElementById('footerHistory');
+  const footerDownloads = document.getElementById('footerDownloads');
+  const footerSettings = document.getElementById('footerSettings');
 
   let state = { tabs: [], activeTabId: null, groups: [] };
   /** @type {null | 'panel' | 'palette' | 'find'} */
@@ -53,7 +59,6 @@
     reload: '<svg viewBox="0 0 16 16"><path d="M13 8a5 5 0 1 1-5-5c1.4 0 2.74.56 3.74 1.53L13 5.78"/><path d="M13 3v2.78h-2.78"/></svg>',
     stop: '<svg viewBox="0 0 16 16"><path d="M4.25 4.25l7.5 7.5M11.75 4.25l-7.5 7.5"/></svg>',
     close: '<svg viewBox="0 0 16 16"><path d="M4.75 4.75l6.5 6.5M11.25 4.75l-6.5 6.5"/></svg>',
-    plus: '<svg viewBox="0 0 16 16"><path d="M8 3.25v9.5M3.25 8h9.5"/></svg>',
     pin: '<svg viewBox="0 0 16 16"><path d="M5 3h6l-1 5 2 2v1H4v-1l2-2z"/><path d="M8 11v3"/></svg>',
     mute: '<svg viewBox="0 0 16 16"><path d="M2 6h3l4-3.5v11L5 10H2z"/><path d="M11 5.5l3 5M14 5.5l-3 5"/></svg>',
   };
@@ -375,28 +380,6 @@
     return row;
   }
 
-  function newTabRow() {
-    const row = document.createElement('div');
-    row.className = 'island-row newtab';
-    row.innerHTML = `${ICONS.plus}<span class="row-title">New tab</span><span class="row-kbd">${modKey}T</span>`;
-    row.addEventListener('click', () => {
-      window.browserAPI.closeOverlay();
-      window.browserAPI.createTab(); // main reopens the panel focused on the blank tab
-    });
-    return row;
-  }
-
-  function newPrivateTabRow() {
-    const row = document.createElement('div');
-    row.className = 'island-row newtab';
-    row.innerHTML = `${ICONS.plus}<span class="row-title">New private tab</span><span class="row-private">private</span><span class="row-kbd">${modShiftKey}N</span>`;
-    row.addEventListener('click', () => {
-      window.browserAPI.closeOverlay();
-      window.browserAPI.createTab(null, { private: true });
-    });
-    return row;
-  }
-
   // --- Slash commands ---
 
   const COMMANDS = [
@@ -625,7 +608,7 @@
         if (group?.collapsed) rows.push(foldedGroupRow(group, gtabs));
         else rows.push(...gtabs.map(tabRow));
       }
-      islandList.replaceChildren(...rows, newTabRow(), newPrivateTabRow());
+      islandList.replaceChildren(...rows);
 
       const pickerInput = islandList.querySelector('.group-picker-input');
       if (pickerInput && pickerValue) pickerInput.value = pickerValue;
@@ -729,6 +712,33 @@
       : window.browserAPI.reload(state.activeTabId);
   });
   heartBtn.addEventListener('click', () => window.browserAPI.toggleBookmark());
+
+  // --- Footer action bar (static: new tab / private launchers + quick pages) ---
+  // These moved out of the scrollable list so they stay put while it shows
+  // slash commands or Quick-Switcher results. Platform-correct shortcut hints.
+  document.getElementById('footerNewTabKbd').textContent = `${modKey}T`;
+  document.getElementById('footerNewPrivateKbd').textContent = `${modShiftKey}N`;
+  footerNewTab.title = `New tab (${modKey}T)`;
+  footerNewPrivate.title = `New private tab (${modShiftKey}N)`;
+
+  footerNewTab.addEventListener('click', () => {
+    window.browserAPI.closeOverlay();
+    window.browserAPI.createTab(); // main reopens the panel focused on the blank tab
+  });
+  footerNewPrivate.addEventListener('click', () => {
+    window.browserAPI.closeOverlay();
+    window.browserAPI.createTab(null, { private: true });
+  });
+  // Each shortcut opens its internal page; close first so main can re-show
+  // the overlay cleanly where needed (mirrors runCommand for /favorites etc).
+  const openPageFromFooter = (name) => {
+    window.browserAPI.closeOverlay();
+    window.browserAPI.openPage(name);
+  };
+  footerFavorites.addEventListener('click', () => openPageFromFooter('bookmarks'));
+  footerHistory.addEventListener('click', () => openPageFromFooter('history'));
+  footerDownloads.addEventListener('click', () => openPageFromFooter('downloads'));
+  footerSettings.addEventListener('click', () => openPageFromFooter('settings'));
 
   addressInput.addEventListener('input', () => {
     inputTouched = true;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -614,10 +614,6 @@ body[data-mode="palette"] #panelAnchor { top: 120px; }
 /* Group results in the Quick Switcher use the mono voice. */
 .island-row .row-title.mono { font-family: var(--font-mono); font-size: 12.5px; flex: 0 0 auto; }
 
-.island-row.newtab { color: var(--text-dim); }
-.island-row.newtab .row-title { color: inherit; font-size: 12.5px; flex: 0 0 auto; }
-.island-row.newtab svg { width: 14px; height: 14px; }
-
 .row-kbd {
   font-family: var(--font-mono);
   font-size: 11px;
@@ -677,6 +673,69 @@ body[data-mode="palette"] #panelAnchor { top: 120px; }
   color: var(--text-dim);
   padding: 10px;
 }
+
+/* ---------- Island: expanded-panel footer action bar ----------
+   New tab / private launchers on the left, quick-access page shortcuts
+   (favorites, history, downloads, settings) on the right. A static row
+   below the list — always visible, unlike the old in-list "New tab"/
+   "private" rows it replaces, so it stays put while the list shows
+   commands or Quick-Switcher results. */
+#islandFooter {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.footer-new {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 8px;
+  border-radius: var(--radius);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+.footer-new:hover { background: var(--surface); color: var(--text); }
+.footer-new svg { width: 13px; height: 13px; }
+
+/* Private launcher: hairline separator on its left, and its label wears the
+   dashed underline that marks private throughout the chrome. */
+.footer-new.private {
+  margin-left: 2px;
+  padding-left: 10px;
+  border-left: 1px solid var(--border);
+  border-radius: 0;
+}
+.footer-private-label { border-bottom: 1px dashed var(--text-dim); }
+
+.footer-kbd {
+  font-size: 10.5px;
+  opacity: 0.55;
+  margin-left: 2px;
+}
+
+.footer-spacer { flex: 1 1 auto; }
+
+.footer-act {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-dim);
+  padding: 0;
+  flex: 0 0 auto;
+}
+.footer-act:hover { background: var(--surface); color: var(--text); }
+.footer-act svg { width: 15px; height: 15px; }
 
 #islandHint {
   font-family: var(--font-mono);


### PR DESCRIPTION
Reworks the expanded island panel's footer per the Blanc Browser Design System handoff (`ui_kits/browser`). "New tab" and "New private tab" move out of the scrollable tab list into a static footer action bar separated by a hairline, so they stay put while the list shows slash commands or Quick-Switcher results. The footer also gains quick-access shortcuts to Favorites, History, Downloads, and Settings on the right.

## Changes
- **`overlay.html`** — add `#islandFooter` (new tab / private launchers + four quick-access icon buttons) between the list and the hint line.
- **`overlay.js`** — drop the in-list `newTabRow`/`newPrivateTabRow` (and the now-unused `ICONS.plus`); wire the static footer buttons with platform-correct shortcut hints (`⌘T`/`⌘⇧N` on macOS, `ctrl+…` elsewhere). Quick actions close the overlay then open the page, mirroring the existing `/favorites` etc. slash-command flow.
- **`styles.css`** — style the footer; remove the obsolete `.island-row.newtab` rules.

The footer is now a static sibling of `#islandList`, so it stays visible regardless of what the list renders — the point of the redesign.

## Verification
- Drove the real `overlay.html` + `styles.css` + `overlay.js` in Chromium with a stubbed `browserAPI`, opened the panel, and screenshotted light and dark — both match the design.
- Programmatic checks: footer present, correct shortcut labels, all four quick actions wired, zero leftover in-list newtab rows; clicking History fired `closeOverlay` → `openPage("history")`.
- `node --check` passes on both JS files; `npm run substrate:check` passes (no token/settings/copy drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JRmBUSgZjhnPefa68717G

---
_Generated by [Claude Code](https://claude.ai/code/session_016JRmBUSgZjhnPefa68717G)_