### PR TITLE
Reflect favorites folders in the native Favorites menu

### DIFF
--- a/src/main/bookmark-data.js
+++ b/src/main/bookmark-data.js
@@ -127,7 +127,11 @@ function canonicalizeFolders(items) {
 /** Group favorites for the native Favorites menu: folders first (alphabetical,
  * case-insensitive), each folder's items newest-first, then ungrouped items
  * newest-first — mirroring the Favorites page. Pure: the menu builder wires
- * click handlers onto the returned bookmarks. */
+ * click handlers onto the returned bookmarks.
+ *
+ * Ordering is intentionally identical to `group()` in
+ * src/renderer/pages/bookmarks.js (the page can't share this — different
+ * runtime); keep the two in sync so the menu and page never disagree. */
 function groupFavoritesForMenu(items) {
   const newestFirst = (a, b) => (b.addedAt ?? 0) - (a.addedAt ?? 0);
   const byKey = new Map(); // folderKey -> { name, items }

--- a/src/main/bookmark-data.js
+++ b/src/main/bookmark-data.js
@@ -124,6 +124,28 @@ function canonicalizeFolders(items) {
   });
 }
 
+/** Group favorites for the native Favorites menu: folders first (alphabetical,
+ * case-insensitive), each folder's items newest-first, then ungrouped items
+ * newest-first — mirroring the Favorites page. Pure: the menu builder wires
+ * click handlers onto the returned bookmarks. */
+function groupFavoritesForMenu(items) {
+  const newestFirst = (a, b) => (b.addedAt ?? 0) - (a.addedAt ?? 0);
+  const byKey = new Map(); // folderKey -> { name, items }
+  const ungrouped = [];
+  for (const b of items) {
+    if (b.folder == null) { ungrouped.push(b); continue; }
+    const key = folderKey(b.folder);
+    if (!byKey.has(key)) byKey.set(key, { name: b.folder, items: [] });
+    byKey.get(key).items.push(b);
+  }
+  const folders = [...byKey.values()].sort((a, b) =>
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  for (const f of folders) f.items.sort(newestFirst);
+  ungrouped.sort(newestFirst);
+  return { folders, ungrouped };
+}
+
 module.exports = {
   addImported, applySetFolder, applyRenameFolder, applyRemoveFolder, canonicalizeFolders,
+  groupFavoritesForMenu,
 };

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -20,6 +20,7 @@ const { attachContextMenu } = require('./context-menu');
 const { promptForCredentials } = require('./auth-dialog');
 const settings = require('./settings');
 const bookmarks = require('./bookmarks');
+const { groupFavoritesForMenu } = require('./bookmark-data');
 const history = require('./history');
 const { JsonStore } = require('./store');
 const { shouldClearFaviconOnNavigate } = require('./favicon-policy');
@@ -1609,11 +1610,19 @@ function tabMenuItems() {
 
 /** Native-menu items for the most-recently-added favorites, newest first. */
 function favoritesMenuItems() {
-  const all = bookmarks.listBookmarks(); // oldest-first
-  return all.slice(-20).reverse().map((b) => ({
-    label: (b.title || b.url).length > 120 ? `${(b.title || b.url).slice(0, 119)}…` : (b.title || b.url),
-    click: () => setActiveTab(createTab(b.url)),
-  }));
+  const label = (b) => {
+    const t = b.title || b.url;
+    return t.length > 120 ? `${t.slice(0, 119)}…` : t;
+  };
+  const open = (b) => ({ label: label(b), click: () => setActiveTab(createTab(b.url)) });
+  // Folders as submenus first (alphabetical), then ungrouped favorites inline —
+  // mirroring the Favorites page. Everything is shown; folders keep the menu
+  // navigable regardless of favorite count (no flat cap).
+  const { folders, ungrouped } = groupFavoritesForMenu(bookmarks.listBookmarks());
+  const items = folders.map((f) => ({ label: f.name, submenu: f.items.map(open) }));
+  if (folders.length && ungrouped.length) items.push({ type: 'separator' });
+  items.push(...ungrouped.map(open));
+  return items;
 }
 
 // --- Keyboard shortcuts inventory (Help → Keyboard Shortcuts page) ---
@@ -1832,9 +1841,6 @@ function buildMenu() {
         },
         { type: 'separator' },
         ...favoritesMenuItems(),
-        ...(bookmarks.listBookmarks().length > 20
-          ? [{ label: 'Show All Favorites…', click: () => openInternalPage('blanc://bookmarks/') }]
-          : []),
         { type: 'separator' },
         { label: 'Show Favorites', accelerator: isMac ? 'Cmd+Alt+B' : 'Ctrl+Shift+O', click: () => openInternalPage('blanc://bookmarks/') },
         { label: 'Show History', accelerator: 'CmdOrCtrl+Y', click: () => openInternalPage('blanc://history/') },

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1600,7 +1600,7 @@ function tabMenuItems() {
     }
     const label = `${tab.title || 'New Tab'} — ${domain}${group ? ` (${group.name})` : ''}`;
     return {
-      label: label.length > 120 ? `${label.slice(0, 119)}…` : label,
+      label: escapeMenuLabel(label.length > 120 ? `${label.slice(0, 119)}…` : label),
       type: 'checkbox',
       checked: id === activeTabId,
       click: () => setActiveTab(id),
@@ -1608,18 +1608,24 @@ function tabMenuItems() {
   });
 }
 
-/** Native-menu items for the most-recently-added favorites, newest first. */
+/** Double a literal '&' so native menus on Windows/Linux don't swallow it as
+ * an Alt-mnemonic (macOS has no mnemonics). Apply to every menu label built
+ * from user content — tab/favorite titles and folder names. */
+const escapeMenuLabel = (label) => (process.platform === 'darwin' ? label : label.replace(/&/g, '&&'));
+
+/** Native Favorites-menu items: folder submenus first (alphabetical), then
+ * ungrouped favorites inline — mirroring the Favorites page. */
 function favoritesMenuItems() {
   const label = (b) => {
     const t = b.title || b.url;
     return t.length > 120 ? `${t.slice(0, 119)}…` : t;
   };
-  const open = (b) => ({ label: label(b), click: () => setActiveTab(createTab(b.url)) });
+  const open = (b) => ({ label: escapeMenuLabel(label(b)), click: () => setActiveTab(createTab(b.url)) });
   // Folders as submenus first (alphabetical), then ungrouped favorites inline —
   // mirroring the Favorites page. Everything is shown; folders keep the menu
-  // navigable regardless of favorite count (no flat cap).
+  // navigable regardless of favorite count (no flat cap on ungrouped either).
   const { folders, ungrouped } = groupFavoritesForMenu(bookmarks.listBookmarks());
-  const items = folders.map((f) => ({ label: f.name, submenu: f.items.map(open) }));
+  const items = folders.map((f) => ({ label: escapeMenuLabel(f.name), submenu: f.items.map(open) }));
   if (folders.length && ungrouped.length) items.push({ type: 'separator' });
   items.push(...ungrouped.map(open));
   return items;
@@ -1724,7 +1730,8 @@ function buildMenu() {
   // On Windows/Linux native menus a lone "&" marks the next char as an Alt
   // mnemonic and is swallowed; a literal ampersand must be doubled. macOS
   // has no mnemonics, so leave labels untouched there.
-  const mn = (label) => (isMac ? label : label.replace(/&/g, '&&'));
+  const mn = escapeMenuLabel; // literal '&' → '&&' on Win/Linux; see helper
+  const favItems = favoritesMenuItems(); // computed once; drives the separator below
   const appMenu = isMac
     ? [{
         label: app.name,
@@ -1840,8 +1847,10 @@ function buildMenu() {
           click: addAllTabsToFavorites,
         },
         { type: 'separator' },
-        ...favoritesMenuItems(),
-        { type: 'separator' },
+        ...favItems,
+        // Only divide the favorites list from Show Favorites when there ARE
+        // favorites — otherwise the two separators would collapse into one gap.
+        ...(favItems.length ? [{ type: 'separator' }] : []),
         { label: 'Show Favorites', accelerator: isMac ? 'Cmd+Alt+B' : 'Ctrl+Shift+O', click: () => openInternalPage('blanc://bookmarks/') },
         { label: 'Show History', accelerator: 'CmdOrCtrl+Y', click: () => openInternalPage('blanc://history/') },
       ],

--- a/src/renderer/pages/bookmarks.js
+++ b/src/renderer/pages/bookmarks.js
@@ -26,6 +26,9 @@
   const folderKey = (name) => (typeof name === 'string' ? name.trim().toLowerCase() : '');
   const byDateDesc = (a, b) => (b.addedAt ?? 0) - (a.addedAt ?? 0);
 
+  // Ordering (folders alpha, items newest-first, ungrouped last) is mirrored by
+  // groupFavoritesForMenu in src/main/bookmark-data.js for the native menu —
+  // keep the two in sync.
   function group(items) {
     const byKey = new Map();       // key -> { name, items }
     const ungrouped = [];

--- a/test/unit/bookmark-data.test.js
+++ b/test/unit/bookmark-data.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 const {
   addImported, applySetFolder, applyRenameFolder, applyRemoveFolder, canonicalizeFolders,
+  groupFavoritesForMenu,
 } = require('../../src/main/bookmark-data');
 
 const NOW = 2000;
@@ -109,4 +110,26 @@ test('canonicalizeFolders: mixed spellings collapse deterministically without to
   assert.equal(out.find((it) => it.id === 'c').folder, null);
   // idempotent / convergent
   assert.deepEqual(canonicalizeFolders(out).map((it) => it.folder), out.map((it) => it.folder));
+});
+
+test('groupFavoritesForMenu: folders alphabetical (case-insensitive) + newest-first, then ungrouped newest-first', () => {
+  const items = [
+    { id: '1', url: 'ua', title: 'A', addedAt: 1, folder: 'Zeta' },
+    { id: '2', url: 'ub', title: 'B', addedAt: 5, folder: 'alpha' },
+    { id: '3', url: 'uc', title: 'C', addedAt: 3, folder: 'alpha' },
+    { id: '4', url: 'ud', title: 'D', addedAt: 2, folder: null },
+    { id: '5', url: 'ue', title: 'E', addedAt: 9, folder: null },
+  ];
+  const { folders, ungrouped } = groupFavoritesForMenu(items);
+  assert.deepEqual(folders.map((f) => f.name), ['alpha', 'Zeta']); // case-insensitive alpha order
+  assert.deepEqual(folders[0].items.map((b) => b.title), ['B', 'C']); // newest-first (addedAt 5, 3)
+  assert.deepEqual(ungrouped.map((b) => b.title), ['E', 'D']); // newest-first (addedAt 9, 2)
+});
+
+test('groupFavoritesForMenu: empty and all-ungrouped inputs', () => {
+  assert.deepEqual(groupFavoritesForMenu([]), { folders: [], ungrouped: [] });
+  const only = [{ id: '1', url: 'u', title: 'T', addedAt: 1, folder: null }];
+  const r = groupFavoritesForMenu(only);
+  assert.equal(r.folders.length, 0);
+  assert.equal(r.ungrouped.length, 1);
 });


### PR DESCRIPTION
## Summary

Follow-up to #36. The native **Favorites menubar menu** showed a flat, 20-item-capped list that ignored folders. It now mirrors the Favorites page:

- **Folder submenus first** (alphabetical, case-insensitive), each listing that folder's favorites **newest-first**.
- **Ungrouped favorites inline** after the folders (with a separator).
- **No cap** — submenus keep the menu navigable at any favorite count, so the old `>20` "Show All Favorites…" truncation link is removed ("Show Favorites" remains the page link).

## Implementation

- New pure `groupFavoritesForMenu(items) → { folders: [{ name, items }], ungrouped }` in `bookmark-data.js` (Electron-free, unit-tested). `main.js`'s `favoritesMenuItems()` maps it to Electron `submenu` items and wires the click handlers.
- No behavior change to the Favorites page, sync, or import.

## Testing

- **107/107 unit tests** (2 new for `groupFavoritesForMenu`: alphabetical + newest-first ordering, empty/all-ungrouped edge cases).
- **Live Playwright-Electron smoke**: seeded 3 folders + 1 ungrouped favorite, triggered a real menu rebuild, and asserted the actual `Menu.getApplicationMenu()` Favorites submenu — folder submenus alphabetical & first (`Bookmarks bar`→Example, `News`→Tech & Science, `Other bookmarks`→Plain), ungrouped `Loose` after them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)