### PR TITLE
fix(webauthn): restore Touch ID passkeys without restricted entitlement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/src/main/webauthn.js
+++ b/src/main/webauthn.js
@@ -1,9 +1,10 @@
 // Electron 41.5+ can back WebAuthn platform-authenticator requests with the
-// Mac's Secure Enclave. This is intentionally a Blanc-specific access group:
-// its passkeys are device-bound and do not expose a person's iCloud Keychain.
+// Mac's Secure Enclave. Uses the app's own default keychain access group
+// (TeamID.BundleID) — every signed app can access this implicitly, no
+// keychain-access-groups entitlement or provisioning profile required.
 const APPLE_TEAM_ID = 'XYGUCY4498';
 const BUNDLE_ID = 'me.bnfy.bowser';
-const WEBAUTHN_KEYCHAIN_ACCESS_GROUP = `${APPLE_TEAM_ID}.${BUNDLE_ID}.webauthn`;
+const WEBAUTHN_KEYCHAIN_ACCESS_GROUP = `${APPLE_TEAM_ID}.${BUNDLE_ID}`;
 
 function accountLabel(account, index) {
   const label = account?.displayName || account?.name;

--- a/test/unit/webauthn.test.js
+++ b/test/unit/webauthn.test.js
@@ -14,7 +14,7 @@ const accounts = [
 ];
 
 test('uses Blanc’s stable signing identity for the Secure Enclave access group', () => {
-  assert.equal(WEBAUTHN_KEYCHAIN_ACCESS_GROUP, 'XYGUCY4498.me.bnfy.bowser.webauthn');
+  assert.equal(WEBAUTHN_KEYCHAIN_ACCESS_GROUP, 'XYGUCY4498.me.bnfy.bowser');
 });
 
 test('labels discoverable credentials for the native account chooser', () => {


### PR DESCRIPTION
## Summary

- **Use the app's default keychain access group** (`XYGUCY4498.me.bnfy.bowser`) instead of a custom one (`...webauthn`) — every signed macOS app can access its own default group implicitly, no `keychain-access-groups` entitlement or provisioning profile needed
- **Bump to 0.15.2** — ships working Touch ID passkeys without the Gatekeeper issue from v0.15.0

v0.15.0 used a custom keychain group that required the restricted `keychain-access-groups` entitlement, which broke fresh installs. v0.15.1 removed the entitlement (disabling passkeys). This restores passkey functionality by using the app's implicit default group instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7AaQonCHHMWWQ9qawV9ED)_