### PR TITLE
fix(ios): hold ContentBlocker pending targets weakly, drop on failure

### DIFF
--- a/ios/Blanc/Blanc/ContentBlocker.swift
+++ b/ios/Blanc/Blanc/ContentBlocker.swift
@@ -66,11 +66,19 @@ final class WKRuleListStoreAdapter: RuleListStoring {
 
 @Observable
 final class ContentBlocker {
+    /// A *weakly*-held queued attach target. Web views waiting on the cold-compile
+    /// window must not be pinned by the blocker: a tab closed mid-compile has to be
+    /// able to deallocate, and a terminal compile failure must not leak the whole
+    /// queue for the app's lifetime.
+    private struct WeakTarget {
+        weak var target: RuleListAttaching?
+    }
+
     var isReady = false
 
     @ObservationIgnored var compiledRuleList: WKContentRuleList?
     @ObservationIgnored private let store: RuleListStoring
-    @ObservationIgnored private var pendingTargets: [RuleListAttaching] = []
+    @ObservationIgnored private var pendingTargets: [WeakTarget] = []
 
     init(store: RuleListStoring = WKRuleListStoreAdapter()) {
         self.store = store
@@ -111,8 +119,17 @@ final class ContentBlocker {
         if isReady {
             target.attachContentBlockingRules(from: self)
         } else {
-            pendingTargets.append(target)
+            pendingTargets.append(WeakTarget(target: target))
         }
+    }
+
+    /// Removes `target` from the pending queue — called when a tab closes during the
+    /// compile window so its detached web view never receives a pointless add-rules +
+    /// reload on drain. `closeTab` calls this with the web view still alive (before the
+    /// tab is dropped), so an identity match is sufficient; `drainPending` separately
+    /// skips any box whose target deallocated while queued.
+    func cancelPending(for target: RuleListAttaching) {
+        pendingTargets.removeAll { $0.target === target }
     }
 
     private func compile(version: String, jsonString: String) {
@@ -120,17 +137,23 @@ final class ContentBlocker {
             forIdentifier: version,
             encodedContentRuleList: jsonString
         ) { [weak self] success in
-            guard let self, success else { return }
+            guard let self else { return }
+            guard success else {
+                // Terminal failure: drop the queue so it can't leak for the app's lifetime.
+                self.pendingTargets.removeAll()
+                return
+            }
             self.isReady = true
             self.drainPending()
         }
     }
 
     private func drainPending() {
-        let targets = pendingTargets
+        let boxes = pendingTargets
         pendingTargets.removeAll()
-        for target in targets {
-            target.attachContentBlockingRules(from: self)
+        for box in boxes {
+            // Skip any target that deallocated while queued (e.g. a tab closed mid-compile).
+            box.target?.attachContentBlockingRules(from: self)
         }
     }
 }

--- a/ios/Blanc/Blanc/TabsManager.swift
+++ b/ios/Blanc/Blanc/TabsManager.swift
@@ -49,6 +49,9 @@ final class TabsManager {
     func closeTab(_ id: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
         let wasActive = id == activeTabId
+        // If the tab is still queued for a cold-compile drain, drop it so its web view
+        // isn't reloaded after it's gone (and isn't kept alive by the pending queue).
+        contentBlocker.cancelPending(for: tabs[index].webView)
         tabs.remove(at: index)
 
         if tabs.isEmpty {

--- a/ios/Blanc/BlancTests/ContentBlockerTests.swift
+++ b/ios/Blanc/BlancTests/ContentBlockerTests.swift
@@ -40,6 +40,14 @@ final class ContentBlockerTests: XCTestCase {
             compileCallback = nil
         }
 
+        /// Fires a *terminal* compile failure — the real store calls `completed(false)`
+        /// when WebKit rejects the rule list (e.g. `WKErrorDomain` 6). Distinct from
+        /// `compileResult = false`, which only defers a later *success* via `flushCompile()`.
+        func failCompile() {
+            compileCallback?(false)
+            compileCallback = nil
+        }
+
         func flushLookup(found: Bool) {
             lookupCallback?(found)
             lookupCallback = nil
@@ -163,6 +171,76 @@ final class ContentBlockerTests: XCTestCase {
         // Miss → provider read exactly once, then compiled.
         XCTAssertEqual(providerCalls, 1)
         XCTAssertTrue(blocker.isReady)
+    }
+
+    // MARK: - Failure & lifetime
+
+    func testCompileFailureLeavesNotReadyAndDoesNotRetainQueuedTargets() {
+        let store = FakeRuleListStore()
+        store.lookupResult = false
+        store.compileResult = false   // defer the compile completion
+        let blocker = ContentBlocker(store: store)
+        blocker.prepare(version: "abc", jsonProvider: { "[]" })
+
+        weak var weakTarget: FakeAttachTarget?
+        do {
+            let target = FakeAttachTarget()
+            weakTarget = target
+            blocker.attach(to: target)        // queued while not ready
+
+            store.flushLookup(found: false)   // miss → compile (deferred)
+            store.failCompile()               // terminal failure: completed(false)
+
+            XCTAssertFalse(blocker.isReady, "a failed compile must leave the blocker not ready")
+            XCTAssertEqual(target.attachCount, 0, "a failed compile must not attach queued targets")
+        }
+        // After a terminal failure the queue must not pin the web view for the app's lifetime.
+        XCTAssertNil(weakTarget, "compile failure must drop queued targets, not retain them")
+    }
+
+    func testDeallocatedTargetIsNotRetainedOrAttachedOnDrain() {
+        let store = FakeRuleListStore()
+        store.lookupResult = false
+        store.compileResult = false
+        let blocker = ContentBlocker(store: store)
+        blocker.prepare(version: "abc", jsonProvider: { "[]" })
+
+        weak var weakDoomed: FakeAttachTarget?
+        do {
+            let doomed = FakeAttachTarget()
+            weakDoomed = doomed
+            blocker.attach(to: doomed)        // queued while not ready
+        }
+        // A tab closed mid-compile deallocates its web view; the queue must hold it weakly.
+        XCTAssertNil(weakDoomed, "queued targets must be held weakly so a closed tab can deallocate")
+
+        let survivor = FakeAttachTarget()
+        blocker.attach(to: survivor)
+        store.flushLookup(found: false)
+        store.flushCompile()                  // drain: skip the dead box, attach the survivor
+
+        XCTAssertEqual(survivor.attachCount, 1, "drain attaches live targets after skipping a deallocated one")
+    }
+
+    func testTargetRemovedBeforeDrainIsNotAttached() {
+        let store = FakeRuleListStore()
+        store.lookupResult = false
+        store.compileResult = false
+        let blocker = ContentBlocker(store: store)
+        blocker.prepare(version: "abc", jsonProvider: { "[]" })
+
+        let removed = FakeAttachTarget()
+        let kept = FakeAttachTarget()
+        blocker.attach(to: removed)
+        blocker.attach(to: kept)
+
+        blocker.cancelPending(for: removed)   // e.g. its tab was closed during the compile window
+
+        store.flushLookup(found: false)
+        store.flushCompile()                  // success → drain
+
+        XCTAssertEqual(removed.attachCount, 0, "a target removed before drain must not be attached")
+        XCTAssertEqual(kept.attachCount, 1, "targets still queued at drain time are attached")
     }
 
     // MARK: - Integration Test


### PR DESCRIPTION
## Summary

Fixes two latent lifetime defects in the iOS `ContentBlocker` ad-block queue (P3 #1 from the M5 final review):

1. **Strong refs + never drained on failure** — `pendingTargets` held queued `WKWebView`s strongly and was never drained on a compile failure (or when `WKContentRuleListStore.default()` is nil, whose completion never fires), leaking them for the app's lifetime.
2. **Orphaned-tab reload** — a tab closed during the ~cold-compile window was kept alive and then received a pointless `add(ruleList)` + `reload()` on its detached web view when the queue drained.

## Changes

- Hold `pendingTargets` as weak boxes; `drainPending` skips targets that deallocated while queued.
- Clear the queue on terminal compile failure.
- `TabsManager.closeTab` removes the closing tab's web view via `ContentBlocker.cancelPending(for:)` so it is neither reloaded nor retained.

## Tests

- Added `FakeRuleListStore.failCompile()` to model a terminal `completed(false)` (distinct from the existing defer-then-succeed).
- New tests: compile-failure branch (not-ready, not-attached, not-retained), removed-before-drain, and deallocated-before-drain.
- Full `BlancTests` suite: **81/81 green**, including the real-WebKit integration test and `TabsManagerTests`.

Resolves P3 #1 and closes the P3 #5 compile-failure test-fidelity gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
