### PR TITLE
Import favorites from other browsers + favorites folders

### DIFF
--- a/src/main/bookmark-data.js
+++ b/src/main/bookmark-data.js
@@ -1,0 +1,129 @@
+// Pure, non-mutating transforms over a { items, tombstones } snapshot. Each
+// returns new arrays and a `changed` flag; bookmarks.js writes only when
+// changed. All folder identity/canonicalization rules live here.
+const { validFavicon, validFolder, folderKey } = require('./bookmark-validate');
+
+/** Map folderKey -> canonical spelling, chosen from the item with the oldest
+ * addedAt (tie: smallest id) — fully deterministic so independent devices
+ * converge on the same spelling. Ungrouped items are ignored. */
+function buildCanonMap(items) {
+  const map = new Map(); // key -> { folder, addedAt, id }
+  for (const it of items) {
+    if (it.folder == null) continue;
+    const key = folderKey(it.folder);
+    const cur = map.get(key);
+    const addedAt = Number.isFinite(it.addedAt) ? it.addedAt : 0;
+    const id = String(it.id ?? '');
+    if (!cur || addedAt < cur.addedAt || (addedAt === cur.addedAt && id < cur.id)) {
+      map.set(key, { folder: it.folder, addedAt, id });
+    }
+  }
+  return map;
+}
+
+const oldestFirst = (a, b) => (a.addedAt ?? 0) - (b.addedAt ?? 0);
+
+function addImported({ items, tombstones }, entries, { now, makeId }) {
+  const seen = new Set(items.map((it) => it.url));
+  const canon = buildCanonMap(items); // key -> { folder }
+  const added = [];
+  let skipped = 0;
+  for (const e of entries || []) {
+    if (typeof e.url !== 'string' || seen.has(e.url)) { skipped++; continue; }
+    seen.add(e.url);
+    let folder = validFolder(e.folder);
+    if (folder != null) {
+      const key = folderKey(folder);
+      const existing = canon.get(key);
+      if (existing) folder = existing.folder;      // first-existing spelling wins
+      else canon.set(key, { folder });             // new folder: first-in-file spelling
+    }
+    added.push({
+      id: makeId(),
+      url: e.url,
+      title: typeof e.title === 'string' && e.title ? e.title : e.url,
+      favicon: validFavicon(e.favicon),
+      addedAt: Number.isFinite(e.addedAt) ? e.addedAt : now,
+      updatedAt: now,
+      folder,
+    });
+  }
+  if (added.length === 0) return { items, tombstones, added: 0, skipped, changed: false };
+  const addedUrls = new Set(added.map((it) => it.url));
+  return {
+    items: [...items, ...added].sort(oldestFirst),
+    tombstones: tombstones.filter((t) => !addedUrls.has(t.url)),
+    added: added.length,
+    skipped,
+    changed: true,
+  };
+}
+
+function applySetFolder({ items }, id, folder, { now }) {
+  const idx = items.findIndex((it) => it.id === id);
+  if (idx === -1) return { items, changed: false };
+  let target;
+  if (folder === null) {
+    target = null;
+  } else {
+    const valid = validFolder(folder);
+    if (valid === null) return { items, changed: false }; // invalid string: no-op, never ungroup
+    const existing = buildCanonMap(items).get(folderKey(valid));
+    target = existing ? existing.folder : valid;
+  }
+  if ((items[idx].folder ?? null) === (target ?? null)) return { items, changed: false };
+  const next = items.slice();
+  next[idx] = { ...items[idx], folder: target, updatedAt: now };
+  return { items: next, changed: true };
+}
+
+function applyRenameFolder({ items }, oldName, newName, { now }) {
+  const target0 = validFolder(newName);
+  if (target0 === null) return { items, changed: false }; // reject blank/over-long
+  const oldKey = folderKey(oldName);
+  let target;
+  if (folderKey(newName) === oldKey) {
+    target = target0; // case-only rename: use the new spelling verbatim
+  } else {
+    const existing = buildCanonMap(items).get(folderKey(target0));
+    target = existing ? existing.folder : target0; // merge-on-collision
+  }
+  let changed = false;
+  const next = items.map((it) => {
+    if (it.folder != null && folderKey(it.folder) === oldKey && it.folder !== target) {
+      changed = true;
+      return { ...it, folder: target, updatedAt: now };
+    }
+    return it;
+  });
+  return changed ? { items: next, changed: true } : { items, changed: false };
+}
+
+function applyRemoveFolder({ items }, name, { now }) {
+  const key = folderKey(name);
+  let changed = false;
+  const next = items.map((it) => {
+    if (it.folder != null && folderKey(it.folder) === key) {
+      changed = true;
+      return { ...it, folder: null, updatedAt: now };
+    }
+    return it;
+  });
+  return changed ? { items: next, changed: true } : { items, changed: false };
+}
+
+/** Collapse every folderKey group to one spelling. Rewrites folder spelling
+ * ONLY — never touches updatedAt (cosmetic, must not outrank a real edit under
+ * LWW or trigger sync ping-pong). */
+function canonicalizeFolders(items) {
+  const canon = buildCanonMap(items);
+  return items.map((it) => {
+    if (it.folder == null) return it;
+    const target = canon.get(folderKey(it.folder))?.folder;
+    return target && target !== it.folder ? { ...it, folder: target } : it;
+  });
+}
+
+module.exports = {
+  addImported, applySetFolder, applyRenameFolder, applyRemoveFolder, canonicalizeFolders,
+};

