### PR TITLE
Network privacy (M2+M3): WebRTC leak protection + encrypted DNS

### DIFF
--- a/.github/workflows/prerelease-smoke.yml
+++ b/.github/workflows/prerelease-smoke.yml
@@ -1,0 +1,39 @@
+name: Pre-release smoke
+
+# Launches the real app headlessly on Linux and Windows with BLANC_TEST=1 and asserts
+# it starts and app.configureHostResolver ran without throwing — the pre-release
+# cross-platform execution path for the network-privacy DoH config (see the M2+M3 plan).
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'src/main/**'
+      - 'test/desktop/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/prerelease-smoke.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: DNS launch smoke (Linux, headless)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run test:dns-smoke
+      - name: DNS launch smoke (Windows)
+        if: runner.os == 'Windows'
+        run: npm run test:dns-smoke

--- a/docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md
+++ b/docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md
@@ -1103,13 +1103,18 @@ const app = await _electron.launch({
 });
 
 // Resolve a host through the default session's Chromium resolver, which honors the
-// process-wide app.configureHostResolver config. true = resolved, false = failed.
-const canResolve = (host) => app.evaluate(async (h) => {
-  const { session } = require('electron');
+// process-wide app.configureHostResolver config. Playwright passes the Electron module
+// as the FIRST callback arg and the supplied value SECOND (so no require() needed).
+// true = resolved, false = failed.
+const canResolve = (host) => app.evaluate(async ({ session }, h) => {
   try { await session.defaultSession.resolveHost(h); return true; } catch { return false; }
 }, host);
-// Let the onSettingsChanged listener's configureHostResolver + async cache clear settle.
-const settle = () => new Promise((r) => setTimeout(r, 750));
+// After a DNS setting change, app.configureHostResolver has already run synchronously
+// inside the settings listener; await a cache clear (deterministic — not a fixed sleep)
+// so the next probe uses the new resolver.
+const clearDnsCache = () => app.evaluate(async ({ session }) => {
+  await session.defaultSession.clearHostResolverCache();
+});
 
 try {
   await app.firstWindow(); // startup didn't crash (a ready-handler throw would prevent this)
@@ -1119,12 +1124,12 @@ try {
 
   // Secure mode WORKS here without enableBuiltInResolver (the Linux question).
   await app.evaluate(() => globalThis.__blanc.setSecureDns('cloudflare'));
-  await settle();
+  await clearDnsCache();
   assert.ok(await canResolve('example.com'), 'Cloudflare secure DoH should resolve example.com');
 
   // Strict custom FAILS CLOSED — unreachable resolver, distinct host to dodge any cache.
   await app.evaluate(() => globalThis.__blanc.setSecureDns('custom', 'https://127.0.0.1:9/dns-query'));
-  await settle();
+  await clearDnsCache();
   assert.ok(!(await canResolve('cloudflare.com')), 'unreachable strict custom DoH must fail closed');
 
   console.log(`dns-smoke OK on ${process.platform}`);
@@ -1155,6 +1160,8 @@ on:
     paths:
       - 'src/main/**'
       - 'test/desktop/**'
+      - 'package.json'
+      - 'package-lock.json'
       - '.github/workflows/prerelease-smoke.yml'
 
 permissions:
@@ -1174,10 +1181,10 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - name: DNS/WebRTC launch smoke (Linux, headless)
+      - name: DNS launch smoke (Linux, headless)
         if: runner.os == 'Linux'
         run: xvfb-run -a npm run test:dns-smoke
-      - name: DNS/WebRTC launch smoke (Windows)
+      - name: DNS launch smoke (Windows)
         if: runner.os == 'Windows'
         run: npm run test:dns-smoke
 ```
@@ -1189,12 +1196,12 @@ Locally the smoke runs headed but still passes:
 ```bash
 npm run test:dns-smoke
 ```
-Expected: `dns-smoke OK on darwin: secureDns=auto webrtcPolicy=standard`, exit 0.
+Expected: `dns-smoke OK on darwin`, exit 0.
 
 ```bash
 git status --short   # expect test-hook.js, dns-smoke.mjs, prerelease-smoke.yml, package.json
 git add src/main/test-hook.js test/desktop/dns-smoke.mjs .github/workflows/prerelease-smoke.yml package.json
-git commit -m "Add pre-release DNS/WebRTC launch smoke (Linux + Windows CI)"
+git commit -m "Add pre-release DNS launch smoke (Linux + Windows CI)"
 ```
 
 - [ ] **Step 5: Push, run the workflow on both runners, and require green**
@@ -1224,6 +1231,8 @@ gh run watch "$RUN_ID" --repo "$REPO" --exit-status
 - [ ] **Step 1: Decide the Electron devDependency**
 
 Per CLAUDE.md, releasing is the moment to consider bumping `electron` (it tracks Chromium stable, which can't be swapped out of a running app). Check whether a newer 43.x/stable is available and worth taking. If bumping, do it as its own commit and re-run the full suite (the verified API facts in this plan are for 43.1.0 — re-verify `configureHostResolver`/`setWebRTCIPHandlingPolicy` still match if you move a major version). If not bumping, note that explicitly and proceed. Do not bump silently.
+
+**If you bump Electron, the Task 8 smoke must be re-validated on the new version.** The smoke (Task 8) runs before this step, so a later Electron bump would otherwise ship untested. The workflow's `push` paths now include `package.json`/`package-lock.json`, so pushing the bump commit re-triggers the smoke automatically — require it green again (re-run Task 8 Step 5) before release. Because a bump changes what the smoke validates, the cleanest option is to make the Electron decision *before* Task 8 whenever a bump is likely.
 
 - [ ] **Step 2: Harden `release.sh` to tag the exact built commit**
 
@@ -1285,9 +1294,9 @@ The release tags the remote HEAD, so every implementation commit from Tasks 1–
 git fetch origin
 git rev-list --count HEAD..origin/main   # if > 0, another session pushed — rebase onto origin/main, do NOT force-push
 git push origin main
-test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" && echo "PARITY OK" || echo "NOT IN SYNC — stop"
+if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ]; then echo "PARITY OK"; else echo "NOT IN SYNC — stop" >&2; exit 1; fi
 ```
-Expected: `PARITY OK`. The hardened `release.sh` (Step 2) will independently refuse to release if this doesn't hold — this step makes it pass rather than fail at release time.
+Expected: `PARITY OK` (the guard `exit 1`s on mismatch, so automation can't continue past a divergence). The hardened `release.sh` (Step 2) will independently refuse to release if this doesn't hold — this step makes it pass rather than fail at release time.
 
 - [ ] **Step 7: Confirm the cross-platform release prerequisites**
 

--- a/docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md
+++ b/docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md
@@ -1250,11 +1250,31 @@ if [ "$LOCAL_HEAD" != "$(git rev-parse origin/main)" ]; then
 fi
 ```
 
-Then change the release-create line (currently line 113) to bind the tag to that commit:
+Then change the release-create line (currently line 113) to bind the tag to that commit **and lead with an explicit privacy-boundary disclosure**. `--generate-notes` alone lists commit/PR titles, not the DoH boundary the spec requires in release notes (F25: destination IPs stay visible, provider choice is a trust decision, Automatic can fall back to plaintext). Compose notes = boundary paragraph + generated changelog, and pass them via `--notes-file` (do **not** combine `--notes*` with `--generate-notes` — gh ignores the generated notes when explicit notes are given, so generate them into the file first):
 
 ```bash
-gh release create "$TAG" "${ASSETS[@]}" --repo "$REPO" --title "$VERSION" --target "$LOCAL_HEAD" --generate-notes
+# Explicit privacy-boundary disclosure required by the F25 spec, prepended to the
+# auto-generated changelog. Written to a temp notes file passed as --notes-file.
+NOTES_FILE="$(mktemp)"
+{
+  echo "### Network privacy (v$VERSION)"
+  echo
+  echo "This release adds WebRTC leak protection and optional encrypted DNS (DoH)."
+  echo "Encrypted DNS hides your DNS lookups from the network *in transit* to the"
+  echo "resolver you choose — it does **not** hide the sites you visit (destination"
+  echo "IPs remain visible to your network), and choosing a provider is a trust"
+  echo "decision. Automatic mode upgrades opportunistically and can fall back to"
+  echo "unencrypted DNS; only the named-provider and custom positions are strict."
+  echo
+  echo "---"
+  echo
+  gh api "repos/$REPO/releases/generate-notes" -f tag_name="$TAG" -f target_commitish="$LOCAL_HEAD" --jq .body 2>/dev/null || true
+} > "$NOTES_FILE"
+gh release create "$TAG" "${ASSETS[@]}" --repo "$REPO" --title "$VERSION" --target "$LOCAL_HEAD" --notes-file "$NOTES_FILE"
+rm -f "$NOTES_FILE"
 ```
+
+(`gh api .../releases/generate-notes` returns the same changelog `--generate-notes` would, so the boundary text leads and the changelog follows; if that API call is unavailable the release still publishes with just the boundary disclosure, which is the spec-required part.)
 
 Then syntax-check the edited script before relying on it at release time (a slip here wouldn't surface until `npm run release`):
 

--- a/docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md
+++ b/docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md
@@ -1254,8 +1254,16 @@ Then change the release-create line (currently line 113) to bind the tag to that
 
 ```bash
 # Explicit privacy-boundary disclosure required by the F25 spec, prepended to the
-# auto-generated changelog. Written to a temp notes file passed as --notes-file.
+# auto-generated changelog. Fails CLOSED: if the changelog can't be generated we
+# abort BEFORE publishing an immutable release with incomplete notes.
 NOTES_FILE="$(mktemp)"
+trap 'rm -f "$NOTES_FILE"' EXIT
+# gh api returns the same changelog --generate-notes would. Require it to succeed
+# AND be non-empty — no `|| true`, so a transient API failure stops the release.
+if ! GENERATED="$(gh api "repos/$REPO/releases/generate-notes" -f tag_name="$TAG" -f target_commitish="$LOCAL_HEAD" --jq .body)" || [ -z "$GENERATED" ]; then
+  echo "Failed to generate the release changelog — aborting before publish." >&2
+  exit 1
+fi
 {
   echo "### Network privacy (v$VERSION)"
   echo
@@ -1268,13 +1276,12 @@ NOTES_FILE="$(mktemp)"
   echo
   echo "---"
   echo
-  gh api "repos/$REPO/releases/generate-notes" -f tag_name="$TAG" -f target_commitish="$LOCAL_HEAD" --jq .body 2>/dev/null || true
+  printf '%s\n' "$GENERATED"
 } > "$NOTES_FILE"
 gh release create "$TAG" "${ASSETS[@]}" --repo "$REPO" --title "$VERSION" --target "$LOCAL_HEAD" --notes-file "$NOTES_FILE"
-rm -f "$NOTES_FILE"
 ```
 
-(`gh api .../releases/generate-notes` returns the same changelog `--generate-notes` would, so the boundary text leads and the changelog follows; if that API call is unavailable the release still publishes with just the boundary disclosure, which is the spec-required part.)
+(The `trap ... EXIT` removes `NOTES_FILE` on any exit — success, the abort above, or a later failure. Note this assignment-in-`if` pattern catches the failure even under `set -e`, where a plain `X="$(failing-cmd)"` would not abort.)
 
 Then syntax-check the edited script before relying on it at release time (a slip here wouldn't surface until `npm run release`):
 

--- a/docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md
+++ b/docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md
@@ -839,31 +839,42 @@ In `src/renderer/pages/settings.js`, after the existing simple bindings (theme/s
     const secureDnsTemplate = document.getElementById('secureDnsTemplate');
     const secureDnsError = document.getElementById('secureDnsError');
 
-    // Reflect a persisted-settings snapshot back into the controls, and show the
-    // error only when the user asked for custom but the persisted provider is not
-    // custom (i.e. the main-process guard rejected an invalid template).
-    const applyState = (s, attempted) => {
+    // Reflect an ACCEPTED persisted snapshot into the controls (clears any error).
+    const showAccepted = (s) => {
       secureDns.value = s.secureDns ?? 'auto';
       secureDnsTemplate.value = s.secureDnsTemplate ?? '';
       secureDnsRow.hidden = secureDns.value !== 'custom';
-      const rejected = attempted === 'custom' && secureDns.value !== 'custom';
-      secureDnsError.hidden = !rejected;
-      secureDnsTemplate.setAttribute('aria-invalid', rejected ? 'true' : 'false');
+      secureDnsError.hidden = true;
+      secureDnsTemplate.setAttribute('aria-invalid', 'false');
     };
 
-    // Send the change and re-render from the ACTUAL persisted result (set() now
-    // returns the settings). No client-side DoH validation — the main process is
-    // the single validator, so the UI can never disagree with what was stored.
+    // The main process is the sole validator. Send the change, then render from the
+    // ACTUAL persisted result (set() returns the settings). If the user asked for
+    // custom but it wasn't stored, the guard rejected the template: keep their draft
+    // visible — dropdown on custom, row OPEN, typed text intact — and show the error.
+    // Do NOT snap back to the old provider (that would hide the row and the error and
+    // erase what they typed).
     const commit = async (partial, attempted) => {
       const next = await window.bowserPages.settings.set(partial);
-      applyState(next, attempted);
+      if (attempted === 'custom' && next.secureDns !== 'custom') {
+        secureDns.value = 'custom';
+        secureDnsRow.hidden = false;
+        secureDnsError.hidden = false;
+        secureDnsTemplate.setAttribute('aria-invalid', 'true');
+        return; // leaves secureDnsTemplate.value (the rejected text) untouched
+      }
+      showAccepted(next);
     };
 
-    applyState(settings, null); // initial render from the get() payload
+    showAccepted(settings); // initial render from the get() payload
 
     secureDns.addEventListener('change', () => {
       if (secureDns.value === 'custom') {
-        commit({ secureDns: 'custom', secureDnsTemplate: secureDnsTemplate.value.trim() }, 'custom');
+        secureDnsRow.hidden = false; // reveal the field so they can type
+        secureDnsError.hidden = true; // don't error before they've entered anything
+        const t = secureDnsTemplate.value.trim();
+        if (t) commit({ secureDns: 'custom', secureDnsTemplate: t }, 'custom');
+        // else: wait for the template's own change event to commit + validate
       } else {
         commit({ secureDns: secureDns.value }, secureDns.value);
       }
@@ -1048,8 +1059,9 @@ git commit -m "Add WebRTC + encrypted-DNS sections to the security page"
 ### Task 8: Pre-release cross-platform launch smoke (Linux execution path)
 
 **Files:**
-- Modify: `src/main/test-hook.js` (add `secureDns` / `webrtcPolicy` readers to `globalThis.__blanc`)
-- Create: `test/desktop/dns-smoke.mjs` (standalone Playwright-Electron smoke)
+- Modify: `src/main/test-hook.js` (add `secureDns`/`secureDnsTemplate`/`webrtcPolicy` readers + `setSecureDns` to `globalThis.__blanc`)
+- Create: `test/desktop/dns-smoke.mjs` (standalone Playwright-Electron smoke, isolated profile)
+- Modify: `package.json` (`scripts.test:dns-smoke`)
 - Create: `.github/workflows/prerelease-smoke.yml` (windows-latest + ubuntu-latest)
 
 **Interfaces:**
@@ -1059,46 +1071,72 @@ git commit -m "Add WebRTC + encrypted-DNS sections to the security page"
 
 - [ ] **Step 1: Expose the network-privacy settings on the test hook**
 
-In `src/main/test-hook.js`, in the `globalThis.__blanc = { ... }` object (near the other settings readers like `adblockEnabled()` at line 141), add:
+In `src/main/test-hook.js`, in the `globalThis.__blanc = { ... }` object (near the other settings readers like `adblockEnabled()` at line 141), add readers plus a setter so the smoke can drive live DoH transitions (which fire the Task 4 `onSettingsChanged` listener → `app.configureHostResolver` + cache clear):
 
 ```js
     secureDns() { return settings.getSettings().secureDns; },
     secureDnsTemplate() { return settings.getSettings().secureDnsTemplate; },
     webrtcPolicy() { return settings.getSettings().webrtcPolicy; },
+    setSecureDns(dns, template = '') { settings.setSettings({ secureDns: dns, secureDnsTemplate: template }); },
 ```
 
 - [ ] **Step 2: Write the smoke script**
 
-Create `test/desktop/dns-smoke.mjs` (models the harness's `_electron.launch` + `BLANC_TEST=1` from `test/desktop/support/hooks.js`):
+Create `test/desktop/dns-smoke.mjs`. It (a) launches in an **isolated throwaway profile** (`mkdtempSync` + `--user-data-dir`, like `test/desktop/support/hooks.js:21`) so it never reads the developer's real settings, and (b) actually exercises DoH via `session.resolveHost()` — proving secure mode *works* on this platform (the core Linux question) and that a strict unreachable resolver *fails closed*, not just that a default value is stored:
 
 ```js
-// Headless launch smoke: proves the app starts and app.configureHostResolver ran
-// without throwing on this platform, and that the network-privacy defaults are live.
-// Run by .github/workflows/prerelease-smoke.yml on windows-latest + ubuntu-latest.
+// Cross-platform DoH launch smoke. Proves: the app starts (no configureHostResolver
+// throw), defaults are live, Cloudflare secure DoH resolves, and an unreachable strict
+// custom resolver fails closed (no plaintext fallback). Isolated profile — never reads
+// the developer's real settings. Run by .github/workflows/prerelease-smoke.yml.
 import { _electron } from 'playwright';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-dns-smoke-'));
 const app = await _electron.launch({
-  args: [path.resolve('.')],
+  args: [path.resolve('.'), `--user-data-dir=${userDataDir}`],
   env: { ...process.env, BLANC_TEST: '1' },
 });
+
+// Resolve a host through the default session's Chromium resolver, which honors the
+// process-wide app.configureHostResolver config. true = resolved, false = failed.
+const canResolve = (host) => app.evaluate(async (h) => {
+  const { session } = require('electron');
+  try { await session.defaultSession.resolveHost(h); return true; } catch { return false; }
+}, host);
+// Let the onSettingsChanged listener's configureHostResolver + async cache clear settle.
+const settle = () => new Promise((r) => setTimeout(r, 750));
+
 try {
-  // Wait for the main window (proves startup didn't crash — a configureHostResolver
-  // throw in the ready handler would prevent this).
-  await app.firstWindow();
-  const dns = await app.evaluate(() => globalThis.__blanc.secureDns());
-  const webrtc = await app.evaluate(() => globalThis.__blanc.webrtcPolicy());
-  assert.equal(dns, 'auto', `expected default secureDns=auto, got ${dns}`);
-  assert.equal(webrtc, 'standard', `expected default webrtcPolicy=standard, got ${webrtc}`);
-  console.log(`dns-smoke OK on ${process.platform}: secureDns=${dns} webrtcPolicy=${webrtc}`);
+  await app.firstWindow(); // startup didn't crash (a ready-handler throw would prevent this)
+
+  assert.equal(await app.evaluate(() => globalThis.__blanc.secureDns()), 'auto', 'default secureDns should be auto');
+  assert.equal(await app.evaluate(() => globalThis.__blanc.webrtcPolicy()), 'standard', 'default webrtcPolicy should be standard');
+
+  // Secure mode WORKS here without enableBuiltInResolver (the Linux question).
+  await app.evaluate(() => globalThis.__blanc.setSecureDns('cloudflare'));
+  await settle();
+  assert.ok(await canResolve('example.com'), 'Cloudflare secure DoH should resolve example.com');
+
+  // Strict custom FAILS CLOSED — unreachable resolver, distinct host to dodge any cache.
+  await app.evaluate(() => globalThis.__blanc.setSecureDns('custom', 'https://127.0.0.1:9/dns-query'));
+  await settle();
+  assert.ok(!(await canResolve('cloudflare.com')), 'unreachable strict custom DoH must fail closed');
+
+  console.log(`dns-smoke OK on ${process.platform}`);
 } finally {
   await app.close();
+  fs.rmSync(userDataDir, { recursive: true, force: true });
 }
 ```
 
 Add an npm script to `package.json` (`scripts`): `"test:dns-smoke": "node test/desktop/dns-smoke.mjs"`.
+
+Note: the positive Cloudflare assertion needs outbound HTTPS to `cloudflare-dns.com` (GitHub runners have it). If it proves flaky in a restricted network, gate it on reachability rather than deleting it — the fail-closed assertion (which needs no network) is the one that must never be dropped.
 
 - [ ] **Step 3: Add the CI workflow**
 
@@ -1112,7 +1150,8 @@ name: Pre-release smoke
 # cross-platform execution path for the network-privacy DoH config (see the M2+M3 plan).
 on:
   workflow_dispatch:
-  pull_request:
+  push:
+    branches: [main]
     paths:
       - 'src/main/**'
       - 'test/desktop/**'
@@ -1158,15 +1197,26 @@ git add src/main/test-hook.js test/desktop/dns-smoke.mjs .github/workflows/prere
 git commit -m "Add pre-release DNS/WebRTC launch smoke (Linux + Windows CI)"
 ```
 
-- [ ] **Step 5: Confirm the workflow runs green on both runners**
+- [ ] **Step 5: Push, run the workflow on both runners, and require green**
 
-Because `workflow_dispatch` only works once the workflow file is on the default branch (same constraint as `release-windows-linux.yml`, per CLAUDE.md), the first run happens via the `pull_request` trigger (the commit touches `src/main/**` and the workflow file) or after this lands on `main`. Confirm both the `ubuntu-latest` and `windows-latest` jobs pass before treating Task 4's Linux path as satisfied. A red smoke blocks the release (Task 9 Step 5).
+This checkout commits directly to `main` (no PRs), so the workflow can only run once it's on the default branch — `workflow_dispatch` and the `push`-to-`main` trigger both require that (same constraint as `release-windows-linux.yml`, per CLAUDE.md). Push, then dispatch and watch explicitly:
+
+```bash
+git push origin main   # lands the workflow (the push-on-paths trigger also fires a run)
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+gh workflow run prerelease-smoke.yml --repo "$REPO"
+sleep 6
+RUN_ID=$(gh run list --repo "$REPO" --workflow=prerelease-smoke.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID" --repo "$REPO" --exit-status
+```
+`--exit-status` makes `gh run watch` return non-zero if either matrix job fails. **Both** `ubuntu-latest` and `windows-latest` must pass before Task 9's release. If the Linux job fails on the *Cloudflare-resolves* assertion, secure DoH needs `enableBuiltInResolver` on Linux — apply the Task 4 Step 4 testing-gated change, commit, and re-run. If it fails on *fail-closed*, the strict wiring is wrong — fix before proceeding. A red smoke blocks the release (Task 9 Step 7).
 
 ---
 
 ### Task 9: Version bump, full verification, and release (user-gated)
 
 **Files:**
+- Modify: `scripts/release.sh` (require `HEAD == origin/main`; bind the tag to the built commit)
 - Modify: `package.json` **and** `package-lock.json` (`version` 0.16.0 → 0.17.0 in both — the lockfile records it at its top level and at `packages[""]`)
 
 **Interfaces:** none. This task cuts a real public release — its final step is gated on explicit user go-ahead, like M1's deploy.
@@ -1175,7 +1225,29 @@ Because `workflow_dispatch` only works once the workflow file is on the default 
 
 Per CLAUDE.md, releasing is the moment to consider bumping `electron` (it tracks Chromium stable, which can't be swapped out of a running app). Check whether a newer 43.x/stable is available and worth taking. If bumping, do it as its own commit and re-run the full suite (the verified API facts in this plan are for 43.1.0 — re-verify `configureHostResolver`/`setWebRTCIPHandlingPolicy` still match if you move a major version). If not bumping, note that explicitly and proceed. Do not bump silently.
 
-- [ ] **Step 2: Bump the app version (both manifest files)**
+- [ ] **Step 2: Harden `release.sh` to tag the exact built commit**
+
+`gh release create <tag>` creates a *missing* tag from the **remote** default-branch HEAD, not local `HEAD` — so an unpushed local release commit would build macOS assets from new code while the tag (and the Windows/Linux CI that checks it out) uses older remote code. Close this in `scripts/release.sh`. After the dirty-source check (the `Release sources are dirty` block ending ~line 57), add:
+
+```bash
+# The tag must point at exactly the commit we build. gh release create makes a
+# missing tag from the REMOTE default-branch HEAD, so require local HEAD to be
+# pushed and bind the tag to it explicitly (see --target below).
+git fetch origin --quiet
+LOCAL_HEAD="$(git rev-parse HEAD)"
+if [ "$LOCAL_HEAD" != "$(git rev-parse origin/main)" ]; then
+  echo "HEAD is not on origin/main. Push the release commit first: git push origin main" >&2
+  exit 1
+fi
+```
+
+Then change the release-create line (currently line 113) to bind the tag to that commit:
+
+```bash
+gh release create "$TAG" "${ASSETS[@]}" --repo "$REPO" --title "$VERSION" --target "$LOCAL_HEAD" --generate-notes
+```
+
+- [ ] **Step 3: Bump the app version (both manifest files)**
 
 Use npm so `package.json` and `package-lock.json` are updated together (a hand-edit of `package.json` alone leaves the lockfile at 0.16.0, and `release.sh` treats both as release-source metadata):
 
@@ -1188,7 +1260,7 @@ Expected: prints `v0.17.0`; `git status --short` now shows both `package.json` a
 grep -c '"version": "0.17.0"' package-lock.json   # expect >= 2 (top-level + packages[""])
 ```
 
-- [ ] **Step 3: Full pre-release verification**
+- [ ] **Step 4: Full pre-release verification**
 
 ```bash
 npm run test:unit
@@ -1197,45 +1269,60 @@ npm run test:acceptance:dry
 ```
 Expected: all three exit 0. If any fails, stop and fix before releasing.
 
-Also confirm the **cross-platform release prerequisites** are met (these gate the release, not just the bump):
-- macOS DoH verification (Task 4 Step 4) done on this machine.
-- Windows DoH verification (Task 4 Step 4) done on Parallels/hardware.
-- The Task 8 pre-release smoke is **green on both `ubuntu-latest` and `windows-latest`**.
-
-If any is missing, do not release — complete it first (or, for a red smoke, fix the regression it caught).
-
-- [ ] **Step 4: Commit the bump**
+- [ ] **Step 5: Commit the release-source changes**
 
 ```bash
-git status --short   # expect package.json AND package-lock.json
-git add package.json package-lock.json
+git status --short   # expect scripts/release.sh, package.json, package-lock.json
+git add scripts/release.sh package.json package-lock.json
 git commit -m "Release v0.17.0: WebRTC leak protection + encrypted DNS"
 ```
 
-- [ ] **Step 5: Ask the user for the release go-ahead**
+- [ ] **Step 6: Push and verify remote parity (release-critical)**
 
-`npm run release` builds, signs, notarizes, publishes a GitHub release, and dispatches the Windows/Linux CI — a public, irreversible, immutable release. Confirm with the user before running it. Do not proceed on silence. If the user defers, still run the tag cleanup in Step 8 and stop.
+The release tags the remote HEAD, so every implementation commit from Tasks 1–8 **and** this bump must be on `origin/main` before releasing. Re-fetch first (shared checkout), reconcile if another session pushed, then push and confirm parity:
 
-- [ ] **Step 6: Cut the release (only after go-ahead)**
+```bash
+git fetch origin
+git rev-list --count HEAD..origin/main   # if > 0, another session pushed — rebase onto origin/main, do NOT force-push
+git push origin main
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" && echo "PARITY OK" || echo "NOT IN SYNC — stop"
+```
+Expected: `PARITY OK`. The hardened `release.sh` (Step 2) will independently refuse to release if this doesn't hold — this step makes it pass rather than fail at release time.
+
+- [ ] **Step 7: Confirm the cross-platform release prerequisites**
+
+These gate the release (not just the bump):
+- macOS DoH verification (Task 4 Step 4) done on this machine.
+- Windows DoH verification (Task 4 Step 4) done on Parallels/hardware.
+- The Task 8 pre-release smoke is **green on both `ubuntu-latest` and `windows-latest`** (see Task 8 Step 5).
+
+If any is missing, do not release — complete it first (or, for a red smoke, fix the regression it caught).
+
+- [ ] **Step 8: Ask the user for the release go-ahead**
+
+`npm run release` builds, signs, notarizes, publishes a GitHub release, and dispatches the Windows/Linux CI — a public, irreversible, immutable release. Confirm with the user before running it. Do not proceed on silence. If the user defers, still run the tag cleanup in Step 11 and stop.
+
+- [ ] **Step 9: Cut the release (only after go-ahead)**
 
 ```bash
 npm run release
 ```
-Expected: `scripts/release.sh` runs clean (dirty-tree refusal won't trigger — all work is committed), builds the signed+notarized macOS artifacts, creates the GitHub release, and dispatches `release-windows-linux.yml`. Watch it to completion.
+Expected: `scripts/release.sh` runs clean (dirty-tree and HEAD-parity guards both pass — all work is committed and pushed), builds the signed+notarized macOS artifacts, creates the GitHub release bound to the pushed commit, and dispatches `release-windows-linux.yml`. Watch it to completion.
 
-- [ ] **Step 7: Sync and deploy the site (security-page sections + regenerated changelog)**
+- [ ] **Step 10: Sync and deploy the site (security-page sections + regenerated changelog)**
 
-`release.sh` seds the site version metadata and regenerates the changelog. Commit those, then deploy the site (which now carries the Task 7 security-page sections):
+`release.sh` seds the site version metadata and regenerates the changelog. Commit + push those, then deploy the site (which now carries the Task 7 security-page sections):
 
 ```bash
 git status --short
 git add site/index.html site/sitemap.xml site/changelog.html site/changelog.xml
 git commit -m "Sync site changelog + version metadata for v0.17.0"
+git push origin main
 npx wrangler pages deploy site --project-name=blancbrowser
 ```
 Verify live (cache-busted): `curl -s "https://blancbrowser.com/features/security?cb=$RANDOM" | grep -c "on the network"` → ≥1.
 
-- [ ] **Step 8: Remove the base tag**
+- [ ] **Step 11: Remove the base tag**
 
 ```bash
 git tag -d m2m3-base
@@ -1249,8 +1336,9 @@ git tag -d m2m3-base
 - **Electron API (verified against `electron.d.ts`):** `app.configureHostResolver` is process-wide (App method, line 1044), called once after `ready`; `clearHostResolverCache` is per-Session (line 12902) and its promises are collected with `Promise.allSettled`. `enableBuiltInResolver` is deliberately NOT forced (it would break the Off/system-resolver contract on Win/Linux) — its addition is a testing-gated, per-mode decision in Task 4 Step 4.
 - **Strict DNS never falls back:** enforced in the settings layer (setSettings reject + getSettings coerce, Task 2 Step 2), so `hostResolverOptionsFor`'s `custom` branch is unconditionally strict-secure — verified by unit test (Task 1) and manual test (Task 5 Step 3).
 - **Capability guards:** both new controls are wrapped in `supports(...)` with `.remove()` fallbacks (Task 5 Step 2), matching `homePage`/`appIcon`, so D17/D18's "no iOS controls" holds by construction.
-- **Lockfile:** the version bump uses `npm version --no-git-tag-version` and stages `package.json` + `package-lock.json` together (Task 9 Steps 2, 4).
-- **Cross-platform verification is achievable, not hand-waved:** macOS (dev machine) + Windows (Parallels/hardware) manual DoH checks, Linux via the Task 8 launch smoke on `ubuntu-latest` + a CI-AppImage spot-check — all release prerequisites (Task 9 Step 5).
+- **Lockfile:** the version bump uses `npm version --no-git-tag-version` and stages `package.json` + `package-lock.json` together (Task 9 Steps 3, 5).
+- **Cross-platform verification is achievable, not hand-waved:** macOS (dev machine) + Windows (Parallels/hardware) manual DoH checks, Linux via the Task 8 launch smoke on `ubuntu-latest` + a CI-AppImage spot-check — all release prerequisites (Task 9 Step 7). The smoke tests real DoH **behavior** (isolated profile; Cloudflare secure-resolves + unreachable-custom fails-closed via `session.resolveHost`), not just a stored default.
+- **Release tags the built commit:** `release.sh` is hardened to require `HEAD == origin/main` and pass `--target "$LOCAL_HEAD"` to `gh release create` (Task 9 Step 2), and the plan pushes + verifies parity before releasing (Task 9 Step 6) — so macOS assets, the tag, and the Windows/Linux CI can never diverge in source.
 - **Validator hardened:** `isValidDohTemplate` rejects unmatched raw braces (Task 1), and the strict-custom state machine (`reconcileSecureDnsWrite`/`coerceSecureDnsRead`) is unit-tested for valid/invalid/atomic/clearing/corrupted cases (Task 1); the renderer holds no duplicate validator — it round-trips through the main process (Task 5).
 - **Honesty rules** are enforced with a strengthened grep gate (Task 7 Step 3, now catching "closes a … leak") and baked into every label/copy string; "strict" is only an internal enum id, never a user-facing word; the WebRTC claim is "reduces one proxy-bypass risk", never "closes the leak".
 - **Type/name consistency:** `webrtcPolicyFor`, `hostResolverOptionsFor`, `isValidDohTemplate`, `applyWebrtcPolicyToAllTabs`, `lastSecureDns`/`lastSecureDnsTemplate`, and the setting keys `webrtcPolicy`/`secureDns`/`secureDnsTemplate` are used identically across Tasks 1–5.

--- a/docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md
+++ b/docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md
@@ -1256,6 +1256,13 @@ Then change the release-create line (currently line 113) to bind the tag to that
 gh release create "$TAG" "${ASSETS[@]}" --repo "$REPO" --title "$VERSION" --target "$LOCAL_HEAD" --generate-notes
 ```
 
+Then syntax-check the edited script before relying on it at release time (a slip here wouldn't surface until `npm run release`):
+
+```bash
+bash -n scripts/release.sh && echo "release.sh syntax OK"
+```
+Expected: `release.sh syntax OK`, exit 0.
+
 - [ ] **Step 3: Bump the app version (both manifest files)**
 
 Use npm so `package.json` and `package-lock.json` are updated together (a hand-edit of `package.json` alone leaves the lockfile at 0.16.0, and `release.sh` treats both as release-source metadata):

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:oauth:live": "node scripts/oauth-canary.js",
     "test:acceptance:dry": "cucumber-js -c test/desktop/cucumber.mjs -p dry",
     "test:acceptance:desktop": "cucumber-js -c test/desktop/cucumber.mjs -p runnable",
+    "test:dns-smoke": "node test/desktop/dns-smoke.mjs",
     "adblock:build": "node adblock/build.mjs",
     "adblock:check": "node adblock/build.mjs --check",
     "tokens:build": "node tokens/build.mjs",

--- a/settings-schema/build.mjs
+++ b/settings-schema/build.mjs
@@ -37,6 +37,12 @@ function genSwift() {
   out += 'public enum BlancThemePreference: String, CaseIterable {\n';
   for (const t of spec.themes) out += `    case ${swiftCase(t)}\n`;
   out += '}\n\n';
+  out += 'public enum BlancWebrtcPolicy: String, CaseIterable {\n';
+  for (const v of spec.webrtcPolicies) out += `    case ${swiftCase(v)}\n`;
+  out += '}\n\n';
+  out += 'public enum BlancSecureDns: String, CaseIterable {\n';
+  for (const v of spec.secureDnsOptions) out += `    case ${swiftCase(v)}\n`;
+  out += '}\n\n';
   out += 'public enum BlancAppIcon: String, CaseIterable {\n';
   for (const i of icons) out += `    case ${swiftCase(i.id)}\n`;
   out += '    public var label: String {\n        switch self {\n';
@@ -50,6 +56,9 @@ function genSwift() {
   out += `    public static let adblockEnabled: Bool = ${spec.defaults.adblockEnabled}\n`;
   out += `    public static let homePage: String = ${JSON.stringify(spec.defaults.homePage)}\n`;
   out += `    public static let theme: BlancThemePreference = .${swiftCase(spec.defaults.theme)}\n`;
+  out += `    public static let webrtcPolicy: BlancWebrtcPolicy = .${swiftCase(spec.defaults.webrtcPolicy)}\n`;
+  out += `    public static let secureDns: BlancSecureDns = .${swiftCase(spec.defaults.secureDns)}\n`;
+  out += `    public static let secureDnsTemplate: String = ${JSON.stringify(spec.defaults.secureDnsTemplate)}\n`;
   out += `    public static let appIcon: BlancAppIcon = .${swiftCase(spec.defaults.appIcon)}\n`;
   out += `    public static let usagePing: Bool = ${spec.defaults.usagePing}\n`;
   out += '    // adblockExceptions defaults to []; supporter defaults to nil (structural).\n}\n';
@@ -65,6 +74,10 @@ function genKotlin() {
   out += spec.searchEngines.map((e) => `    ${upper(e.id)}("${e.id}", ${JSON.stringify(e.label)})`).join(',\n') + ';\n}\n\n';
   out += 'enum class BlancThemePreference(val id: String) {\n';
   out += spec.themes.map((t) => `    ${upper(t)}("${t}")`).join(',\n') + ';\n}\n\n';
+  out += 'enum class BlancWebrtcPolicy(val id: String) {\n';
+  out += spec.webrtcPolicies.map((v) => `    ${upper(v)}("${v}")`).join(',\n') + ';\n}\n\n';
+  out += 'enum class BlancSecureDns(val id: String) {\n';
+  out += spec.secureDnsOptions.map((v) => `    ${upper(v)}("${v}")`).join(',\n') + ';\n}\n\n';
   out += 'enum class BlancAppIcon(val id: String, val label: String, val isSupporterOnly: Boolean) {\n';
   out += icons.map((i) => `    ${upper(i.id)}("${i.id}", ${JSON.stringify(i.label)}, ${i.sup})`).join(',\n') + ';\n}\n\n';
   out += 'object BlancSettingsDefaults {\n';
@@ -72,6 +85,9 @@ function genKotlin() {
   out += `    const val adblockEnabled = ${spec.defaults.adblockEnabled}\n`;
   out += `    const val homePage = ${JSON.stringify(spec.defaults.homePage)}\n`;
   out += `    val theme = BlancThemePreference.${upper(spec.defaults.theme)}\n`;
+  out += `    val webrtcPolicy = BlancWebrtcPolicy.${upper(spec.defaults.webrtcPolicy)}\n`;
+  out += `    val secureDns = BlancSecureDns.${upper(spec.defaults.secureDns)}\n`;
+  out += `    const val secureDnsTemplate = ${JSON.stringify(spec.defaults.secureDnsTemplate)}\n`;
   out += `    val appIcon = BlancAppIcon.${upper(spec.defaults.appIcon)}\n`;
   out += `    const val usagePing = ${spec.defaults.usagePing}\n`;
   out += '    // adblockExceptions defaults to emptyList(); supporter defaults to null (structural).\n}\n';
@@ -95,6 +111,10 @@ function parseSettingsJs() {
   // contain //) so a commented-out entry like `// 'dark'` isn't read as live.
   const themesBlock = (js.match(/const THEMES = \[([^\]]*)\]/)?.[1] ?? '').replace(/\/\/.*$/gm, '');
   const themes = [...themesBlock.matchAll(/'([^']+)'/g)].map((m) => m[1]);
+  const webrtcBlock = (js.match(/const WEBRTC_POLICIES = \[([^\]]*)\]/)?.[1] ?? '').replace(/\/\/.*$/gm, '');
+  const webrtcPolicies = [...webrtcBlock.matchAll(/'([^']+)'/g)].map((m) => m[1]);
+  const secureDnsBlock = (js.match(/const SECURE_DNS_OPTIONS = \[([^\]]*)\]/)?.[1] ?? '').replace(/\/\/.*$/gm, '');
+  const secureDnsOptions = [...secureDnsBlock.matchAll(/'([^']+)'/g)].map((m) => m[1]);
   const appIcons = pairs(js.match(/const APP_ICON_LABELS = \{([\s\S]*?)\}/)?.[1]);
   const supporterIcons = pairs(js.match(/const SUPPORTER_ICON_LABELS = \{([\s\S]*?)\}/)?.[1]);
   const D = js.match(/const DEFAULTS = \{([\s\S]*?)\n\};/)?.[1] ?? '';
@@ -104,6 +124,9 @@ function parseSettingsJs() {
     adblockEnabled: s(/^\s*adblockEnabled:\s*(true|false)/m),
     homePage: s(/^\s*homePage:\s*'([^']*)'/m),
     theme: s(/^\s*theme:\s*'([^']*)'/m),
+    webrtcPolicy: s(/^\s*webrtcPolicy:\s*'([^']*)'/m),
+    secureDns: s(/^\s*secureDns:\s*'([^']*)'/m),
+    secureDnsTemplate: s(/^\s*secureDnsTemplate:\s*'([^']*)'/m),
     appIcon: s(/^\s*appIcon:\s*'([^']*)'/m),
     usagePing: s(/^\s*usagePing:\s*(true|false)/m),
     adblockExceptionsEmpty: /^\s*adblockExceptions:\s*\[\]/m.test(D),
