### PR TITLE
fix(build): Gatekeeper rejection on fresh installs + Intel Mac support

### DIFF
--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -9,11 +9,5 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
-
-  <!-- Must match WEBAUTHN_KEYCHAIN_ACCESS_GROUP in src/main/webauthn.js. -->
-  <key>keychain-access-groups</key>
-  <array>
-    <string>XYGUCY4498.me.bnfy.bowser.webauthn</string>
-  </array>
 </dict>
 </plist>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -9,11 +9,5 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
-
-  <!-- Must match WEBAUTHN_KEYCHAIN_ACCESS_GROUP in src/main/webauthn.js. -->
-  <key>keychain-access-groups</key>
-  <array>
-    <string>XYGUCY4498.me.bnfy.bowser.webauthn</string>
-  </array>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -88,8 +88,14 @@
         ]
       },
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": ["arm64", "x64"]
+        },
+        {
+          "target": "zip",
+          "arch": ["arm64", "x64"]
+        }
       ]
     },
     "win": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -90,6 +90,10 @@ ASSETS=(
   "dist/Blanc-$VERSION-arm64-mac.zip.blockmap"
   "dist/Blanc-$VERSION-arm64.dmg"
   "dist/Blanc-$VERSION-arm64.dmg.blockmap"
+  "dist/Blanc-$VERSION-mac.zip"
+  "dist/Blanc-$VERSION-mac.zip.blockmap"
+  "dist/Blanc-$VERSION.dmg"
+  "dist/Blanc-$VERSION.dmg.blockmap"
   "dist/latest-mac.yml"
 )
 for f in "${ASSETS[@]}"; do


### PR DESCRIPTION
## Summary

- **Remove `keychain-access-groups` entitlement** from both `entitlements.mac.plist` and `entitlements.mac.inherit.plist` — this restricted entitlement (added in v0.15.0 for Touch ID passkeys) requires a Developer ID provisioning profile; without one, Gatekeeper rejects the app on any machine that didn't build it, showing "The application 'Blanc' can't be opened"
- **Add x64 macOS builds** — the mac target only built for arm64, so Intel Macs couldn't run the app at all
- **Bump to v0.15.1** for a patch release

Touch ID passkeys degrade gracefully — `setupWebAuthn()` catches the missing-entitlement error and returns false. Re-enable once a provisioning profile with Keychain Sharing is set up.

## After merge

Run `npm run release` on the dev machine to ship v0.15.1. The existing v0.15.0 auto-update channel will pick up the new version via `latest-mac.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7AaQonCHHMWWQ9qawV9ED)_