--- a/src/main/bookmark-import.js
+++ b/src/main/bookmark-import.js
@@ -1,0 +1,72 @@
+// Pure parser for the Netscape bookmark HTML format that every major browser
+// exports. Deliberately a simple regex scan (same pragmatic spirit as
+// normalizeAddressInput), not a DOM parse: attribute values containing an
+// unescaped '>' are not supported, which real exports never emit.
+const { validFavicon } = require('./bookmark-validate');
+
+function decodeEntities(s) {
+  return String(s)
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#x27;/gi, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&amp;/gi, '&'); // last, so &amp;lt; decodes to &lt; not <
+}
+
+/** Read one attribute from a tag's attribute string, case-insensitively.
+ * Handles double-quoted, single-quoted, and bare values. */
+function attr(attrs, name) {
+  const m =
+    attrs.match(new RegExp(`${name}\\s*=\\s*"([^"]*)"`, 'i')) ||
+    attrs.match(new RegExp(`${name}\\s*=\\s*'([^']*)'`, 'i')) ||
+    attrs.match(new RegExp(`${name}\\s*=\\s*([^\\s>]+)`, 'i'));
+  return m ? m[1] : null;
+}
+
+const TOKEN = /<\/dl\s*>|<dl\b[^>]*>|<h3\b[^>]*>([\s\S]*?)<\/h3\s*>|<a\b([^>]*)>([\s\S]*?)<\/a\s*>/gi;
+
+function parseNetscapeBookmarks(html, { now = Date.now() } = {}) {
+  const out = [];
+  const stack = [];              // folder path; top = current folder or null
+  let pending;                   // folder name awaiting its <DL>, or undefined
+  const current = () => (stack.length ? stack[stack.length - 1] : null);
+
+  for (const m of String(html).matchAll(TOKEN)) {
+    const tok = m[0].slice(0, 4).toLowerCase();
+    if (tok.startsWith('</dl')) {
+      stack.pop();
+    } else if (tok.startsWith('<dl')) {
+      stack.push(pending !== undefined ? pending : null);
+      pending = undefined;
+    } else if (tok.startsWith('<h3')) {
+      pending = decodeEntities(m[1] || '').trim() || null;
+    } else {
+      const attrs = m[2] || '';
+      const rawHref = attr(attrs, 'href');
+      if (!rawHref) continue;
+      const url = decodeEntities(rawHref);
+      if (!/^https?:\/\//i.test(url)) continue; // http(s) only
+      const rawIcon = attr(attrs, 'icon');
+      const secs = Number(attr(attrs, 'add_date'));
+      let addedAt = now;
+      if (Number.isFinite(secs) && secs > 0) {
+        const ms = secs * 1000;
+        if (ms <= now) addedAt = ms; // reject future timestamps
+      }
+      const title = decodeEntities(m[3] || '').trim();
+      out.push({
+        url,
+        title: title || url,
+        favicon: validFavicon(rawIcon),
+        addedAt,
+        folder: current(),
+      });
+    }
+  }
+  return out;
+}
+
+module.exports = { parseNetscapeBookmarks };

--- a/src/main/bookmark-validate.js
+++ b/src/main/bookmark-validate.js
@@ -1,0 +1,27 @@
+// Pure, Electron-free validators shared by bookmark-import.js, bookmark-data.js
+// and bookmarks.js. Kept out of bookmarks.js so importing them can't drag in
+// the JsonStore singleton (which needs Electron's app at construction), which
+// would make these untestable under `node --test`.
+
+/** Same allow-list/length cap as the async-refined favicon path in main.js. */
+function validFavicon(favicon) {
+  return typeof favicon === 'string' && favicon.length <= 2048 && /^(https?:|data:image\/)/i.test(favicon)
+    ? favicon
+    : null;
+}
+
+/** A storable folder name, or null (= ungrouped). null is ONLY ever an
+ * explicit ungroup — callers must treat a null result from a non-null input
+ * as "reject", not "ungroup". */
+function validFolder(name) {
+  if (typeof name !== 'string') return null;
+  const trimmed = name.trim();
+  return trimmed.length >= 1 && trimmed.length <= 100 ? trimmed : null;
+}
+
+/** Case-insensitive folder identity key. Work and work are one folder. */
+function folderKey(name) {
+  return typeof name === 'string' ? name.trim().toLowerCase() : '';
+}
+
+module.exports = { validFavicon, validFolder, folderKey };

--- a/src/main/bookmarks.js
+++ b/src/main/bookmarks.js
@@ -1,5 +1,7 @@
 const crypto = require('crypto');
 const { JsonStore } = require('./store');
+const { validFavicon, validFolder } = require('./bookmark-validate');
+const data = require('./bookmark-data');
 
 let store = null;
 const ensureStore = () => (store ??= new JsonStore('bookmarks', { items: [], tombstones: [] }));
@@ -15,15 +17,6 @@ const onChanged = (fn) => changeListeners.add(fn);
 const onMerged = (fn) => mergeListeners.add(fn);
 const notifyChanged = () => { for (const fn of changeListeners) fn(); };
 const notifyMerged = () => { for (const fn of mergeListeners) fn(); };
-
-/** Same allow-list/length cap main.js's pickBestFavicon applies to the
- * async-refined favicon — the immediate page-favicon-updated value skips
- * that check, so anything persisted here must be validated independently. */
-function validFavicon(favicon) {
-  return typeof favicon === 'string' && favicon.length <= 2048 && /^(https?:|data:image\/)/i.test(favicon)
-    ? favicon
-    : null;
-}
 
 function listBookmarks() {
   return [...ensureStore().data.items];
@@ -50,7 +43,7 @@ function toggleBookmark(url, title, favicon) {
   }
   s.update((d) => {
     const now = Date.now();
-    d.items.push({ id: crypto.randomUUID(), url, title: title || url, favicon: validFavicon(favicon), addedAt: now, updatedAt: now });
+    d.items.push({ id: crypto.randomUUID(), url, title: title || url, favicon: validFavicon(favicon), addedAt: now, updatedAt: now, folder: null });
     d.tombstones = d.tombstones.filter((t) => t.url !== url); // re-favoriting clears a prior delete
   });
   notifyChanged();
@@ -86,6 +79,41 @@ function removeBookmark(id) {
   notifyChanged();
 }
 
+/** Bulk-import parsed entries; dedupe by url, one sync-triggering write. */
+function importBookmarks(entries) {
+  const s = ensureStore();
+  const res = data.addImported(s.data, entries, { now: Date.now(), makeId: crypto.randomUUID });
+  if (res.changed) {
+    s.update((d) => { d.items = res.items; d.tombstones = res.tombstones; });
+    notifyChanged();
+  }
+  return { added: res.added, skipped: res.skipped };
+}
+
+function setBookmarkFolder(id, folder) {
+  const s = ensureStore();
+  const res = data.applySetFolder(s.data, id, folder, { now: Date.now() });
+  if (!res.changed) return;
+  s.update((d) => { d.items = res.items; });
+  notifyChanged();
+}
+
+function renameFolder(oldName, newName) {
+  const s = ensureStore();
+  const res = data.applyRenameFolder(s.data, oldName, newName, { now: Date.now() });
+  if (!res.changed) return;
+  s.update((d) => { d.items = res.items; });
+  notifyChanged();
+}
+
+function removeFolder(name) {
+  const s = ensureStore();
+  const res = data.applyRemoveFolder(s.data, name, { now: Date.now() });
+  if (!res.changed) return;
+  s.update((d) => { d.items = res.items; });
+  notifyChanged();
+}
+
 function exportForSync() {
   const { items, tombstones } = ensureStore().data;
   return { items, tombstones };
@@ -109,6 +137,7 @@ function sanitizeRemoteItem(it) {
     favicon: validFavicon(it.favicon),
     addedAt,
     updatedAt: Number.isFinite(it.updatedAt) ? it.updatedAt : addedAt,
+    folder: validFolder(it.folder),
   };
 }
 
@@ -137,7 +166,12 @@ function mergeFromSync(remote) {
     }
     // Oldest-first: listBookmarks() consumers (favoritesMenuItems' slice(-20)
     // .reverse(), the start page) rely on insertion (oldest-first) order.
-    d.items = [...byUrl.values()].sort((a, b) => (a.addedAt ?? 0) - (b.addedAt ?? 0));
+    // Canonicalize folder spellings after merge: two devices can independently
+    // create Work and work, and sanitizeRemoteItem only validates strings — so
+    // collapse each folderKey group to one deterministic spelling here.
+    d.items = data.canonicalizeFolders(
+      [...byUrl.values()].sort((a, b) => (a.addedAt ?? 0) - (b.addedAt ?? 0))
+    );
     // Drop tombstones superseded by a surviving newer item, plus stale ones.
     const cutoff = Date.now() - 90 * 24 * 60 * 60 * 1000;
     d.tombstones = [...tomb.values()].filter((t) => {
@@ -149,4 +183,4 @@ function mergeFromSync(remote) {
   notifyMerged();
 }
 
-module.exports = { listBookmarks, isBookmarked, toggleBookmark, updateFavicon, removeBookmark, exportForSync, mergeFromSync, onChanged, onMerged };
+module.exports = { listBookmarks, isBookmarked, toggleBookmark, updateFavicon, removeBookmark, importBookmarks, setBookmarkFolder, renameFolder, removeFolder, exportForSync, mergeFromSync, onChanged, onMerged };

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2004,6 +2004,8 @@ app.whenReady().then(async () => {
   setupPages({
     sessions: browsingSessions,
     onDataChanged: refreshBookmarkFlags,
+    // Parent for the favorites-import file dialog (evaluated lazily at click).
+    getMainWindow: () => (hasLiveWindow() ? win : undefined),
     // The start page's ledger sections read live tab-group state and the
     // rolling blocked counter, both owned here.
     startPage: {

--- a/src/main/pages.js
+++ b/src/main/pages.js
@@ -1,7 +1,11 @@
-const { app, protocol, net, ipcMain, session } = require('electron');
+const { app, protocol, net, ipcMain, session, dialog } = require('electron');
 const path = require('path');
+const fs = require('fs');
 const { pathToFileURL } = require('url');
 const bookmarks = require('./bookmarks');
+const { parseNetscapeBookmarks } = require('./bookmark-import');
+
+const MAX_IMPORT_BYTES = 20 * 1024 * 1024; // 20 MiB
 const history = require('./history');
 const downloads = require('./downloads');
 const settings = require('./settings');
@@ -73,6 +77,40 @@ function setupPages(hooks = {}) {
   // The start page reports a stored favicon URL that failed to load, so
   // it's cleared and stops being retried on future loads.
   handle('pages:bookmarks:clear-favicon', (url) => bookmarks.updateFavicon(url, null));
+
+  handle('pages:bookmarks:import', async () => {
+    const parent = hooks.getMainWindow?.();
+    const picked = await dialog.showOpenDialog(parent ?? undefined, {
+      title: 'Import favorites',
+      filters: [{ name: 'Bookmarks', extensions: ['html', 'htm'] }],
+      properties: ['openFile'],
+    });
+    if (picked.canceled || !picked.filePaths.length) return { cancelled: true };
+    try {
+      const stat = await fs.promises.stat(picked.filePaths[0]);
+      if (stat.size > MAX_IMPORT_BYTES) return { error: 'too-large' };
+      const html = await fs.promises.readFile(picked.filePaths[0], 'utf8');
+      const entries = parseNetscapeBookmarks(html);
+      if (!entries.length) return { error: 'empty' };
+      const { added, skipped } = bookmarks.importBookmarks(entries);
+      hooks.onDataChanged?.();
+      return { added, skipped };
+    } catch {
+      return { error: 'unreadable' };
+    }
+  });
+  handle('pages:bookmarks:set-folder', (id, folder) => {
+    bookmarks.setBookmarkFolder(id, folder);
+    hooks.onDataChanged?.();
+  });
+  handle('pages:bookmarks:rename-folder', (oldName, newName) => {
+    bookmarks.renameFolder(oldName, newName);
+    hooks.onDataChanged?.();
+  });
+  handle('pages:bookmarks:remove-folder', (name) => {
+    bookmarks.removeFolder(name);
+    hooks.onDataChanged?.();
+  });
 
   handle('pages:history:list', (opts) => history.listHistory(opts ?? {}));
   handle('pages:history:remove', (url, visitedAt) => history.removeVisit(url, visitedAt));

--- a/src/main/tab-preload.js
+++ b/src/main/tab-preload.js
@@ -13,6 +13,10 @@ if (window.location.protocol === 'blanc:') {
       list: () => ipcRenderer.invoke('pages:bookmarks:list'),
       remove: (id) => ipcRenderer.invoke('pages:bookmarks:remove', id),
       clearFavicon: (url) => ipcRenderer.invoke('pages:bookmarks:clear-favicon', url),
+      import: () => ipcRenderer.invoke('pages:bookmarks:import'),
+      setFolder: (id, folder) => ipcRenderer.invoke('pages:bookmarks:set-folder', id, folder),
+      renameFolder: (oldName, newName) => ipcRenderer.invoke('pages:bookmarks:rename-folder', oldName, newName),
+      removeFolder: (name) => ipcRenderer.invoke('pages:bookmarks:remove-folder', name),
     },
     history: {
       list: (opts) => ipcRenderer.invoke('pages:history:list', opts),

--- a/src/renderer/pages/bookmarks.html
+++ b/src/renderer/pages/bookmarks.html
@@ -16,7 +16,11 @@
       <a href="blanc://history/">History</a>
       <a href="blanc://downloads/">Downloads</a>
     </nav>
-    <h1>Favorites</h1>
+    <div class="page-head">
+      <h1>Favorites</h1>
+      <button id="importBtn" type="button">Import…</button>
+    </div>
+    <p id="importStatus" class="section-hint" role="status"></p>
     <div id="list" class="row-list"></div>
   </div>
   <script src="bookmarks.js"></script>

--- a/src/renderer/pages/bookmarks.js
+++ b/src/renderer/pages/bookmarks.js
@@ -23,51 +23,205 @@
     refresh();
   });
 
+  const folderKey = (name) => (typeof name === 'string' ? name.trim().toLowerCase() : '');
+  const byDateDesc = (a, b) => (b.addedAt ?? 0) - (a.addedAt ?? 0);
+
+  function group(items) {
+    const byKey = new Map();       // key -> { name, items }
+    const ungrouped = [];
+    for (const b of items) {
+      if (b.folder == null) { ungrouped.push(b); continue; }
+      const key = folderKey(b.folder);
+      if (!byKey.has(key)) byKey.set(key, { name: b.folder, items: [] });
+      byKey.get(key).items.push(b);
+    }
+    const folders = [...byKey.values()].sort((a, b) =>
+      a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+    for (const f of folders) f.items.sort(byDateDesc);
+    ungrouped.sort(byDateDesc);
+    return { folders, ungrouped, names: folders.map((f) => f.name) };
+  }
+
   async function refresh() {
     const items = await window.bowserPages.bookmarks.list();
     list.replaceChildren();
-
     if (items.length === 0) {
       const empty = document.createElement('div');
       empty.className = 'empty';
-      empty.textContent = 'No favorites yet. Press Ctrl/Cmd+D on a page to add one.';
+      empty.textContent = 'No favorites yet. Press Ctrl/Cmd+D on a page to add one, or use Import.';
       list.append(empty);
       return;
     }
+    const { folders, ungrouped, names } = group(items);
+    for (const f of folders) list.append(folderSection(f, names));
+    if (ungrouped.length) list.append(ungroupedSection(ungrouped, names));
+  }
 
-    for (const b of [...items].reverse()) {
-      const row = document.createElement('div');
-      row.className = 'row';
+  function folderSection(folder, allNames) {
+    const section = document.createElement('section');
+    section.className = 'folder-section';
 
-      const main = document.createElement('div');
-      main.className = 'main';
-      const title = document.createElement('a');
-      title.className = 'title';
-      title.href = b.url;
-      title.textContent = b.title;
-      const url = document.createElement('div');
-      url.className = 'url';
-      url.textContent = b.url;
-      main.append(title, url);
+    const head = document.createElement('div');
+    head.className = 'folder-header';
+    const name = document.createElement('span');
+    name.className = 'folder-name';
+    name.textContent = folder.name;
+    const count = document.createElement('span');
+    count.className = 'folder-count';
+    count.textContent = String(folder.items.length);
 
-      const meta = document.createElement('div');
-      meta.className = 'meta';
-      meta.textContent = new Date(b.addedAt).toLocaleDateString();
+    const acts = document.createElement('div');
+    acts.className = 'folder-actions';
+    const renameBtn = document.createElement('button');
+    renameBtn.type = 'button';
+    renameBtn.textContent = 'Rename';
+    renameBtn.addEventListener('click', () => startRename(head, folder.name));
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = 'Remove folder';
+    removeBtn.addEventListener('click', async () => {
+      await window.bowserPages.bookmarks.removeFolder(folder.name);
+      refresh();
+    });
+    acts.append(renameBtn, removeBtn);
+    head.append(name, count, acts);
+    section.append(head);
+    for (const b of folder.items) section.append(row(b, allNames));
+    return section;
+  }
 
-      const actions = document.createElement('div');
-      actions.className = 'actions';
-      const remove = document.createElement('button');
-      remove.className = 'danger';
-      remove.textContent = 'Remove';
-      remove.addEventListener('click', async () => {
-        await window.bowserPages.bookmarks.remove(b.id);
-        refresh();
-      });
-      actions.append(remove);
-
-      row.append(main, meta, actions);
-      list.append(row);
+  function ungroupedSection(items, allNames) {
+    const section = document.createElement('section');
+    section.className = 'folder-section';
+    if (allNames.length) {
+      const head = document.createElement('div');
+      head.className = 'folder-header';
+      const name = document.createElement('span');
+      name.className = 'folder-name folder-name-dim';
+      name.textContent = 'Ungrouped';
+      head.append(name);
+      section.append(head);
     }
+    for (const b of items) section.append(row(b, allNames));
+    return section;
+  }
+
+  function startRename(head, oldName) {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.maxLength = 100;
+    input.value = oldName;
+    input.className = 'folder-rename-input';
+    // One-shot guard shared by Enter/Escape/blur: Escape (and Enter) call
+    // refresh(), which detaches the input and fires its own blur handler —
+    // without this guard, an Escape-cancel would still commit via that blur.
+    let settled = false;
+    const commit = async () => {
+      if (settled) return;
+      settled = true;
+      const next = input.value.trim();
+      if (next && next !== oldName) await window.bowserPages.bookmarks.renameFolder(oldName, next);
+      refresh();
+    };
+    const cancel = () => {
+      if (settled) return;
+      settled = true;
+      refresh();
+    };
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); commit(); }
+      else if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+    });
+    input.addEventListener('blur', commit);
+    head.replaceChildren(input);
+    input.focus();
+    input.select();
+  }
+
+  function row(b, allNames) {
+    const el = document.createElement('div');
+    el.className = 'row';
+
+    const main = document.createElement('div');
+    main.className = 'main';
+    const title = document.createElement('a');
+    title.className = 'title';
+    title.href = b.url;
+    title.textContent = b.title;
+    const url = document.createElement('div');
+    url.className = 'url';
+    url.textContent = b.url;
+    main.append(title, url);
+
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+    meta.textContent = new Date(b.addedAt).toLocaleDateString();
+
+    const actions = document.createElement('div');
+    actions.className = 'actions bookmark-actions';
+    const folderBtn = document.createElement('button');
+    folderBtn.type = 'button';
+    folderBtn.className = 'folder-chip';
+    folderBtn.textContent = b.folder ? `▸ ${b.folder}` : '▸ folder';
+    folderBtn.addEventListener('click', () => openPicker(folderBtn, b, allNames));
+    const remove = document.createElement('button');
+    remove.className = 'danger';
+    remove.textContent = 'Remove';
+    remove.addEventListener('click', async () => {
+      await window.bowserPages.bookmarks.remove(b.id);
+      refresh();
+    });
+    actions.append(folderBtn, remove);
+
+    el.append(main, meta, actions);
+    return el;
+  }
+
+  let openMenu = null;
+  function closeMenu() { openMenu?.remove(); openMenu = null; }
+  document.addEventListener('click', (e) => {
+    if (openMenu && !openMenu.contains(e.target) && !e.target.classList.contains('folder-chip')) closeMenu();
+  });
+
+  function openPicker(anchor, b, allNames) {
+    if (openMenu) { closeMenu(); return; }
+    const menu = document.createElement('div');
+    menu.className = 'folder-picker';
+    const pick = async (fn) => { await fn(); closeMenu(); refresh(); };
+
+    for (const nm of allNames) {
+      if (folderKey(nm) === folderKey(b.folder)) continue;
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'picker-item';
+      item.textContent = `→ ${nm}`;
+      item.addEventListener('click', () => pick(() => window.bowserPages.bookmarks.setFolder(b.id, nm)));
+      menu.append(item);
+    }
+    if (b.folder) {
+      const none = document.createElement('button');
+      none.type = 'button';
+      none.className = 'picker-item';
+      none.textContent = '→ none';
+      none.addEventListener('click', () => pick(() => window.bowserPages.bookmarks.setFolder(b.id, null)));
+      menu.append(none);
+    }
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.maxLength = 100;
+    nameInput.placeholder = 'new folder…';
+    nameInput.className = 'picker-new';
+    nameInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        const v = nameInput.value.trim();
+        if (v) pick(() => window.bowserPages.bookmarks.setFolder(b.id, v));
+      } else if (e.key === 'Escape') closeMenu();
+    });
+    menu.append(nameInput);
+
+    anchor.parentElement.append(menu);
+    openMenu = menu;
+    nameInput.focus();
   }
 
   refresh();

--- a/src/renderer/pages/bookmarks.js
+++ b/src/renderer/pages/bookmarks.js
@@ -178,13 +178,18 @@
   }
 
   let openMenu = null;
-  function closeMenu() { openMenu?.remove(); openMenu = null; }
+  let openAnchor = null;
+  function closeMenu() { openMenu?.remove(); openMenu = null; openAnchor = null; }
   document.addEventListener('click', (e) => {
     if (openMenu && !openMenu.contains(e.target) && !e.target.classList.contains('folder-chip')) closeMenu();
   });
 
   function openPicker(anchor, b, allNames) {
-    if (openMenu) { closeMenu(); return; }
+    // Same chip toggles the picker closed; a different chip closes the old one
+    // and opens the new one in a single click (not two).
+    const sameAnchor = openAnchor === anchor;
+    if (openMenu) closeMenu();
+    if (sameAnchor) return;
     const menu = document.createElement('div');
     menu.className = 'folder-picker';
     const pick = async (fn) => { await fn(); closeMenu(); refresh(); };
@@ -221,6 +226,7 @@
 
     anchor.parentElement.append(menu);
     openMenu = menu;
+    openAnchor = anchor;
     nameInput.focus();
   }
 

--- a/src/renderer/pages/bookmarks.js
+++ b/src/renderer/pages/bookmarks.js
@@ -1,5 +1,27 @@
 (async () => {
   const list = document.getElementById('list');
+  const importBtn = document.getElementById('importBtn');
+  const importStatus = document.getElementById('importStatus');
+
+  const plural = (n, w) => `${n} ${w}${n === 1 ? '' : 's'}`;
+  function importSummary(added, skipped) {
+    if (added === 0 && skipped > 0) return `All ${plural(skipped, 'favorite')} were already saved.`;
+    const tail = skipped > 0 ? ` (skipped ${skipped} already saved)` : '';
+    return `Imported ${plural(added, 'favorite')}${tail}.`;
+  }
+
+  importBtn.addEventListener('click', async () => {
+    importBtn.disabled = true;
+    importStatus.textContent = 'Choose a bookmarks file…';
+    const res = await window.bowserPages.bookmarks.import();
+    importBtn.disabled = false;
+    if (res.cancelled) { importStatus.textContent = ''; return; }
+    if (res.error === 'empty') { importStatus.textContent = 'No bookmarks found in that file.'; return; }
+    if (res.error === 'unreadable') { importStatus.textContent = "Couldn't read that file."; return; }
+    if (res.error === 'too-large') { importStatus.textContent = 'That file is too large to import.'; return; }
+    importStatus.textContent = importSummary(res.added, res.skipped);
+    refresh();
+  });
 
   async function refresh() {
     const items = await window.bowserPages.bookmarks.list();

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -620,3 +620,63 @@ a.ledger-label:hover { color: var(--accent); }
 }
 .page-head h1 { margin-bottom: 12px; }
 #importStatus { margin: 0 0 16px; min-height: 16px; }
+
+.folder-section { margin-bottom: 14px; }
+.folder-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2px;
+}
+.folder-name { font-family: var(--font-mono); font-size: 12.5px; color: var(--text); }
+.folder-name-dim { color: var(--text-dim); }
+.folder-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  background: var(--surface);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+.folder-actions { margin-left: auto; display: flex; gap: 6px; }
+.folder-actions button { padding: 3px 9px; font-size: 11px; }
+.folder-rename-input { width: 220px; }
+.folder-chip {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 3px 9px;
+}
+/* Favorites rows only. The shared `.row .actions { opacity: 0 }` (used by
+   history/downloads too) is left untouched; child opacity can't override an
+   ancestor's, so instead keep this container visible and hide ONLY Remove
+   until hover/focus, leaving the folder chip always reachable. The extra
+   class raises specificity above the shared rule. */
+.row .actions.bookmark-actions { opacity: 1; position: relative; }
+.row .actions.bookmark-actions .danger { opacity: 0; }
+.row:hover .actions.bookmark-actions .danger,
+.row:focus-within .actions.bookmark-actions .danger { opacity: 1; }
+.folder-picker {
+  position: absolute;
+  z-index: 20;
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 180px;
+  padding: 6px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+.picker-item {
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  border: none;
+  background: transparent;
+}
+.picker-item:hover { background: var(--surface); border-color: transparent; }
+.picker-new { margin-top: 4px; font-size: 11.5px; }

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -610,3 +610,13 @@ a.ledger-label:hover { color: var(--accent); }
   padding: 2px 8px;
   white-space: nowrap;
 }
+
+/* Favorites page: import header + folder sections */
+.page-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.page-head h1 { margin-bottom: 12px; }
+#importStatus { margin: 0 0 16px; min-height: 16px; }

--- a/test/fixtures/chrome-bookmarks.html
+++ b/test/fixtures/chrome-bookmarks.html
@@ -1,0 +1,19 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><H3 ADD_DATE="1700000000" LAST_MODIFIED="1700000000" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks bar</H3>
+    <DL><p>
+        <DT><A HREF="https://example.com/" ADD_DATE="1700000000" ICON="data:image/png;base64,AAAA">Example</A>
+        <DT><H3 ADD_DATE="1700000100">News</H3>
+        <DL><p>
+            <DT><A HREF="https://news.example.com/tech?q=a&amp;b=1" ADD_DATE="1700000200">Tech &amp; Science</A>
+        </DL><p>
+    </DL><p>
+    <DT><H3>Other bookmarks</H3>
+    <DL><p>
+        <DT><A HREF="javascript:void(0)" ADD_DATE="1700000300">A Bookmarklet</A>
+        <DT><A HREF="https://plain.example.org/">Plain</A>
+    </DL><p>
+</DL><p>

--- a/test/fixtures/firefox-bookmarks.html
+++ b/test/fixtures/firefox-bookmarks.html
@@ -1,0 +1,12 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks Menu</TITLE>
+<H1>Bookmarks Menu</H1>
+<DL><p>
+    <DT><H3 ADD_DATE='1600000000' LAST_MODIFIED='1600000000'>Mozilla Firefox</H3>
+    <DL><p>
+        <DT><A HREF="https://www.mozilla.org/" ADD_DATE=1600000000>Mozilla</A>
+        <DT><A HREF="place:type=6&maxResults=10" ADD_DATE="1600000000">Recently Bookmarked</A>
+        <DT><A HREF="https://future.example.com/" ADD_DATE="99999999999">Future Dated</A>
+    </DL><p>
+</DL><p>

--- a/test/fixtures/safari-bookmarks.html
+++ b/test/fixtures/safari-bookmarks.html
@@ -1,0 +1,14 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<HTML>
+<HEAD><TITLE>Bookmarks</TITLE></HEAD>
+<BODY>
+<H1>Bookmarks</H1>
+<DL><P>
+    <DT><H3 FOLDED>Favorites</H3>
+    <DL><P>
+        <DT><A HREF="https://apple.com/">Apple</A>
+    </DL><P>
+    <DT><A HREF="https://toplevel.example.net/">Top Level</A>
+</DL><P>
+</BODY>
+</HTML>

--- a/test/unit/bookmark-data.test.js
+++ b/test/unit/bookmark-data.test.js
@@ -1,0 +1,112 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  addImported, applySetFolder, applyRenameFolder, applyRemoveFolder, canonicalizeFolders,
+} = require('../../src/main/bookmark-data');
+
+const NOW = 2000;
+let seq = 0;
+const makeId = () => `id${++seq}`;
+const opts = { now: NOW, makeId };
+test.beforeEach(() => { seq = 0; });
+
+const snap = (items, tombstones = []) => ({ items, tombstones });
+
+test('addImported: dedupe vs existing and intra-batch, first occurrence wins', () => {
+  const cur = snap([{ id: 'a', url: 'https://a.com/', title: 'A', favicon: null, addedAt: 1, updatedAt: 1, folder: null }]);
+  const entries = [
+    { url: 'https://a.com/', title: 'dup existing', addedAt: 5, folder: 'X' },
+    { url: 'https://b.com/', title: 'B', addedAt: 10, folder: 'Work' },
+    { url: 'https://b.com/', title: 'dup batch', addedAt: 11, folder: 'work' },
+  ];
+  const res = addImported(cur, entries, opts);
+  assert.equal(res.added, 1);
+  assert.equal(res.skipped, 2);
+  assert.equal(res.changed, true);
+  const b = res.items.find((it) => it.url === 'https://b.com/');
+  assert.equal(b.title, 'B');
+  assert.equal(b.folder, 'Work');
+  assert.equal(b.updatedAt, NOW);
+  // existing item untouched
+  assert.equal(res.items.find((it) => it.url === 'https://a.com/').folder, null);
+  // result oldest-first by addedAt
+  assert.deepEqual(res.items.map((it) => it.addedAt), [1, 10]);
+});
+
+test('addImported: adopts existing folder spelling; all-duplicate => changed:false', () => {
+  const cur = snap([{ id: 'a', url: 'https://a.com/', title: 'A', favicon: null, addedAt: 1, updatedAt: 1, folder: 'Work' }]);
+  const res = addImported(cur, [{ url: 'https://c.com/', title: 'C', addedAt: 3, folder: 'WORK' }], opts);
+  assert.equal(res.items.find((it) => it.url === 'https://c.com/').folder, 'Work'); // existing spelling wins
+
+  const res2 = addImported(cur, [{ url: 'https://a.com/', title: 'dup', addedAt: 9, folder: 'X' }], opts);
+  assert.equal(res2.changed, false);
+  assert.equal(res2.added, 0);
+  assert.equal(res2.skipped, 1);
+});
+
+test('addImported: clears tombstone for re-added url', () => {
+  const cur = snap([], [{ url: 'https://a.com/', deletedAt: 100 }]);
+  const res = addImported(cur, [{ url: 'https://a.com/', title: 'A', addedAt: 5, folder: null }], opts);
+  assert.equal(res.tombstones.length, 0);
+});
+
+test('applySetFolder: explicit null ungroups; invalid string is a no-op (not ungroup)', () => {
+  const cur = snap([{ id: 'a', url: 'u', title: 'A', favicon: null, addedAt: 1, updatedAt: 1, folder: 'Work' }]);
+  assert.equal(applySetFolder(cur, 'a', null, opts).items[0].folder, null);
+  assert.equal(applySetFolder(cur, 'a', '   ', opts).changed, false);       // blank
+  assert.equal(applySetFolder(cur, 'a', 'x'.repeat(101), opts).changed, false); // too long
+  assert.equal(applySetFolder(cur, 'missing', 'Y', opts).changed, false);   // unknown id
+  assert.equal(applySetFolder(cur, 'a', 'Work', opts).changed, false);      // unchanged
+});
+
+test('applySetFolder: adopts existing spelling for a case-variant target', () => {
+  const cur = snap([
+    { id: 'a', url: 'ua', title: 'A', favicon: null, addedAt: 1, updatedAt: 1, folder: 'Reading' },
+    { id: 'b', url: 'ub', title: 'B', favicon: null, addedAt: 2, updatedAt: 2, folder: null },
+  ]);
+  const res = applySetFolder(cur, 'b', 'READING', opts);
+  assert.equal(res.items.find((it) => it.id === 'b').folder, 'Reading');
+});
+
+test('applyRenameFolder: merge-on-collision, case-only re-spell, rejects invalid', () => {
+  const cur = snap([
+    { id: 'a', url: 'ua', title: 'A', favicon: null, addedAt: 1, updatedAt: 1, folder: 'news' },
+    { id: 'b', url: 'ub', title: 'B', favicon: null, addedAt: 2, updatedAt: 2, folder: 'Reading' },
+  ]);
+  const merged = applyRenameFolder(cur, 'News', 'Reading', opts); // collision -> merge
+  assert.equal(merged.items.find((it) => it.id === 'a').folder, 'Reading');
+  assert.equal(merged.items.find((it) => it.id === 'a').updatedAt, NOW);
+
+  // case-only rename: stored 'news' re-spelled to 'News' (a real change)
+  const respell = applyRenameFolder(cur, 'news', 'News', opts);
+  assert.equal(respell.items.find((it) => it.id === 'a').folder, 'News');
+  assert.equal(respell.changed, true);
+
+  assert.equal(applyRenameFolder(cur, 'News', '   ', opts).changed, false);        // blank rejected
+  assert.equal(applyRenameFolder(cur, 'Nope', 'Whatever', opts).changed, false);   // unknown folder
+});
+
+test('applyRemoveFolder: ungroups all in folder; empty => changed:false', () => {
+  const cur = snap([
+    { id: 'a', url: 'ua', title: 'A', favicon: null, addedAt: 1, updatedAt: 1, folder: 'Work' },
+    { id: 'b', url: 'ub', title: 'B', favicon: null, addedAt: 2, updatedAt: 2, folder: 'Work' },
+  ]);
+  const res = applyRemoveFolder(cur, 'work', opts);
+  assert.equal(res.changed, true);
+  assert.equal(res.items.every((it) => it.folder === null), true);
+  assert.equal(applyRemoveFolder(cur, 'Ghost', opts).changed, false);
+});
+
+test('canonicalizeFolders: mixed spellings collapse deterministically without touching updatedAt', () => {
+  const items = [
+    { id: 'a', url: 'ua', title: 'A', favicon: null, addedAt: 5, updatedAt: 5, folder: 'work' },
+    { id: 'b', url: 'ub', title: 'B', favicon: null, addedAt: 2, updatedAt: 2, folder: 'Work' }, // oldest -> canonical
+    { id: 'c', url: 'uc', title: 'C', favicon: null, addedAt: 9, updatedAt: 9, folder: null },
+  ];
+  const out = canonicalizeFolders(items);
+  assert.equal(out.find((it) => it.id === 'a').folder, 'Work');
+  assert.equal(out.find((it) => it.id === 'a').updatedAt, 5); // NOT bumped
+  assert.equal(out.find((it) => it.id === 'c').folder, null);
+  // idempotent / convergent
+  assert.deepEqual(canonicalizeFolders(out).map((it) => it.folder), out.map((it) => it.folder));
+});

--- a/test/unit/bookmark-import.test.js
+++ b/test/unit/bookmark-import.test.js
@@ -1,0 +1,46 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { parseNetscapeBookmarks } = require('../../src/main/bookmark-import');
+
+const FIXED_NOW = 1710000000000; // ms, after all fixture ADD_DATEs, before the "future" one
+const fixture = (name) => fs.readFileSync(path.join(__dirname, '..', 'fixtures', name), 'utf8');
+const byUrl = (entries) => new Map(entries.map((e) => [e.url, e]));
+
+test('chrome: immediate-parent folders, entity decode, icon, non-http dropped', () => {
+  const entries = parseNetscapeBookmarks(fixture('chrome-bookmarks.html'), { now: FIXED_NOW });
+  const m = byUrl(entries);
+  assert.equal(m.get('https://example.com/').folder, 'Bookmarks bar');
+  assert.equal(m.get('https://example.com/').favicon, 'data:image/png;base64,AAAA');
+  assert.equal(m.get('https://example.com/').addedAt, 1700000000 * 1000);
+  // immediate parent is News, not the joined path
+  assert.equal(m.get('https://news.example.com/tech?q=a&b=1').folder, 'News');
+  assert.equal(m.get('https://news.example.com/tech?q=a&b=1').title, 'Tech & Science');
+  assert.equal(m.get('https://plain.example.org/').folder, 'Other bookmarks');
+  // javascript: bookmarklet is dropped
+  assert.equal([...m.keys()].some((u) => u.startsWith('javascript:')), false);
+});
+
+test('firefox: single/bare quotes, place: dropped, future date clamped to now', () => {
+  const entries = parseNetscapeBookmarks(fixture('firefox-bookmarks.html'), { now: FIXED_NOW });
+  const m = byUrl(entries);
+  assert.equal(m.get('https://www.mozilla.org/').folder, 'Mozilla Firefox');
+  assert.equal(m.get('https://www.mozilla.org/').addedAt, 1600000000 * 1000);
+  assert.equal([...m.keys()].some((u) => u.startsWith('place:')), false);
+  assert.equal(m.get('https://future.example.com/').addedAt, FIXED_NOW); // future rejected
+});
+
+test('safari: uppercase tags, top-level (no H3) is ungrouped', () => {
+  const entries = parseNetscapeBookmarks(fixture('safari-bookmarks.html'), { now: FIXED_NOW });
+  const m = byUrl(entries);
+  assert.equal(m.get('https://apple.com/').folder, 'Favorites');
+  assert.equal(m.get('https://toplevel.example.net/').folder, null);
+});
+
+test('over-length ICON is dropped to null favicon', () => {
+  const big = 'data:image/png;base64,' + 'A'.repeat(3000);
+  const html = `<DL><p><DT><A HREF="https://x.com/" ICON="${big}">X</A></DL><p>`;
+  const [e] = parseNetscapeBookmarks(html, { now: FIXED_NOW });
+  assert.equal(e.favicon, null);
+});

--- a/test/unit/bookmark-validate.test.js
+++ b/test/unit/bookmark-validate.test.js
@@ -1,0 +1,27 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { validFavicon, validFolder, folderKey } = require('../../src/main/bookmark-validate');
+
+test('validFavicon accepts http(s) and data:image, rejects others and over-long', () => {
+  assert.equal(validFavicon('https://x.com/f.ico'), 'https://x.com/f.ico');
+  assert.equal(validFavicon('data:image/png;base64,AAAA'), 'data:image/png;base64,AAAA');
+  assert.equal(validFavicon('javascript:alert(1)'), null);
+  assert.equal(validFavicon('data:text/html,x'), null);
+  assert.equal(validFavicon('data:image/png;base64,' + 'A'.repeat(3000)), null);
+  assert.equal(validFavicon(42), null);
+});
+
+test('validFolder trims, caps at 100 chars, else null', () => {
+  assert.equal(validFolder('  Work  '), 'Work');
+  assert.equal(validFolder(''), null);
+  assert.equal(validFolder('   '), null);
+  assert.equal(validFolder('x'.repeat(100)), 'x'.repeat(100));
+  assert.equal(validFolder('x'.repeat(101)), null);
+  assert.equal(validFolder(null), null);
+});
+
+test('folderKey lowercases and trims; non-string is empty', () => {
+  assert.equal(folderKey('  Work '), 'work');
+  assert.equal(folderKey('WORK'), 'work');
+  assert.equal(folderKey(null), '');
+});


### PR DESCRIPTION
## Summary

- **Import favorites** from any browser's exported bookmarks HTML (the universal *Netscape* format — Chrome/Edge/Brave/Firefox/Safari) via a native file picker on the Favorites page. No new dependencies; nothing reaches into other apps' profile directories.
- **First-class, single-level favorites folders** (modeled on Blanc's tab groups), managed on the Favorites page: assign/move via a per-row picker, **Rename** (merge-on-collision), **Remove folder** (ungroup). A folder exists only while a favorite references it.

## Design

- Spec: `docs/superpowers/specs/2026-07-11-import-favorites-folders-design.md`
- Plan: `docs/superpowers/plans/2026-07-11-import-favorites-folders.md`

## Implementation notes

- Pure, Electron-free cores — `bookmark-validate.js`, `bookmark-import.js`, `bookmark-data.js` — unit-tested under `node --test`; `bookmarks.js` stays the thin `JsonStore` wrapper that **writes only on a real change**.
- `folder` is a per-item field. Case-insensitive identity (`folderKey`); first-existing spelling wins; rename-to-existing merges. `mergeFromSync` runs `canonicalizeFolders` so two devices creating `Work`/`work` converge deterministically **without bumping `updatedAt`** (no sync ping-pong).
- Import: immediate-parent folder naming, `http(s)`-only filter, `ICON`/`ADD_DATE` handling, HTML-entity decode, quote/case-tolerant scan, 20 MiB cap via `stat()` before `readFile`.
- Guarded `pages:bookmarks:*` IPC; file dialog parented via a new `getMainWindow` hook. Other favorites surfaces (start page, ⌘L, menu) ignore the additive `folder` field — flat list preserved.

## Testing

- **105/105 unit tests** (15 new: validators; parser against Chrome/Firefox/Safari fixtures; import/folder/canonicalize transforms).
- **Live Playwright-Electron smoke** (`BLANC_TEST=1`, isolated profile): import → grouped render → `setFolder`/`renameFolder`(merge)/`removeFolder` through the real bridge → IPC → store chain; folder-chip visibility verified via computed styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)