@@ -112,7 +135,7 @@ function parseSettingsJs() {
   // Every key literally declared in DEFAULTS (line-anchored, so // comments are
   // excluded) — used to catch keys the schema doesn't know about.
   const defaultKeys = [...D.matchAll(/^\s*(\w+):/gm)].map((m) => m[1]);
-  return { engines, themes, appIcons, supporterIcons, defaults, defaultKeys };
+  return { engines, themes, webrtcPolicies, secureDnsOptions, appIcons, supporterIcons, defaults, defaultKeys };
 }
 
 function check() {
@@ -123,6 +146,8 @@ function check() {
 
   cmp('searchEngines', js.engines, spec.searchEngines);
   cmp('themes', js.themes, spec.themes);
+  cmp('webrtcPolicies', js.webrtcPolicies, spec.webrtcPolicies);
+  cmp('secureDnsOptions', js.secureDnsOptions, spec.secureDnsOptions);
   cmp('appIcons', js.appIcons, spec.appIcons);
   cmp('supporterIcons', js.supporterIcons, spec.supporterIcons);
 
@@ -144,6 +169,9 @@ function check() {
   eq('adblockEnabled', jd.adblockEnabled, String(d.adblockEnabled));
   eq('homePage', jd.homePage, d.homePage);
   eq('theme', jd.theme, d.theme);
+  eq('webrtcPolicy', jd.webrtcPolicy, d.webrtcPolicy);
+  eq('secureDns', jd.secureDns, d.secureDns);
+  eq('secureDnsTemplate', jd.secureDnsTemplate, d.secureDnsTemplate);
   eq('appIcon', jd.appIcon, d.appIcon);
   eq('usagePing', jd.usagePing, String(d.usagePing));
   if (!jd.adblockExceptionsEmpty) problems.push('defaults.adblockExceptions: settings.js is not []');

--- a/settings-schema/generated/BlancSettings.kt
+++ b/settings-schema/generated/BlancSettings.kt
@@ -16,6 +16,20 @@ enum class BlancThemePreference(val id: String) {
     DARK("dark");
 }
 
+enum class BlancWebrtcPolicy(val id: String) {
+    STANDARD("standard"),
+    STRICT("strict");
+}
+
+enum class BlancSecureDns(val id: String) {
+    AUTO("auto"),
+    OFF("off"),
+    CLOUDFLARE("cloudflare"),
+    QUAD9("quad9"),
+    MULLVAD("mullvad"),
+    CUSTOM("custom");
+}
+
 enum class BlancAppIcon(val id: String, val label: String, val isSupporterOnly: Boolean) {
     PAPER("paper", "Paper", false),
     INK("ink", "Ink", false),
@@ -35,6 +49,9 @@ object BlancSettingsDefaults {
     const val adblockEnabled = true
     const val homePage = ""
     val theme = BlancThemePreference.SYSTEM
+    val webrtcPolicy = BlancWebrtcPolicy.STANDARD
+    val secureDns = BlancSecureDns.AUTO
+    const val secureDnsTemplate = ""
     val appIcon = BlancAppIcon.PAPER
     const val usagePing = true
     // adblockExceptions defaults to emptyList(); supporter defaults to null (structural).

--- a/settings-schema/generated/BlancSettings.swift
+++ b/settings-schema/generated/BlancSettings.swift
@@ -24,6 +24,20 @@ public enum BlancThemePreference: String, CaseIterable {
     case dark
 }
 
+public enum BlancWebrtcPolicy: String, CaseIterable {
+    case standard
+    case strict
+}
+
+public enum BlancSecureDns: String, CaseIterable {
+    case auto
+    case off
+    case cloudflare
+    case quad9
+    case mullvad
+    case custom
+}
+
 public enum BlancAppIcon: String, CaseIterable {
     case paper
     case ink
@@ -64,6 +78,9 @@ public struct BlancSettingsDefaults {
     public static let adblockEnabled: Bool = true
     public static let homePage: String = ""
     public static let theme: BlancThemePreference = .system
+    public static let webrtcPolicy: BlancWebrtcPolicy = .standard
+    public static let secureDns: BlancSecureDns = .auto
+    public static let secureDnsTemplate: String = ""
     public static let appIcon: BlancAppIcon = .paper
     public static let usagePing: Bool = true
     // adblockExceptions defaults to []; supporter defaults to nil (structural).

--- a/settings-schema/schema.json
+++ b/settings-schema/schema.json
@@ -8,6 +8,8 @@
     { "id": "brave", "label": "Brave Search" }
   ],
   "themes": ["system", "light", "dark"],
+  "webrtcPolicies": ["standard", "strict"],
+  "secureDnsOptions": ["auto", "off", "cloudflare", "quad9", "mullvad", "custom"],
   "appIcons": [
     { "id": "paper", "label": "Paper" },
     { "id": "ink", "label": "Ink" },
@@ -30,6 +32,9 @@
     "theme": "system",
     "appIcon": "paper",
     "adblockExceptions": [],
+    "webrtcPolicy": "standard",
+    "secureDns": "auto",
+    "secureDnsTemplate": "",
     "usagePing": true,
     "supporter": null
   },
@@ -40,6 +45,9 @@
     { "key": "adblockEnabled", "type": "boolean", "default": true },
     { "key": "homePage", "type": "string", "default": "", "note": "trimmed on write; empty = blanc://newtab" },
     { "key": "theme", "type": "enum", "enum": "themes", "default": "system", "note": "drives nativeTheme.themeSource" },
+    { "key": "webrtcPolicy", "type": "enum", "enum": "webrtcPolicies", "default": "standard", "note": "maps to webContents.setWebRTCIPHandlingPolicy; strict = disable_non_proxied_udp" },
+    { "key": "secureDns", "type": "enum", "enum": "secureDnsOptions", "default": "auto", "note": "app.configureHostResolver secureDnsMode; strict positions hard-fail" },
+    { "key": "secureDnsTemplate", "type": "string", "default": "", "note": "custom DoH RFC8484 template; validated raw (not URL-normalized)" },
     { "key": "appIcon", "type": "enum", "enum": "appIcons+supporterIcons", "default": "paper", "note": "supporter ids allowed only when supporter active; sanitize-on-read == validate-on-write" },
     { "key": "adblockExceptions", "type": "string[]", "default": [], "normalize": "trim, lowercase, strip leading www., dedupe" },
     { "key": "usagePing", "type": "boolean", "default": true },

--- a/site/features/security.html
+++ b/site/features/security.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Blanc Browser Security — Private by Architecture</title>
-<meta name="description" content="How Blanc is built for privacy: sandboxed pages, network-level ad and tracker blocking, no extension runtime, encrypted sync, and a usage ping you can switch off.">
+<meta name="description" content="How Blanc is built for privacy: sandboxed pages, network-level ad and tracker blocking, no extension runtime, encrypted sync, WebRTC leak protection, optional encrypted DNS, and a usage ping you can switch off.">
 <meta name="robots" content="index,follow,max-image-preview:large">
 <meta name="theme-color" content="#ffffff">
 <meta name="application-name" content="Blanc Browser">
@@ -68,6 +68,13 @@
       <article><h3>Passkeys live in the Secure Enclave.</h3><p>On a Mac with Touch ID, Blanc creates device-bound passkeys inside Apple&rsquo;s Secure Enclave. The private key never leaves the chip, and Blanc is signed with an Apple-issued Developer ID and provisioned to hold its own keychain access group. macOS only for now.</p></article>
       <article><h3>Permissions ask first.</h3><p>Camera, microphone, location, notifications — each request raises a Blanc prompt, and each decision is remembered for that site. Decisions made in a private tab are never written to disk.</p></article>
       <article><h3>A ping per launch, and you can turn it off.</h3><p>When the packaged app launches, it sends a small pseudonymous usage ping; the <a href="../privacy.html">privacy policy</a> lists every field. None of them include browsing data, and the random install ID identifies the installation, not you. Settings turns it off with one switch.</p></article>
+    </div>
+  </section>
+  <section class="feature-copy-grid" aria-labelledby="security-network-title">
+    <div><p class="section-kicker">on the network</p><h2 id="security-network-title">Respecting the VPN you already chose.</h2></div>
+    <div class="feature-copy-list">
+      <article><h3>WebRTC stays in its lane.</h3><p>WebRTC can reveal network addresses that sidestep a proxy. Blanc limits it to your default connection by default, and an optional &ldquo;disable direct UDP&rdquo; mode blocks a specific direct-UDP path around an application proxy. It is not a promise of anonymity — it reduces one well-known proxy-bypass risk.</p></article>
+      <article><h3>DNS you can encrypt — or hand to your VPN.</h3><p>Blanc can send DNS lookups over an encrypted connection (DoH) to Cloudflare, Quad9, Mullvad, or a provider you name — or stay out of the way and leave DNS to your system or VPN. Encryption hides your lookups from the network in transit; it does not hide the sites themselves, and it makes the resolver a party you choose to trust. Automatic mode upgrades opportunistically and is not a guarantee.</p></article>
     </div>
   </section>
   <aside class="truth-note" aria-labelledby="security-note-title"><p class="section-kicker">good to know</p><h2 id="security-note-title">Private by architecture, not by magic.</h2><p>No browser can make you anonymous on its own. Blanc reduces what runs inside the browser and what leaves your device; it does not hide your traffic from your network, your employer, or your internet provider. If you use a VPN you trust, Blanc runs quietly underneath it.</p><a class="text-link" href="../privacy.html" data-track="feature_cta_click" data-feature="security" data-cta-position="truth-note">Read the full privacy policy <span aria-hidden="true">↗</span></a></aside>

--- a/site/index.html
+++ b/site/index.html
@@ -280,7 +280,7 @@
       </article>
       <article>
         <h3>Why is there no built-in VPN?</h3>
-        <p>Running a VPN means becoming a service business with your traffic in the middle — done honestly it takes audits, infrastructure, and a support organization; done halfway it is a proxy wearing a trench coat. Blanc&rsquo;s privacy work goes where the browser actually is: blocking at the network layer, sandboxing every page, and shipping no third-party extension runtime. If you already use a VPN you trust, Blanc runs under it like any other app on your device.</p>
+        <p>Running a VPN means becoming a service business with your traffic in the middle — done honestly it takes audits, infrastructure, and a support organization; done halfway it is a proxy wearing a trench coat. Blanc&rsquo;s privacy work goes where the browser actually is: blocking at the network layer, sandboxing every page, and shipping no third-party extension runtime. It can also keep WebRTC from opening direct paths that sidestep a proxy, and its encrypted-DNS setting can hand DNS to your system or VPN resolver instead of Blanc&rsquo;s own. If you already use a VPN you trust, Blanc runs under it like any other app on your device.</p>
       </article>
       <article>
         <h3>Which systems does Blanc support?</h3>

--- a/site/index.html
+++ b/site/index.html
@@ -280,7 +280,7 @@
       </article>
       <article>
         <h3>Why is there no built-in VPN?</h3>
-        <p>Running a VPN means becoming a service business with your traffic in the middle — done honestly it takes audits, infrastructure, and a support organization; done halfway it is a proxy wearing a trench coat. Blanc&rsquo;s privacy work goes where the browser actually is: blocking at the network layer, sandboxing every page, and shipping no third-party extension runtime. It can also keep WebRTC from opening direct paths that sidestep a proxy, and its encrypted-DNS setting can hand DNS to your system or VPN resolver instead of Blanc&rsquo;s own. If you already use a VPN you trust, Blanc runs under it like any other app on your device.</p>
+        <p>Running a VPN means becoming a service business with your traffic in the middle — done honestly it takes audits, infrastructure, and a support organization; done halfway it is a proxy wearing a trench coat. Blanc&rsquo;s privacy work goes where the browser actually is: blocking at the network layer, sandboxing every page, and shipping no third-party extension runtime. It can also stop WebRTC from opening direct UDP paths around an application proxy, and its encrypted-DNS setting can defer DNS to your system or VPN resolver instead of choosing a browser-level provider. If you already use a VPN you trust, Blanc runs under it like any other app on your device.</p>
       </article>
       <article>
         <h3>Which systems does Blanc support?</h3>

--- a/spec/divergence-register.md
+++ b/spec/divergence-register.md
@@ -358,3 +358,37 @@ ephemeral, and says so in the private-tab copy.
 opt-out; renderer-side blocking would be bypassable). Revisit if
 [electron/electron#52302](https://github.com/electron/electron/issues/52302)
 lands. Hardware acceptance: F4-6.
+
+## D17 — Encrypted DNS control (F25)
+**Features:** F25
+**Why:** In-app DoH control depends on the platform's network stack.
+
+- **Desktop:** full control via `app.configureHostResolver` (Electron 43,
+  process-wide, applied after `ready`).
+- **Android:** OS-level Private DNS (DoT) exists; per-app DoH control to be
+  assessed at port time.
+- **iOS:** WKWebView exposes no in-app DoH control; encrypted DNS is an OS concern
+  (Settings / configuration profiles). iOS contract: **document and defer to OS**,
+  no in-app control.
+
+**Parity contract:** the *encrypted-DNS control* is desktop-only; the *protection*
+(encrypted DNS when the user configures it) is available on every platform through
+whatever layer that platform provides.
+
+**Status:** Accepted 2026-07-11.
+
+---
+
+## D18 — WebRTC IP-handling control (F26)
+**Features:** F26
+**Why:** WebRTC IP-policy control depends on the engine.
+
+- **Desktop:** `webContents.setWebRTCIPHandlingPolicy` (standard + disable-direct-UDP).
+- **Android:** WebView WebRTC IP-handling support to be assessed at port time.
+- **iOS:** WKWebView exposes no WebRTC IP-handling policy; iOS contract downgrades
+  to **platform default behavior, documented** (no in-app control).
+
+**Parity contract:** the *control* is desktop-first; where a platform can't express
+it, that's a documented capability gap, not a behavioral promise broken.
+
+**Status:** Accepted 2026-07-11.

--- a/spec/features.md
+++ b/spec/features.md
@@ -348,3 +348,26 @@ From the desktop `DEFAULTS`:
   group, not iCloud-synced), with private-tab passkeys ephemeral per D16.
 - **Acceptance:** On a login form in a Blanc tab, the OS AutoFill affordance offers
   saved credentials; a passkey sign-in invokes the platform authenticator.
+
+## F25 — Encrypted DNS (DoH)
+
+- A Settings → Privacy control chooses how DNS is resolved: **Automatic**
+  (opportunistic upgrade, may fall back to plaintext — no guarantee), **Off**
+  (system resolver — the right choice under a VPN that runs its own DNS), a
+  **named provider** (Cloudflare/Quad9/Mullvad — strict, hard-fail, no plaintext
+  fallback), or a **Custom** RFC8484 template. DoH encrypts lookups between the
+  browser and the chosen resolver; it does not hide destination IPs, and it makes
+  the resolver a trusted party. Applies to normal and private sessions alike.
+- **Acceptance:** With a named provider selected, `one.one.one.one/help` (or the
+  provider's equivalent) reports DoH active; a deliberately-unreachable custom
+  template fails closed rather than silently resolving over plaintext.
+
+## F26 — WebRTC leak protection
+
+- A Settings → Privacy control sets the WebRTC IP-handling policy: **Standard**
+  exposes no addresses beyond the default route's public interface; **Disable
+  direct UDP** additionally stops WebRTC from opening direct UDP paths that bypass
+  an application-level proxy (not relay-only enforcement). Applied to every tab.
+- **Acceptance:** On a WebRTC test page, Standard reveals no local/multi-homed
+  private addresses; with an application proxy configured, Disable-direct-UDP
+  removes direct UDP candidates.

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const crypto = require('crypto');
 const { pathToFileURL } = require('url');
 const { setupAdBlocker, attachAdBlockerToSession, setAdBlockEnabled, getBlocker } = require('./adblock');
+const { webrtcPolicyFor, hostResolverOptionsFor } = require('./network-privacy');
 const {
   chromeClientHintPlatform,
   chromeClientHintArchitecture,
@@ -904,6 +905,9 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
   tabOrder.push(id);
 
   const wc = view.webContents;
+  // WebRTC IP-handling policy applies per-webContents; this is the single choke
+  // point every tab (fresh or adopted window.open child) passes through.
+  wc.setWebRTCIPHandlingPolicy(webrtcPolicyFor(settings.getSettings().webrtcPolicy));
   if (muted) wc.setAudioMuted(true); // keep the actual audio state in sync with tab.muted
   const syncNavState = () => {
     tab.canGoBack = wc.navigationHistory.canGoBack();
@@ -1939,10 +1943,34 @@ function createMainWindow() {
   });
 }
 
+// Re-apply the current WebRTC policy to every open tab (used when the setting changes).
+function applyWebrtcPolicyToAllTabs() {
+  const policy = webrtcPolicyFor(settings.getSettings().webrtcPolicy);
+  for (const tab of tabs.values()) {
+    tab.view.webContents.setWebRTCIPHandlingPolicy(policy);
+  }
+}
+
+// Last-applied encrypted-DNS values, so onSettingsChanged only reconfigures the
+// resolver + clears its cache when DNS actually changes — the listener fires on
+// every settings write, and clearing the cache mid-session isn't free.
+let lastSecureDns = null;
+let lastSecureDnsTemplate = null;
+
 app.whenReady().then(async () => {
   const ses = session.defaultSession;
   const privateSes = getPrivateBrowsingSession();
   const browsingSessions = [ses, privateSes];
+  // Encrypted DNS (DoH). app.configureHostResolver is process-wide in Electron 43
+  // (an App method) and must run after 'ready'. ONE call covers every session,
+  // including the private-browsing session, so private tabs inherit it by
+  // construction. Deliberately no enableBuiltInResolver — forcing it would move the
+  // Off position off the system resolver on Win/Linux.
+  {
+    lastSecureDns = settings.getSettings().secureDns;
+    lastSecureDnsTemplate = settings.getSettings().secureDnsTemplate;
+    app.configureHostResolver(hostResolverOptionsFor(lastSecureDns, lastSecureDnsTemplate));
+  }
 
   // Enables device-bound Touch ID passkeys in signed macOS builds. Existing
   // iCloud Passwords passkeys remain gated on Apple's browser entitlement.
@@ -2093,6 +2121,18 @@ app.whenReady().then(async () => {
     setAdBlockEnabled(s.adblockEnabled);
     applyTheme();
     applyAppIcon();
+    // WebRTC reapply is unconditional — setWebRTCIPHandlingPolicy is a cheap,
+    // idempotent per-tab call and settings writes are infrequent/user-initiated.
+    applyWebrtcPolicyToAllTabs();
+    if (s.secureDns !== lastSecureDns || s.secureDnsTemplate !== lastSecureDnsTemplate) {
+      lastSecureDns = s.secureDns;
+      lastSecureDnsTemplate = s.secureDnsTemplate;
+      app.configureHostResolver(hostResolverOptionsFor(s.secureDns, s.secureDnsTemplate));
+      // Clear cached lookups on both sessions so the new resolver takes effect without
+      // a restart. clearHostResolverCache returns a promise; Promise.allSettled collects
+      // any rejection so a failed clear can't surface as an unhandled rejection.
+      Promise.allSettled(browsingSessions.map((sess) => sess.clearHostResolverCache()));
+    }
   });
 
   // Profile sync: sync-on-launch if configured, then follow local changes.

--- a/src/main/network-privacy.js
+++ b/src/main/network-privacy.js
@@ -1,0 +1,127 @@
+// Pure, Electron-free decision logic for the network-privacy settings
+// (WebRTC IP-handling policy + encrypted DNS). Kept dependency-free so it
+// unit-tests in isolation, exactly like permission-decisions.js. main.js and
+// settings.js import from here; nothing here imports electron.
+
+// WebRTC: map the user-facing setting to a Chromium IP-handling policy.
+// 'standard' hides non-default-route/multi-homed addresses (Blanc's hardened
+// default). 'strict' additionally disables direct UDP that would bypass an
+// application-level proxy — this is NOT relay-only enforcement (Electron only
+// offers disable_non_proxied_udp), so no caller may describe it as such.
+const WEBRTC_IP_HANDLING_POLICY = {
+  standard: 'default_public_interface_only',
+  strict: 'disable_non_proxied_udp',
+};
+
+function webrtcPolicyFor(value) {
+  return WEBRTC_IP_HANDLING_POLICY[value] || WEBRTC_IP_HANDLING_POLICY.standard;
+}
+
+// DoH provider templates. Cloudflare/Mullvad are unfiltered; dns.quad9.net is
+// Quad9's malware-blocking + DNSSEC-validating endpoint (that filtering is its
+// signature service — the Settings label says so). Ad/tracker filtering stays
+// the job of Blanc's own blocker.
+const SECURE_DNS_TEMPLATES = {
+  cloudflare: 'https://cloudflare-dns.com/dns-query',
+  quad9: 'https://dns.quad9.net/dns-query',
+  mullvad: 'https://dns.mullvad.net/dns-query',
+};
+
+// Validate a custom DoH template against the raw string. We deliberately do NOT
+// round-trip through new URL() for the whole value, because that percent-encodes
+// the RFC8484 {?dns} braces. Grammar: https scheme, no credentials (userinfo),
+// no fragment, <= 2048 chars, and either no template variable or a single
+// terminal {?dns}.
+function isValidDohTemplate(str) {
+  if (typeof str !== 'string') return false;
+  if (str.length === 0 || str.length > 2048) return false;
+  if (!str.startsWith('https://')) return false;
+  if (str.includes('#')) return false; // no fragment
+
+  const authority = str.slice('https://'.length).split(/[/?]/)[0];
+  if (authority.length === 0 || authority.includes('@')) return false; // no userinfo
+
+  const tokens = str.match(/\{[^}]*\}/g) || [];
+  if (tokens.length > 1) return false;
+  if (tokens.length === 1 && (tokens[0] !== '{?dns}' || !str.endsWith('{?dns}'))) return false;
+
+  // Remove the one permitted terminal {?dns}, then reject any remaining raw brace.
+  // The token regex only matches balanced {...}, so a stray '{' or '}' (e.g.
+  // '.../dns-query{' or '.../oops}') yields zero tokens and would otherwise slip
+  // through new URL(), which silently percent-encodes lone braces.
+  const base = str.replace('{?dns}', '');
+  if (base.includes('{') || base.includes('}')) return false;
+
+  try {
+    const u = new URL(base);
+    if (u.protocol !== 'https:') return false;
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+// Build the options object for app.configureHostResolver() (process-wide, Electron
+// 43). We deliberately do NOT set enableBuiltInResolver — it defaults on for macOS,
+// off for Windows/Linux, and forcing it would push Off/system-resolver users off
+// their configured DNS. Named providers use secureDnsMode 'secure' (hard-fail, no
+// plaintext fallback); auto is 'automatic' (opportunistic, may fall back to plaintext
+// by design); off disables DoH.
+//
+// 'custom' is ALWAYS strict-secure and never degrades to automatic: the settings
+// layer (setSettings reject + getSettings coerce) guarantees a valid template
+// accompanies 'custom', so a valid strict choice is never silently downgraded.
+function hostResolverOptionsFor(secureDns, secureDnsTemplate) {
+  switch (secureDns) {
+    case 'off':
+      return { secureDnsMode: 'off' };
+    case 'cloudflare':
+    case 'quad9':
+    case 'mullvad':
+      return { secureDnsMode: 'secure', secureDnsServers: [SECURE_DNS_TEMPLATES[secureDns]] };
+    case 'custom':
+      return { secureDnsMode: 'secure', secureDnsServers: [secureDnsTemplate] };
+    case 'auto':
+    default:
+      return { secureDnsMode: 'automatic' };
+  }
+}
+
+// Cross-field write rule for the DNS settings. Given the currently-persisted
+// { secureDns, secureDnsTemplate } and an already-sanitized incoming partial,
+// return the pair to persist. Strict-custom invariant (F25): a change that would
+// leave secureDns='custom' without a valid template is REJECTED wholesale — both
+// fields revert to their previous values — rather than silently degrading to
+// plaintext-capable Automatic. Only reconciles when the incoming partial actually
+// touches a DNS field.
+function reconcileSecureDnsWrite(prev, incoming) {
+  const touchesDns = 'secureDns' in incoming || 'secureDnsTemplate' in incoming;
+  if (!touchesDns) return { secureDns: prev.secureDns, secureDnsTemplate: prev.secureDnsTemplate };
+  const next = {
+    secureDns: 'secureDns' in incoming ? incoming.secureDns : prev.secureDns,
+    secureDnsTemplate: 'secureDnsTemplate' in incoming ? incoming.secureDnsTemplate : prev.secureDnsTemplate,
+  };
+  if (next.secureDns === 'custom' && !isValidDohTemplate(next.secureDnsTemplate)) {
+    return { secureDns: prev.secureDns, secureDnsTemplate: prev.secureDnsTemplate };
+  }
+  return next;
+}
+
+// Read-side coercion for a corrupted persisted state (e.g. a hand-edited
+// settings.json): 'custom' without a valid template reads back as `fallback`
+// (the default), never as plaintext-capable custom. The write rule above keeps a
+// live user action from ever producing this state.
+function coerceSecureDnsRead(secureDns, secureDnsTemplate, fallback) {
+  if (secureDns === 'custom' && !isValidDohTemplate(secureDnsTemplate)) return fallback;
+  return secureDns;
+}
+
+module.exports = {
+  WEBRTC_IP_HANDLING_POLICY,
+  webrtcPolicyFor,
+  SECURE_DNS_TEMPLATES,
+  isValidDohTemplate,
+  hostResolverOptionsFor,
+  reconcileSecureDnsWrite,
+  coerceSecureDnsRead,
+};

--- a/src/main/pages.js
+++ b/src/main/pages.js
@@ -144,6 +144,10 @@ function setupPages(hooks = {}) {
   }));
   handle('pages:settings:set', (partial) => {
     settings.setSettings(partial ?? {});
+    // Echo the persisted non-secret projection so the renderer can reflect the
+    // actual stored state (e.g. a rejected strict-custom DNS transition). Never
+    // raw getSettings() — that includes the supporter key.
+    return clientSettings();
   });
   handle('pages:settings:supporter-activate', (key) => supporter.activateSupporter(key));
 

--- a/src/main/settings.js
+++ b/src/main/settings.js
@@ -1,4 +1,5 @@
 const { JsonStore } = require('./store');
+const { isValidDohTemplate, reconcileSecureDnsWrite, coerceSecureDnsRead } = require('./network-privacy');
 
 const SEARCH_ENGINES = {
   duckduckgo: { label: 'DuckDuckGo', url: (q) => `https://duckduckgo.com/?q=${encodeURIComponent(q)}` },
@@ -8,6 +9,10 @@ const SEARCH_ENGINES = {
 };
 
 const THEMES = ['system', 'light', 'dark'];
+
+// Network-privacy enums (bare arrays, like THEMES — build.mjs parses them by name).
+const WEBRTC_POLICIES = ['standard', 'strict'];
+const SECURE_DNS_OPTIONS = ['auto', 'off', 'cloudflare', 'quad9', 'mullvad', 'custom'];
 
 // Keys that sync across devices (see the profile-sync spec). Deliberately
 // excludes appIcon (device-local), usagePing (per-install consent), and
@@ -57,6 +62,10 @@ const DEFAULTS = {
   appIcon: 'paper',
   // Lowercased hostnames, no protocol/path/www. prefix.
   adblockExceptions: [],
+  // Network privacy (device-local — deliberately NOT in SYNCED_KEYS).
+  webrtcPolicy: 'standard',
+  secureDns: 'auto',
+  secureDnsTemplate: '',
   // Anonymous "app launched" ping — see main/telemetry.js. On by default
   // (opt-out in Settings); no browsing data, only version/OS plus a random
   // per-install id used solely to count distinct active users.
@@ -84,6 +93,10 @@ function ensureStore() {
 function getSettings() {
   const data = { ...ensureStore().data };
   if (!isAppIconAllowed(data.appIcon)) data.appIcon = DEFAULTS.appIcon;
+  // Read coercion for a corrupted stored state (hand-edited settings.json): custom
+  // without a valid template reads back as the default, never as plaintext-capable
+  // custom. The setSettings guard prevents a valid user action from producing this.
+  data.secureDns = coerceSecureDnsRead(data.secureDns, data.secureDnsTemplate, DEFAULTS.secureDns);
   return data;
 }
 
@@ -103,6 +116,15 @@ function sanitize(partial) {
   if (typeof partial.usagePing === 'boolean') clean.usagePing = partial.usagePing;
   if (typeof partial.homePage === 'string') clean.homePage = partial.homePage.trim();
   if (THEMES.includes(partial.theme)) clean.theme = partial.theme;
+  if (WEBRTC_POLICIES.includes(partial.webrtcPolicy)) clean.webrtcPolicy = partial.webrtcPolicy;
+  if (SECURE_DNS_OPTIONS.includes(partial.secureDns)) clean.secureDns = partial.secureDns;
+  if (typeof partial.secureDnsTemplate === 'string') {
+    // Accept only an empty string or a valid template. An invalid value is DROPPED
+    // (key omitted from clean) so it can never overwrite a good stored template; the
+    // cross-field guard in setSettings then decides the secureDns transition.
+    const t = partial.secureDnsTemplate.trim();
+    if (t === '' || isValidDohTemplate(t)) clean.secureDnsTemplate = t;
+  }
   if (isAppIconAllowed(partial.appIcon)) clean.appIcon = partial.appIcon;
   if (Array.isArray(partial.adblockExceptions)) {
     clean.adblockExceptions = [
@@ -119,6 +141,17 @@ function sanitize(partial) {
 function setSettings(partial) {
   const s = ensureStore();
   const clean = sanitize(partial);
+  // Strict-custom invariant (F25): an invalid custom transition must not degrade to
+  // plaintext-capable Automatic. reconcileSecureDnsWrite (unit-tested) rejects such a
+  // change, preserving the last valid configuration.
+  if ('secureDns' in clean || 'secureDnsTemplate' in clean) {
+    const dns = reconcileSecureDnsWrite(
+      { secureDns: s.data.secureDns, secureDnsTemplate: s.data.secureDnsTemplate },
+      clean,
+    );
+    clean.secureDns = dns.secureDns;
+    clean.secureDnsTemplate = dns.secureDnsTemplate;
+  }
   const now = Date.now();
   s.update((data) => {
     Object.assign(data, clean);

--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -143,6 +143,10 @@ function install(refs) {
     searchEngine() { return settings.getSettings().searchEngine; },
     setAppIcon(x) { settings.setSettings({ appIcon: x }); },
     appIcon() { return settings.getSettings().appIcon; },
+    secureDns() { return settings.getSettings().secureDns; },
+    secureDnsTemplate() { return settings.getSettings().secureDnsTemplate; },
+    webrtcPolicy() { return settings.getSettings().webrtcPolicy; },
+    setSecureDns(dns, template = '') { settings.setSettings({ secureDns: dns, secureDnsTemplate: template }); },
     clearSupporter() { settings.setSupporter(null); },
     addException(h) {
       const cur = settings.getSettings().adblockExceptions;

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -161,6 +161,8 @@ button {
 button:hover { color: var(--text); border-color: var(--text-dim); }
 button.danger:hover { color: var(--on-danger); background: var(--danger); border-color: var(--danger); }
 
+.hint.field-error { color: var(--danger); }
+
 .spacer { flex: 1 1 auto; }
 
 .row-list { display: flex; flex-direction: column; }

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -95,6 +95,41 @@
               </label>
             </div>
 
+            <div class="setting">
+              <div class="label">
+                <span>WebRTC</span>
+                <span class="hint">Limits which network addresses WebRTC may reveal. Standard hides non-default-route and multi-homed addresses.</span>
+              </div>
+              <select id="webrtcPolicy">
+                <option value="standard">Standard — hide non-default addresses</option>
+                <option value="strict">Disable direct UDP — for proxy users; may break or degrade some video calls</option>
+              </select>
+            </div>
+
+            <div class="setting">
+              <div class="label">
+                <span>Encrypted DNS</span>
+                <span class="hint">Encrypts DNS lookups between Blanc and the chosen resolver. It does not hide the sites you visit from your network, and it makes the resolver a party you trust. Automatic does not guarantee encryption. Strict providers may block captive-portal login pages — switch to Automatic to get through.</span>
+              </div>
+              <select id="secureDns">
+                <option value="auto">Automatic — upgrade when available (may fall back to unencrypted)</option>
+                <option value="off">Off — use the system resolver (best with a VPN's own DNS)</option>
+                <option value="cloudflare">Cloudflare — unfiltered</option>
+                <option value="quad9">Quad9 — blocks known-malware domains, validates DNSSEC</option>
+                <option value="mullvad">Mullvad — unfiltered</option>
+                <option value="custom">Custom provider…</option>
+              </select>
+            </div>
+
+            <div class="setting" id="secureDnsCustomRow" hidden>
+              <div class="label">
+                <span>Custom DoH template</span>
+                <span class="hint">An https:// DoH URL (RFC 8484), e.g. https://dns.nextdns.io/&lt;profile&gt;.</span>
+                <span class="hint field-error" id="secureDnsError" hidden>That is not a valid DoH URL — the previous provider is still in use.</span>
+              </div>
+              <input id="secureDnsTemplate" type="url" placeholder="https://your-provider.example/dns-query" />
+            </div>
+
             <div class="group-subsection">
               <h3 class="section-title">Ad-block exceptions</h3>
               <p class="section-hint">

--- a/src/renderer/pages/settings.js
+++ b/src/renderer/pages/settings.js
@@ -72,14 +72,17 @@
     };
 
     // The main process is the sole validator. Send the change, then render from the
-    // ACTUAL persisted result (set() returns the settings). If the user asked for
-    // custom but it wasn't stored, the guard rejected the template: keep their draft
-    // visible — dropdown on custom, row OPEN, typed text intact — and show the error.
-    // Do NOT snap back to the old provider (that would hide the row and the error and
-    // erase what they typed).
+    // ACTUAL persisted result (set() returns the settings). A custom write is REJECTED
+    // when the store didn't take it — either the provider isn't custom, OR (Custom
+    // already active) the submitted template wasn't stored because it was invalid and
+    // sanitize dropped it, leaving the previous valid template in place. Comparing only
+    // the provider would miss that second case: keep the draft visible (dropdown on
+    // custom, row OPEN, typed text intact) and show the error — never snap back.
     const commit = async (partial, attempted) => {
       const next = await window.bowserPages.settings.set(partial);
-      if (attempted === 'custom' && next.secureDns !== 'custom') {
+      const rejected = attempted === 'custom' &&
+        (next.secureDns !== 'custom' || next.secureDnsTemplate !== partial.secureDnsTemplate);
+      if (rejected) {
         secureDns.value = 'custom';
         secureDnsRow.hidden = false;
         secureDnsError.hidden = false;

--- a/src/renderer/pages/settings.js
+++ b/src/renderer/pages/settings.js
@@ -45,6 +45,70 @@
     document.getElementById('homePage')?.closest('.setting')?.remove();
   }
 
+  // --- WebRTC IP-handling policy ---
+  if (supports('webrtcPolicy')) {
+    const webrtcPolicy = document.getElementById('webrtcPolicy');
+    webrtcPolicy.value = settings.webrtcPolicy ?? 'standard';
+    webrtcPolicy.addEventListener('change', () =>
+      window.bowserPages.settings.set({ webrtcPolicy: webrtcPolicy.value }));
+  } else {
+    document.getElementById('webrtcPolicy')?.closest('.setting')?.remove();
+  }
+
+  // --- Encrypted DNS (DoH) ---
+  if (supports('secureDns')) {
+    const secureDns = document.getElementById('secureDns');
+    const secureDnsRow = document.getElementById('secureDnsCustomRow');
+    const secureDnsTemplate = document.getElementById('secureDnsTemplate');
+    const secureDnsError = document.getElementById('secureDnsError');
+
+    // Reflect an ACCEPTED persisted snapshot into the controls (clears any error).
+    const showAccepted = (s) => {
+      secureDns.value = s.secureDns ?? 'auto';
+      secureDnsTemplate.value = s.secureDnsTemplate ?? '';
+      secureDnsRow.hidden = secureDns.value !== 'custom';
+      secureDnsError.hidden = true;
+      secureDnsTemplate.setAttribute('aria-invalid', 'false');
+    };
+
+    // The main process is the sole validator. Send the change, then render from the
+    // ACTUAL persisted result (set() returns the settings). If the user asked for
+    // custom but it wasn't stored, the guard rejected the template: keep their draft
+    // visible — dropdown on custom, row OPEN, typed text intact — and show the error.
+    // Do NOT snap back to the old provider (that would hide the row and the error and
+    // erase what they typed).
+    const commit = async (partial, attempted) => {
+      const next = await window.bowserPages.settings.set(partial);
+      if (attempted === 'custom' && next.secureDns !== 'custom') {
+        secureDns.value = 'custom';
+        secureDnsRow.hidden = false;
+        secureDnsError.hidden = false;
+        secureDnsTemplate.setAttribute('aria-invalid', 'true');
+        return; // leaves secureDnsTemplate.value (the rejected text) untouched
+      }
+      showAccepted(next);
+    };
+
+    showAccepted(settings); // initial render from the get() payload
+
+    secureDns.addEventListener('change', () => {
+      if (secureDns.value === 'custom') {
+        secureDnsRow.hidden = false; // reveal the field so they can type
+        secureDnsError.hidden = true; // don't error before they've entered anything
+        const t = secureDnsTemplate.value.trim();
+        if (t) commit({ secureDns: 'custom', secureDnsTemplate: t }, 'custom');
+        // else: wait for the template's own change event to commit + validate
+      } else {
+        commit({ secureDns: secureDns.value }, secureDns.value);
+      }
+    });
+    secureDnsTemplate.addEventListener('change', () =>
+      commit({ secureDns: 'custom', secureDnsTemplate: secureDnsTemplate.value.trim() }, 'custom'));
+  } else {
+    document.getElementById('secureDns')?.closest('.setting')?.remove();
+    document.getElementById('secureDnsCustomRow')?.remove();
+  }
+
   // --- Usage ping ---
   if (supports('usagePing')) {
     const usagePing = document.getElementById('usagePing');

--- a/test/desktop/dns-smoke.mjs
+++ b/test/desktop/dns-smoke.mjs
@@ -1,0 +1,52 @@
+// Cross-platform DoH launch smoke. Proves: the app starts (no configureHostResolver
+// throw), defaults are live, Cloudflare secure DoH resolves, and an unreachable strict
+// custom resolver fails closed (no plaintext fallback). Isolated profile — never reads
+// the developer's real settings. Run by .github/workflows/prerelease-smoke.yml.
+import { _electron } from 'playwright';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-dns-smoke-'));
+const app = await _electron.launch({
+  args: [path.resolve('.'), `--user-data-dir=${userDataDir}`],
+  env: { ...process.env, BLANC_TEST: '1' },
+});
+
+// Resolve a host through the default session's Chromium resolver, which honors the
+// process-wide app.configureHostResolver config. Playwright passes the Electron module
+// as the FIRST callback arg and the supplied value SECOND (so no require() needed).
+// true = resolved, false = failed.
+const canResolve = (host) => app.evaluate(async ({ session }, h) => {
+  try { await session.defaultSession.resolveHost(h); return true; } catch { return false; }
+}, host);
+// After a DNS setting change, app.configureHostResolver has already run synchronously
+// inside the settings listener; await a cache clear (deterministic — not a fixed sleep)
+// so the next probe uses the new resolver.
+const clearDnsCache = () => app.evaluate(async ({ session }) => {
+  await session.defaultSession.clearHostResolverCache();
+});
+
+try {
+  await app.firstWindow(); // startup didn't crash (a ready-handler throw would prevent this)
+
+  assert.equal(await app.evaluate(() => globalThis.__blanc.secureDns()), 'auto', 'default secureDns should be auto');
+  assert.equal(await app.evaluate(() => globalThis.__blanc.webrtcPolicy()), 'standard', 'default webrtcPolicy should be standard');
+
+  // Secure mode WORKS here without enableBuiltInResolver (the Linux question).
+  await app.evaluate(() => globalThis.__blanc.setSecureDns('cloudflare'));
+  await clearDnsCache();
+  assert.ok(await canResolve('example.com'), 'Cloudflare secure DoH should resolve example.com');
+
+  // Strict custom FAILS CLOSED — unreachable resolver, distinct host to dodge any cache.
+  await app.evaluate(() => globalThis.__blanc.setSecureDns('custom', 'https://127.0.0.1:9/dns-query'));
+  await clearDnsCache();
+  assert.ok(!(await canResolve('cloudflare.com')), 'unreachable strict custom DoH must fail closed');
+
+  console.log(`dns-smoke OK on ${process.platform}`);
+} finally {
+  await app.close();
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+}

--- a/test/unit/network-privacy.test.js
+++ b/test/unit/network-privacy.test.js
@@ -113,6 +113,16 @@ test('reconcileSecureDnsWrite: clearing the template while custom is active is r
   );
 });
 
+test('reconcileSecureDnsWrite: resubmitting custom with a dropped invalid template keeps the old valid one', () => {
+  // sanitize drops an invalid replacement template, so reconcile sees {secureDns:'custom'}
+  // with no template key while custom is already active — it must retain the prior valid
+  // template (the renderer detects this "template unchanged" case and shows the error).
+  assert.deepEqual(
+    reconcileSecureDnsWrite({ secureDns: 'custom', secureDnsTemplate: VALID }, { secureDns: 'custom' }),
+    { secureDns: 'custom', secureDnsTemplate: VALID },
+  );
+});
+
 test('reconcileSecureDnsWrite: replacing with another valid template is accepted', () => {
   const V2 = 'https://dns.quad9.net/dns-query';
   assert.deepEqual(

--- a/test/unit/network-privacy.test.js
+++ b/test/unit/network-privacy.test.js
@@ -1,0 +1,144 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  WEBRTC_IP_HANDLING_POLICY,
+  webrtcPolicyFor,
+  SECURE_DNS_TEMPLATES,
+  isValidDohTemplate,
+  hostResolverOptionsFor,
+  reconcileSecureDnsWrite,
+  coerceSecureDnsRead,
+} = require('../../src/main/network-privacy');
+
+test('webrtcPolicyFor maps settings to Electron policy strings', () => {
+  assert.equal(webrtcPolicyFor('standard'), 'default_public_interface_only');
+  assert.equal(webrtcPolicyFor('strict'), 'disable_non_proxied_udp');
+  // unknown/garbage falls back to the hardened standard default, never 'default'
+  assert.equal(webrtcPolicyFor('nonsense'), 'default_public_interface_only');
+  assert.equal(webrtcPolicyFor(undefined), 'default_public_interface_only');
+  // every mapping is a real Electron policy value
+  const valid = new Set(['default', 'default_public_interface_only', 'default_public_and_private_interfaces', 'disable_non_proxied_udp']);
+  for (const v of Object.values(WEBRTC_IP_HANDLING_POLICY)) assert.ok(valid.has(v));
+});
+
+test('isValidDohTemplate accepts well-formed templates', () => {
+  assert.ok(isValidDohTemplate('https://cloudflare-dns.com/dns-query'));
+  assert.ok(isValidDohTemplate('https://dns.quad9.net/dns-query'));
+  assert.ok(isValidDohTemplate('https://dns.nextdns.io/abc123'));
+  assert.ok(isValidDohTemplate('https://example.com/dns-query{?dns}')); // single terminal token
+});
+
+test('isValidDohTemplate rejects malformed templates', () => {
+  assert.equal(isValidDohTemplate(''), false);
+  assert.equal(isValidDohTemplate('http://insecure.example/dns-query'), false); // not https
+  assert.equal(isValidDohTemplate('ftp://x'), false);
+  assert.equal(isValidDohTemplate('not a url'), false);
+  assert.equal(isValidDohTemplate('https://user:pass@host/dns-query'), false); // credentials
+  assert.equal(isValidDohTemplate('https://host/dns-query#frag'), false); // fragment
+  assert.equal(isValidDohTemplate('https://host/{?dns}/tail'), false); // token not terminal
+  assert.equal(isValidDohTemplate('https://host/{?dns}{?dns}'), false); // repeated token
+  assert.equal(isValidDohTemplate('https://host/{foo}'), false); // wrong token
+  assert.equal(isValidDohTemplate('https://host/dns-query{'), false); // unmatched opening brace
+  assert.equal(isValidDohTemplate('https://host/oops}'), false); // unmatched closing brace
+  assert.equal(isValidDohTemplate('https://host/a{b/c'), false); // stray brace mid-path
+  assert.equal(isValidDohTemplate('https://host/{?dns}}'), false); // valid token + stray brace
+  assert.equal(isValidDohTemplate('https://' + 'a'.repeat(2100)), false); // oversize
+  assert.equal(isValidDohTemplate(42), false);
+  assert.equal(isValidDohTemplate(null), false);
+});
+
+test('hostResolverOptionsFor never sets enableBuiltInResolver (Off must keep the system resolver)', () => {
+  for (const v of ['auto', 'off', 'cloudflare', 'quad9', 'mullvad', 'custom']) {
+    assert.ok(!('enableBuiltInResolver' in hostResolverOptionsFor(v, 'https://dns.example/dns-query')));
+  }
+});
+
+test('hostResolverOptionsFor: auto and unknown are opportunistic automatic with no servers', () => {
+  assert.deepEqual(hostResolverOptionsFor('auto', ''), { secureDnsMode: 'automatic' });
+  assert.deepEqual(hostResolverOptionsFor('mystery', ''), { secureDnsMode: 'automatic' });
+});
+
+test('hostResolverOptionsFor: off disables DoH', () => {
+  assert.deepEqual(hostResolverOptionsFor('off', ''), { secureDnsMode: 'off' });
+});
+
+test('hostResolverOptionsFor: named providers hard-fail on their own template', () => {
+  assert.deepEqual(hostResolverOptionsFor('cloudflare', ''), {
+    secureDnsMode: 'secure', secureDnsServers: ['https://cloudflare-dns.com/dns-query'],
+  });
+  assert.deepEqual(hostResolverOptionsFor('quad9', ''), {
+    secureDnsMode: 'secure', secureDnsServers: ['https://dns.quad9.net/dns-query'],
+  });
+  assert.deepEqual(hostResolverOptionsFor('mullvad', ''), {
+    secureDnsMode: 'secure', secureDnsServers: ['https://dns.mullvad.net/dns-query'],
+  });
+});
+
+test('hostResolverOptionsFor: custom stays strict (secure) — never degrades to automatic', () => {
+  // The settings layer guarantees a valid template accompanies 'custom' (setSettings
+  // rejects invalid custom transitions; getSettings coerces corrupted state). So the
+  // custom branch is always strict-secure — it must NEVER return automatic.
+  assert.deepEqual(hostResolverOptionsFor('custom', 'https://dns.nextdns.io/abc123'), {
+    secureDnsMode: 'secure', secureDnsServers: ['https://dns.nextdns.io/abc123'],
+  });
+  assert.equal(hostResolverOptionsFor('custom', 'https://dns.nextdns.io/abc123').secureDnsMode, 'secure');
+});
+
+const VALID = 'https://dns.nextdns.io/abc123';
+
+test('reconcileSecureDnsWrite: valid atomic custom write is accepted', () => {
+  assert.deepEqual(
+    reconcileSecureDnsWrite({ secureDns: 'auto', secureDnsTemplate: '' }, { secureDns: 'custom', secureDnsTemplate: VALID }),
+    { secureDns: 'custom', secureDnsTemplate: VALID },
+  );
+});
+
+test('reconcileSecureDnsWrite: selecting custom without a valid template is rejected (keeps previous)', () => {
+  // sanitize drops an invalid template, so the partial reaching here is often just {secureDns:'custom'}.
+  assert.deepEqual(
+    reconcileSecureDnsWrite({ secureDns: 'auto', secureDnsTemplate: '' }, { secureDns: 'custom' }),
+    { secureDns: 'auto', secureDnsTemplate: '' },
+  );
+  assert.deepEqual(
+    reconcileSecureDnsWrite({ secureDns: 'off', secureDnsTemplate: '' }, { secureDns: 'custom', secureDnsTemplate: '' }),
+    { secureDns: 'off', secureDnsTemplate: '' },
+  );
+});
+
+test('reconcileSecureDnsWrite: clearing the template while custom is active is rejected (preserves last valid)', () => {
+  assert.deepEqual(
+    reconcileSecureDnsWrite({ secureDns: 'custom', secureDnsTemplate: VALID }, { secureDnsTemplate: '' }),
+    { secureDns: 'custom', secureDnsTemplate: VALID },
+  );
+});
+
+test('reconcileSecureDnsWrite: replacing with another valid template is accepted', () => {
+  const V2 = 'https://dns.quad9.net/dns-query';
+  assert.deepEqual(
+    reconcileSecureDnsWrite({ secureDns: 'custom', secureDnsTemplate: VALID }, { secureDnsTemplate: V2 }),
+    { secureDns: 'custom', secureDnsTemplate: V2 },
+  );
+});
+
+test('reconcileSecureDnsWrite: switching away from custom keeps the (now-unused) template', () => {
+  assert.deepEqual(
+    reconcileSecureDnsWrite({ secureDns: 'custom', secureDnsTemplate: VALID }, { secureDns: 'off' }),
+    { secureDns: 'off', secureDnsTemplate: VALID },
+  );
+});
+
+test('reconcileSecureDnsWrite: a non-DNS partial leaves DNS untouched', () => {
+  assert.deepEqual(
+    reconcileSecureDnsWrite({ secureDns: 'cloudflare', secureDnsTemplate: '' }, { theme: 'dark' }),
+    { secureDns: 'cloudflare', secureDnsTemplate: '' },
+  );
+});
+
+test('coerceSecureDnsRead: corrupted custom reads back as the fallback; valid custom and others pass through', () => {
+  assert.equal(coerceSecureDnsRead('custom', 'garbage', 'auto'), 'auto');
+  assert.equal(coerceSecureDnsRead('custom', '', 'auto'), 'auto');
+  assert.equal(coerceSecureDnsRead('custom', VALID, 'auto'), 'custom');
+  assert.equal(coerceSecureDnsRead('off', '', 'auto'), 'off');
+  assert.equal(coerceSecureDnsRead('quad9', '', 'auto'), 'quad9');
+});


### PR DESCRIPTION
Implements M2+M3 of the network-privacy plan ([docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md](docs/superpowers/plans/2026-07-11-network-privacy-m2-m3-webrtc-dns.md)) — two settings-driven, session-level protections that respect the VPN/proxy a user already chose rather than shipping one.

## What's in it
- **WebRTC leak protection (F26)** — `webrtcPolicy` setting (`standard` = `default_public_interface_only`, `strict` = `disable_non_proxied_udp`), applied per-tab at the `createTab` choke point and live-reapplied on change.
- **Encrypted DNS / DoH (F25)** — `secureDns` (auto/off/cloudflare/quad9/mullvad/custom) + `secureDnsTemplate`, via process-wide `app.configureHostResolver` after `ready`, live-reconfigured with `clearHostResolverCache` on both browsing sessions. Strict positions hard-fail; a corrupted/invalid custom template can never silently degrade to plaintext Automatic (enforced in the settings layer, unit-tested).
- **Settings → Privacy UI** — two controls; the custom-DoH field round-trips through the main process (sole validator) and shows a themed error without losing the draft on rejection.
- **Substrate** — new keys through the S5 generator (`build.mjs` + regenerated Swift/Kotlin), `substrate:check` green.
- **Parity** — F25/F26 features + D17/D18 divergences (desktop-only controls; iOS defers to OS).
- **Security page** — a shipped-only "on the network" section (honest copy: no "closes the leak", no "anonymous").
- **Pre-release smoke** — `test/desktop/dns-smoke.mjs` + `.github/workflows/prerelease-smoke.yml` (ubuntu + windows) launch the app headlessly and assert secure DoH resolves and unreachable strict DoH fails closed.

## Verification
- 131 unit tests pass (16 new: brace-validator + strict-custom state machine)
- `substrate:check` clean; `test:acceptance:dry` resolves
- DNS smoke passes on macOS (real DoH resolve + fail-closed); headless boot confirms `configureHostResolver` doesn't throw

## Not in this PR (release-gated, per the plan's Task 9)
- Version bump to 0.17.0 + `release.sh` hardening (HEAD==origin/main + `--target`)
- CI smoke green on ubuntu/windows; manual Windows DoH check
- The actual `npm run release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

