### PR TITLE
fix(newtab): keep the ledger footer clear of synced tab rows

### DIFF
--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -427,7 +427,17 @@ button.danger:hover { color: var(--on-danger); background: var(--danger); border
    left-aligned column that reads like a well-kept notebook — date,
    "Where to?", favorites, tab groups — with a quiet margin-note footer. */
 
-.ledger-body { padding: 150px 120px 140px; }
+/* The page must survive overflowing (Tab Sync can add rows per device):
+   flex column + min-height pins the footer to the viewport bottom while
+   content is short, and lets it fall in flow below the content — never
+   overlapping it — once the ledger outgrows the window. The top gap
+   yields with the window height for the same reason. */
+.ledger-body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: clamp(90px, 16vh, 150px) 120px 40px;
+}
 
 .ledger { max-width: 520px; }
 .ledger-date {
@@ -520,10 +530,11 @@ a.ledger-label:hover { color: var(--accent); }
 .ledger-empty { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim); }
 
 .ledger-footer {
-  position: fixed;
-  left: 120px;
-  right: 120px;
-  bottom: 40px;
+  /* Pinned to the viewport bottom by the auto margin while the ledger is
+     short; once it overflows, the padding keeps the footer one section's
+     worth of rhythm (.ledger-section) below the last row. */
+  margin-top: auto;
+  padding-top: 50px;
   display: flex;
   justify-content: space-between;
   align-items: baseline;
@@ -537,8 +548,7 @@ a.ledger-label:hover { color: var(--accent); }
 .ledger-version { opacity: 0.6; font-size: 11px; }
 
 @media (max-width: 720px) {
-  .ledger-body { padding: 90px 48px 140px; }
-  .ledger-footer { left: 48px; right: 48px; }
+  .ledger-body { padding: 90px 48px 40px; }
 }
 
 /* ---------- centered mark (error page) ---------- */


### PR DESCRIPTION
## What

The New Tab ledger page laid its footer out as `position: fixed` at the viewport bottom with no background, on the assumption that page content always fits the window. Tab Sync (#41, v0.20.0) broke that assumption by adding an "on your other devices" section of up to four rows per device — the rows scrolled straight through the transparent footer, leaving the blocked count, version and ⌘L hint illegible under the tab titles. A flat `150px` top pad also left a wide empty band above the date line on shorter windows.

This lays `.ledger-body` out as a flex column with `min-height: 100vh` and puts `.ledger-footer` in normal flow with `margin-top: auto`. Short pages pin the footer to the viewport bottom exactly as before; longer ones let it fall below the last row. Overlap is now structurally impossible rather than merely unlikely. The top gap yields with window height (`clamp(90px, 16vh, 150px)`).

CSS only, one file, +17/−7. No renderer or main-process changes.

## Before / after

| | before | after |
|---|---|---|
| resting (no synced tabs) | footer at viewport bottom | unchanged, pixel-identical |
| synced tabs, 1200×700 | rows render **through** the footer | footer flows below the rows, page scrolls |
| top gap, short window | flat 150px | 90–150px, scales with height |

## Trade-off a reviewer should know

The footer now **scrolls out of view when content overflows**, where the old fixed one was always on screen (just illegible underneath the rows). This was raised with @anthonyjloria explicitly and accepted. Two always-visible alternatives — sticky with an opaque `background: var(--bg)` mask, and sticky with a fade gradient — were offered and declined: the footer holds margin notes, nothing interactive, so a bar pinned across an otherwise bare paper page reads as chrome the ledger design avoids.

Please don't "fix" the footer back to fixed/sticky on seeing it scroll away — that reintroduces the overlap or adds the rejected bar.

## Verification

A Playwright-Electron harness asserted two invariants — no ledger content may enter the footer's box, and the page must never scroll horizontally — across seven cases:

| case | content bottom | footer top | |
|---|---|---|---|
| resting 1400×850 | 281 | 681 | ok |
| synced 1400×850 | 635 | 681 | ok |
| synced 1200×700 | 611 | 611 | ok |
| synced narrow 700×900 | 600 | 719 | ok |
| synced short 1200×520 | 600 | 600 | ok |
| private 1400×850 | 281 | 681 | ok |
| private narrow 700×900 | 245 | 704 | ok |

The cramped `1200×520` case is the one that fails on `main`. The private newtab's longer footer copy legitimately wraps to two lines at ~700px wide — same as before this change, since the in-flow footer inherits the same insets from the body padding that the fixed one had.

`npm run substrate:check` passes all four guards (the tokens checker parses this file) and all 161 unit tests pass.

## Notes

- `.ledger-body` / `.ledger-footer` are used only by `newtab.html`, so blast radius is that one page.
- The footer's overflow gap is `padding-top: 50px`, matching `.ledger-section`'s existing rhythm rather than a new magic number.
- No `:root` token declarations touched, so there's no substrate drift to reconcile.
- F16 in `spec/features.md` pins the footer's *contents*, not its positioning — no divergence register entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)