### PR TITLE
Add newsletter signup with honeypot and KV storage

### DIFF
--- a/cloudflare/.env.1password
+++ b/cloudflare/.env.1password
@@ -1,1 +1,1 @@
-CLOUDFLARE_API_TOKEN=op://Dev/Cloudflare API/credential
+CLOUDFLARE_API_TOKEN=op://Dev/Cloudflare API Token blancbrowser/credential

--- a/cloudflare/.env.1password
+++ b/cloudflare/.env.1password
@@ -1,0 +1,1 @@
+CLOUDFLARE_API_TOKEN=op://Dev/Cloudflare API/credential

--- a/cloudflare/newsletter-worker/README.md
+++ b/cloudflare/newsletter-worker/README.md
@@ -22,9 +22,26 @@ Two consequences to stay honest about:
   self-serve link comes with the sending provider.
 
 Anti-abuse, in order: CORS restricted to `blancbrowser.com` (+ Astro's
-localhost dev origin), a visually-hidden `website` honeypot field (a filled
-honeypot gets a 200 and writes nothing), a per-IP limit of 6 subscribes per
-minute, and loose email-shape validation capped at 254 chars.
+localhost dev origin), a visually-hidden `website` honeypot field, a per-IP
+limit of 6 subscribes per minute, and loose email-shape validation capped at
+254 chars.
+
+**Honeypot quarantine:** a filled honeypot gets the same 200 as a real
+signup but the address goes to a `hp:` key with a 30-day TTL instead of the
+list. That's because the one way a *person* trips the honeypot is their
+browser or password manager autofilling the hidden field — they'd see
+"subscribed" while silently never being stored, with no way for anyone to
+notice. The quarantine makes the miss visible: the export (below) returns
+those addresses under `quarantined`, and a plausible-looking one is rescued
+by re-POSTing it to `/subscribe` without the `website` field:
+
+```
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"email":"a@example.com"}' https://<worker-url>/subscribe
+```
+
+Bot-submitted garbage just ages out on its own; an address already on the
+list is never quarantined.
 
 ## Deploy
 
@@ -66,9 +83,15 @@ Returns JSON like:
   "subscribers": [
     { "email": "a@example.com", "ts": "2026-07-23T10:00:00.000Z" },
     { "email": "b@example.com", "ts": "2026-07-24T09:30:00.000Z" }
+  ],
+  "quarantined": [
+    { "email": "maybe-real@example.com", "ts": "2026-07-24T11:00:00.000Z" }
   ]
 }
 ```
+
+`quarantined` is the honeypot quarantine described above — glance at it
+before a send; anything plausible gets rescued, the rest expires.
 
 ## Removing an address (unsubscribe / data deletion)
 
@@ -77,6 +100,7 @@ curl -X DELETE -H "Authorization: Bearer <ADMIN_TOKEN>" \
   "https://<worker-url>/subscriber?email=a@example.com"
 ```
 
-204 either way — removing an address that isn't on the list is a no-op.
-Do this promptly for any unsubscribe or deletion request; the privacy
-policy promises it.
+204 either way — removing an address that isn't on the list is a no-op, and
+the removal also clears any quarantined copy of the address. Do this
+promptly for any unsubscribe or deletion request; the privacy policy
+promises it.

--- a/cloudflare/newsletter-worker/README.md
+++ b/cloudflare/newsletter-worker/README.md
@@ -45,16 +45,39 @@ list is never quarantined.
 
 ## Deploy
 
-Requires a Cloudflare account and `wrangler` (installed on demand via `npx`,
-no need to add it as a repo dependency).
+Requires `wrangler` (installed on demand via `npx`, no need to add it as a
+repo dependency) and the 1Password CLI — all credentialed commands run
+through `op`, per the house rule (see `scripts/release.sh` for the same
+pattern with notarization). Two 1Password items are involved, both in vault
+**Dev**:
+
+- **"Cloudflare API"** (`credential` field) — the Cloudflare API token
+  wrangler authenticates with, mapped to `CLOUDFLARE_API_TOKEN` by
+  `cloudflare/.env.1password` (shared by the workers; adjust that one file
+  if the item lives elsewhere). No `wrangler login` needed or wanted.
+- **"Blanc Newsletter Admin"** (`password` field) — the worker's
+  `ADMIN_TOKEN`, created below; needed again whenever you export the list
+  or remove an address.
 
 ```
 cd cloudflare/newsletter-worker
-npx wrangler login                                 # opens a browser to authorize
-npx wrangler kv namespace create SUBSCRIBERS       # copy the returned id into wrangler.toml
-npx wrangler secret put ADMIN_TOKEN                # pick any long random string, save it somewhere safe
-npx wrangler deploy
+
+# One-time: mint the admin token straight into 1Password (never touches
+# clipboard or shell history).
+op item create --category=password --vault=Dev --title="Blanc Newsletter Admin" \
+  --generate-password='letters,digits,64'
+
+# Copy the printed id into wrangler.toml and commit it:
+op run --env-file=../.env.1password -- npx wrangler kv namespace create SUBSCRIBERS
+
+op read "op://Dev/Blanc Newsletter Admin/password" | \
+  op run --env-file=../.env.1password -- npx wrangler secret put ADMIN_TOKEN
+
+op run --env-file=../.env.1password -- npx wrangler deploy
 ```
+
+If the token can't be resolved (locked vault, wrong item name) `op` fails
+loudly — there is no unauthenticated fallback to stumble into.
 
 `wrangler deploy` prints the live URL, something like
 `https://blanc-newsletter.<your-subdomain>.workers.dev`. The footer form
@@ -72,7 +95,8 @@ redeploy too.
 ## Exporting the list
 
 ```
-curl -H "Authorization: Bearer <ADMIN_TOKEN>" https://<worker-url>/subscribers
+curl -H "Authorization: Bearer $(op read 'op://Dev/Blanc Newsletter Admin/password')" \
+  https://<worker-url>/subscribers
 ```
 
 Returns JSON like:
@@ -96,7 +120,7 @@ before a send; anything plausible gets rescued, the rest expires.
 ## Removing an address (unsubscribe / data deletion)
 
 ```
-curl -X DELETE -H "Authorization: Bearer <ADMIN_TOKEN>" \
+curl -X DELETE -H "Authorization: Bearer $(op read 'op://Dev/Blanc Newsletter Admin/password')" \
   "https://<worker-url>/subscriber?email=a@example.com"
 ```
 

--- a/cloudflare/newsletter-worker/README.md
+++ b/cloudflare/newsletter-worker/README.md
@@ -51,10 +51,11 @@ through `op`, per the house rule (see `scripts/release.sh` for the same
 pattern with notarization). Two 1Password items are involved, both in vault
 **Dev**:
 
-- **"Cloudflare API"** (`credential` field) — the Cloudflare API token
-  wrangler authenticates with, mapped to `CLOUDFLARE_API_TOKEN` by
-  `cloudflare/.env.1password` (shared by the workers; adjust that one file
-  if the item lives elsewhere). No `wrangler login` needed or wanted.
+- **"Cloudflare API Token blancbrowser"** (`credential` field) — the
+  Cloudflare API token wrangler authenticates with, mapped to
+  `CLOUDFLARE_API_TOKEN` by `cloudflare/.env.1password` (shared by the
+  workers; adjust that one file if the item lives elsewhere). No
+  `wrangler login` needed or wanted.
 - **"Blanc Newsletter Admin"** (`password` field) — the worker's
   `ADMIN_TOKEN`, created below; needed again whenever you export the list
   or remove an address.

--- a/cloudflare/newsletter-worker/README.md
+++ b/cloudflare/newsletter-worker/README.md
@@ -1,0 +1,82 @@
+# blanc-newsletter
+
+Signup store behind the newsletter form in blancbrowser.com's footer
+(`site/src/components/NewsletterForm.astro`). Receives `POST /subscribe` with
+`{email}` and keeps `sub:<email>` → `{ts}` in Workers KV — the address and
+when it arrived, nothing else. No IPs at rest (the per-IP rate-limit keys
+expire within two minutes), no names, no tracking, and signing up is
+idempotent: re-subscribing keeps the original record and returns the same
+response, so nothing leaks about whether an address was already on the list.
+
+This Worker only keeps the list — it sends nothing. Actually mailing the
+newsletter means exporting the list (below) into whatever does the sending.
+Two consequences to stay honest about:
+
+- **No double opt-in (yet).** Sending a confirmation email needs an email
+  provider; when one is chosen, confirmation belongs there (or as a
+  `pending:` state here). Until then anyone can enter any address, which is
+  why every sent mail must carry an unsubscribe path.
+- **Unsubscribe is manual in v1.** Requests arrive at
+  `support@blancbrowser.com` (linked from every mail and the privacy
+  policy); remove the address with the `DELETE` endpoint below. A proper
+  self-serve link comes with the sending provider.
+
+Anti-abuse, in order: CORS restricted to `blancbrowser.com` (+ Astro's
+localhost dev origin), a visually-hidden `website` honeypot field (a filled
+honeypot gets a 200 and writes nothing), a per-IP limit of 6 subscribes per
+minute, and loose email-shape validation capped at 254 chars.
+
+## Deploy
+
+Requires a Cloudflare account and `wrangler` (installed on demand via `npx`,
+no need to add it as a repo dependency).
+
+```
+cd cloudflare/newsletter-worker
+npx wrangler login                                 # opens a browser to authorize
+npx wrangler kv namespace create SUBSCRIBERS       # copy the returned id into wrangler.toml
+npx wrangler secret put ADMIN_TOKEN                # pick any long random string, save it somewhere safe
+npx wrangler deploy
+```
+
+`wrangler deploy` prints the live URL, something like
+`https://blanc-newsletter.<your-subdomain>.workers.dev`. The footer form
+posts to the `NEWSLETTER_ENDPOINT` constant in
+`site/src/components/Footer.astro` — update it if the URL differs, then
+redeploy the site.
+
+To attach it to `api.blancbrowser.com` instead of the `workers.dev`
+subdomain, add a route in the Cloudflare dashboard (Workers & Pages →
+blanc-newsletter → Settings → Triggers → Custom Domains) once
+`blancbrowser.com`'s DNS is on Cloudflare. Note the form's endpoint constant
+lives in `NewsletterForm.astro`, not here — changing the URL means a site
+redeploy too.
+
+## Exporting the list
+
+```
+curl -H "Authorization: Bearer <ADMIN_TOKEN>" https://<worker-url>/subscribers
+```
+
+Returns JSON like:
+
+```json
+{
+  "count": 2,
+  "subscribers": [
+    { "email": "a@example.com", "ts": "2026-07-23T10:00:00.000Z" },
+    { "email": "b@example.com", "ts": "2026-07-24T09:30:00.000Z" }
+  ]
+}
+```
+
+## Removing an address (unsubscribe / data deletion)
+
+```
+curl -X DELETE -H "Authorization: Bearer <ADMIN_TOKEN>" \
+  "https://<worker-url>/subscriber?email=a@example.com"
+```
+
+204 either way — removing an address that isn't on the list is a no-op.
+Do this promptly for any unsubscribe or deletion request; the privacy
+policy promises it.

--- a/cloudflare/newsletter-worker/package.json
+++ b/cloudflare/newsletter-worker/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "blanc-newsletter-worker",
+  "private": true,
+  "type": "module"
+}

--- a/cloudflare/newsletter-worker/src/index.js
+++ b/cloudflare/newsletter-worker/src/index.js
@@ -17,6 +17,7 @@ const ALLOWED_ORIGINS = new Set([
 ]);
 
 const SUBSCRIBE_RATE_LIMIT = 6; // per client IP per minute
+const QUARANTINE_TTL = 30 * 24 * 3600; // honeypot-caught addresses self-clean
 
 const json = (obj, status = 200, headers = {}) =>
   new Response(JSON.stringify(obj), {
@@ -61,17 +62,30 @@ async function handleSubscribe(request, env, cors) {
   }
   if (!body || typeof body !== 'object') return json({ error: 'bad request' }, 400, cors);
 
-  // Honeypot: the form ships a visually-hidden "website" field humans never
-  // fill. A bot that does gets a cheerful 200 and writes nothing.
+  const email =
+    typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const emailValid = email.length <= MAX_EMAIL_LENGTH && EMAIL_RE.test(email);
+
+  // Honeypot: the form ships a visually-hidden "website" field humans can't
+  // reach (off-screen, untabbable). A bot that fills it gets a cheerful 200
+  // and stays off the list — but the address is QUARANTINED under hp: for 30
+  // days rather than discarded, because the one way a real person lands here
+  // is browser/password-manager autofill filling the hidden field. They see
+  // "subscribed", so the miss would otherwise be invisible; the quarantine
+  // shows up in the /subscribers export, where a plausible-looking entry can
+  // be rescued by re-POSTing its email to /subscribe without the field.
   if (typeof body.website === 'string' && body.website.trim() !== '') {
+    if (emailValid && (await env.SUBSCRIBERS.get(`sub:${email}`)) === null) {
+      await env.SUBSCRIBERS.put(
+        `hp:${email}`,
+        JSON.stringify({ ts: new Date().toISOString() }),
+        { expirationTtl: QUARANTINE_TTL }
+      );
+    }
     return json({ ok: true }, 200, cors);
   }
 
-  const email =
-    typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
-  if (email.length > MAX_EMAIL_LENGTH || !EMAIL_RE.test(email)) {
-    return json({ error: 'invalid email' }, 400, cors);
-  }
+  if (!emailValid) return json({ error: 'invalid email' }, 400, cors);
 
   // Idempotent: re-subscribing an existing address keeps the original record
   // (first-seen timestamp survives) and returns the same 200, so the response
@@ -86,24 +100,34 @@ async function handleSubscribe(request, env, cors) {
 const authorized = (request, env) =>
   env.ADMIN_TOKEN && request.headers.get('Authorization') === `Bearer ${env.ADMIN_TOKEN}`;
 
-// GET /subscribers — bearer-token-gated export for whatever actually sends the
-// newsletter. Plain JSON: count + [{email, ts}].
-async function handleExport(env) {
-  const subscribers = [];
+async function listPrefix(env, prefix) {
+  const entries = [];
   let cursor;
   do {
-    const res = await env.SUBSCRIBERS.list({ prefix: 'sub:', cursor });
-    const entries = await Promise.all(
-      res.keys.map(async ({ name }) => ({
-        email: name.slice('sub:'.length),
-        ...(await env.SUBSCRIBERS.get(name, { type: 'json' })),
-      }))
+    const res = await env.SUBSCRIBERS.list({ prefix, cursor });
+    entries.push(
+      ...(await Promise.all(
+        res.keys.map(async ({ name }) => ({
+          email: name.slice(prefix.length),
+          ...(await env.SUBSCRIBERS.get(name, { type: 'json' })),
+        }))
+      ))
     );
-    subscribers.push(...entries);
     cursor = res.list_complete ? undefined : res.cursor;
   } while (cursor);
-  subscribers.sort((a, b) => (a.ts < b.ts ? -1 : 1));
-  return json({ count: subscribers.length, subscribers });
+  entries.sort((a, b) => (a.ts < b.ts ? -1 : 1));
+  return entries;
+}
+
+// GET /subscribers — bearer-token-gated export for whatever actually sends the
+// newsletter. Plain JSON: count + [{email, ts}], plus the honeypot quarantine
+// (see handleSubscribe) so autofill false-positives are visible, not lost.
+async function handleExport(env) {
+  const [subscribers, quarantined] = await Promise.all([
+    listPrefix(env, 'sub:'),
+    listPrefix(env, 'hp:'),
+  ]);
+  return json({ count: subscribers.length, subscribers, quarantined });
 }
 
 // DELETE /subscriber?email=… — bearer-token-gated removal, for unsubscribe and
@@ -112,7 +136,10 @@ async function handleExport(env) {
 async function handleRemove(env, url) {
   const email = (url.searchParams.get('email') ?? '').trim().toLowerCase();
   if (!email) return json({ error: 'email required' }, 400);
-  await env.SUBSCRIBERS.delete(`sub:${email}`);
+  await Promise.all([
+    env.SUBSCRIBERS.delete(`sub:${email}`),
+    env.SUBSCRIBERS.delete(`hp:${email}`),
+  ]);
   return new Response(null, { status: 204 });
 }
 

--- a/cloudflare/newsletter-worker/src/index.js
+++ b/cloudflare/newsletter-worker/src/index.js
@@ -1,0 +1,135 @@
+// Newsletter signup store for blancbrowser.com's footer form. Holds ONLY the
+// email address and when it arrived — no IPs at rest, no names, no tracking,
+// mirroring the honesty of cloudflare/ping-worker and sync-worker. Blanc's
+// newsletter is release notes at most; sending happens elsewhere (export via
+// GET /subscribers), this Worker just keeps the list.
+
+const MAX_EMAIL_LENGTH = 254; // RFC 5321 path limit
+// Deliberately loose: real validation is the confirmation reality of sending
+// mail there. This only rejects obvious non-addresses before they hit KV.
+const EMAIL_RE = /^[^\s@]{1,64}@[^\s@]+\.[^\s@]{2,}$/;
+
+// The form posts cross-origin (Pages site → workers.dev), so CORS is required.
+// localhost is Astro's dev server.
+const ALLOWED_ORIGINS = new Set([
+  'https://blancbrowser.com',
+  'http://localhost:4321',
+]);
+
+const SUBSCRIBE_RATE_LIMIT = 6; // per client IP per minute
+
+const json = (obj, status = 200, headers = {}) =>
+  new Response(JSON.stringify(obj), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+
+function corsHeaders(request) {
+  const origin = request.headers.get('Origin');
+  if (!origin || !ALLOWED_ORIGINS.has(origin)) return {};
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
+  };
+}
+
+// Same coarse KV counter as sync-worker's bumpLimited: the IP appears only in
+// a rate-limit key that expires within two minutes — never in the subscriber
+// records themselves.
+async function ipRateLimited(env, ip) {
+  if (!ip) return false;
+  const key = `ip:${ip}:${Math.floor(Date.now() / 60000)}`;
+  const n = parseInt((await env.SUBSCRIBERS.get(key)) ?? '0', 10);
+  if (n >= SUBSCRIBE_RATE_LIMIT) return true;
+  await env.SUBSCRIBERS.put(key, String(n + 1), { expirationTtl: 120 });
+  return false;
+}
+
+async function handleSubscribe(request, env, cors) {
+  if (await ipRateLimited(env, request.headers.get('CF-Connecting-IP'))) {
+    return json({ error: 'rate-limited' }, 429, cors);
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'bad request' }, 400, cors);
+  }
+  if (!body || typeof body !== 'object') return json({ error: 'bad request' }, 400, cors);
+
+  // Honeypot: the form ships a visually-hidden "website" field humans never
+  // fill. A bot that does gets a cheerful 200 and writes nothing.
+  if (typeof body.website === 'string' && body.website.trim() !== '') {
+    return json({ ok: true }, 200, cors);
+  }
+
+  const email =
+    typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  if (email.length > MAX_EMAIL_LENGTH || !EMAIL_RE.test(email)) {
+    return json({ error: 'invalid email' }, 400, cors);
+  }
+
+  // Idempotent: re-subscribing an existing address keeps the original record
+  // (first-seen timestamp survives) and returns the same 200, so the response
+  // never leaks whether an address was already on the list.
+  const key = `sub:${email}`;
+  if ((await env.SUBSCRIBERS.get(key)) === null) {
+    await env.SUBSCRIBERS.put(key, JSON.stringify({ ts: new Date().toISOString() }));
+  }
+  return json({ ok: true }, 200, cors);
+}
+
+const authorized = (request, env) =>
+  env.ADMIN_TOKEN && request.headers.get('Authorization') === `Bearer ${env.ADMIN_TOKEN}`;
+
+// GET /subscribers — bearer-token-gated export for whatever actually sends the
+// newsletter. Plain JSON: count + [{email, ts}].
+async function handleExport(env) {
+  const subscribers = [];
+  let cursor;
+  do {
+    const res = await env.SUBSCRIBERS.list({ prefix: 'sub:', cursor });
+    const entries = await Promise.all(
+      res.keys.map(async ({ name }) => ({
+        email: name.slice('sub:'.length),
+        ...(await env.SUBSCRIBERS.get(name, { type: 'json' })),
+      }))
+    );
+    subscribers.push(...entries);
+    cursor = res.list_complete ? undefined : res.cursor;
+  } while (cursor);
+  subscribers.sort((a, b) => (a.ts < b.ts ? -1 : 1));
+  return json({ count: subscribers.length, subscribers });
+}
+
+// DELETE /subscriber?email=… — bearer-token-gated removal, for unsubscribe and
+// data-deletion requests (they arrive at support@blancbrowser.com; every sent
+// mail links there). 204 either way — deleting an absent address is a no-op.
+async function handleRemove(env, url) {
+  const email = (url.searchParams.get('email') ?? '').trim().toLowerCase();
+  if (!email) return json({ error: 'email required' }, 400);
+  await env.SUBSCRIBERS.delete(`sub:${email}`);
+  return new Response(null, { status: 204 });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const cors = corsHeaders(request);
+
+    if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+    if (request.method === 'POST' && url.pathname === '/subscribe') {
+      return handleSubscribe(request, env, cors);
+    }
+    if (url.pathname === '/subscribers' || url.pathname === '/subscriber') {
+      if (!authorized(request, env)) return new Response('unauthorized', { status: 401 });
+      if (request.method === 'GET' && url.pathname === '/subscribers') return handleExport(env);
+      if (request.method === 'DELETE' && url.pathname === '/subscriber') return handleRemove(env, url);
+    }
+    return new Response('not found', { status: 404 });
+  },
+};

--- a/cloudflare/newsletter-worker/wrangler.toml
+++ b/cloudflare/newsletter-worker/wrangler.toml
@@ -7,10 +7,11 @@ kv_namespaces = [
   { binding = "SUBSCRIBERS", id = "" }
 ]
 
-# ADMIN_TOKEN is a secret, not a var — set it with:
-#   wrangler secret put ADMIN_TOKEN
-# It gates GET /subscribers (export) and DELETE /subscriber (removal). Without
-# it those endpoints refuse every request (fail closed); /subscribe still works.
+# ADMIN_TOKEN is a secret, not a var — it lives in 1Password (vault Dev, item
+# "Blanc Newsletter Admin") and is piped into `wrangler secret put ADMIN_TOKEN`
+# via `op read`; see README.md for the exact commands. It gates GET /subscribers
+# (export) and DELETE /subscriber (removal). Without it those endpoints refuse
+# every request (fail closed); /subscribe still works.
 
 # Workers Logs — keeps a searchable history of invocations/exceptions in the
 # dashboard, so a runtime 500 can be diagnosed after the fact instead of

--- a/cloudflare/newsletter-worker/wrangler.toml
+++ b/cloudflare/newsletter-worker/wrangler.toml
@@ -1,0 +1,19 @@
+name = "blanc-newsletter"
+main = "src/index.js"
+compatibility_date = "2026-07-01"
+
+# Created by `wrangler kv namespace create SUBSCRIBERS` — paste the returned id below.
+kv_namespaces = [
+  { binding = "SUBSCRIBERS", id = "" }
+]
+
+# ADMIN_TOKEN is a secret, not a var — set it with:
+#   wrangler secret put ADMIN_TOKEN
+# It gates GET /subscribers (export) and DELETE /subscriber (removal). Without
+# it those endpoints refuse every request (fail closed); /subscribe still works.
+
+# Workers Logs — keeps a searchable history of invocations/exceptions in the
+# dashboard, so a runtime 500 can be diagnosed after the fact instead of
+# only while `wrangler tail` happens to be attached.
+[observability]
+enabled = true

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -47,8 +47,10 @@ resolve at build time, so the routine post-release redeploy picks them up.
 rendered by both `Footer.astro` variants, legal pages included — it's a form,
 not analytics) posts `{email, website}` to the `blanc-newsletter` Worker
 (`cloudflare/newsletter-worker/` in the repo root; deploy/export/unsubscribe
-runbook in its README). `website` is a honeypot the Worker silently drops when
-filled. The endpoint constant lives in the component, so a Worker URL change
+runbook in its README). `website` is a honeypot; the Worker keeps a filled one
+off the list but quarantines the address (`hp:`, 30-day TTL, visible in the
+export) since autofill is the one way a human trips it — see the README.
+The endpoint constant lives in the component, so a Worker URL change
 means a site redeploy. The Worker stores only email + signup timestamp in KV;
 no double opt-in yet and unsubscribe is manual (token-gated DELETE) until a
 sending provider is chosen. The privacy page's "Newsletter (optional)" section

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -43,6 +43,17 @@ freshness guard (release-time/manual — not in CI; needs `gh`). Never hand-edit
 longer seds any site file — the JSON-LD version and sitemap `lastmod` both
 resolve at build time, so the routine post-release redeploy picks them up.
 
+**Newsletter signup:** the footer form (`src/components/NewsletterForm.astro`,
+rendered by both `Footer.astro` variants, legal pages included — it's a form,
+not analytics) posts `{email, website}` to the `blanc-newsletter` Worker
+(`cloudflare/newsletter-worker/` in the repo root; deploy/export/unsubscribe
+runbook in its README). `website` is a honeypot the Worker silently drops when
+filled. The endpoint constant lives in the component, so a Worker URL change
+means a site redeploy. The Worker stores only email + signup timestamp in KV;
+no double opt-in yet and unsubscribe is manual (token-gated DELETE) until a
+sending provider is chosen. The privacy page's "Newsletter (optional)" section
+describes exactly this contract — change them together or not at all.
+
 **Sitemap:** `src/pages/sitemap.xml.js` — an explicit route manifest with
 per-route `changefreq`/`priority`, asserted at build time against the real
 page list (adding/removing a page without updating the manifest fails the

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,13 +1,16 @@
 ---
+import NewsletterForm from './NewsletterForm.astro';
 const { variant = 'compact' } = Astro.props;
 ---
 {variant === 'compact' ? (
   <footer class="compact-footer">
+    <NewsletterForm />
     <span>built independently · no investors · © 2026 · <a href="https://bnfy.me" target="_blank" rel="noopener">Bananify</a></span>
     <span><a href="/features">Features</a> · <a href="/about">About</a> · <a href="/changelog">Changelog</a> · <a href="/download">Download</a> · <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a></span>
   </footer>
 ) : (
   <footer>
+    <NewsletterForm />
     <span class="foot-copy">built independently · no investors · © 2026 · <a href="https://bnfy.me" target="_blank" rel="noopener">Bananify</a></span>
     <span class="foot-links">
       <a href="/features">Features</a>

--- a/site/src/components/NewsletterForm.astro
+++ b/site/src/components/NewsletterForm.astro
@@ -1,0 +1,52 @@
+---
+// Footer newsletter signup. Posts to the blanc-newsletter Worker
+// (cloudflare/newsletter-worker/ in the main repo) — the list lives in
+// Workers KV there; see its README for the deploy/export/unsubscribe runbook.
+// The "website" field is a honeypot: visually hidden, skipped by keyboard and
+// screen readers, and any bot that fills it is silently dropped server-side.
+---
+<form class="foot-news" data-newsletter>
+  <label class="foot-news-label" for="newsletterEmail">release notes by email, occasional —</label>
+  <span class="foot-news-controls">
+    <input id="newsletterEmail" name="email" type="email" required maxlength="254" placeholder="you@example.com" autocomplete="email">
+    <input class="foot-news-hp" type="text" name="website" tabindex="-1" autocomplete="off" aria-hidden="true">
+    <button type="submit" data-track="newsletter_subscribe">subscribe</button>
+  </span>
+  <span class="foot-news-status" role="status" aria-live="polite"></span>
+</form>
+<script>
+  const NEWSLETTER_ENDPOINT = 'https://blanc-newsletter.bnfy-441.workers.dev/subscribe';
+
+  document.querySelectorAll('form[data-newsletter]').forEach((form) => {
+    const status = form.querySelector('.foot-news-status');
+    const button = form.querySelector('button');
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      status.textContent = '';
+      button.disabled = true;
+      try {
+        const response = await fetch(NEWSLETTER_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: form.elements.email.value.trim(),
+            website: form.elements.website.value,
+          }),
+        });
+        if (response.ok) {
+          form.querySelector('.foot-news-controls').hidden = true;
+          form.querySelector('.foot-news-label').hidden = true;
+          status.textContent = 'subscribed — see you at the next release';
+        } else if (response.status === 400) {
+          status.textContent = 'that address didn’t look right — try again?';
+        } else {
+          status.textContent = 'couldn’t subscribe just now — try again later';
+        }
+      } catch {
+        status.textContent = 'couldn’t subscribe just now — try again later';
+      } finally {
+        button.disabled = false;
+      }
+    });
+  });
+</script>

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -14,10 +14,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <main class="legal-doc">
   <p class="eyebrow">privacy</p>
   <h1>Privacy Policy</h1>
-  <p class="legal-updated">Last updated: July 22, 2026</p>
+  <p class="legal-updated">Last updated: July 23, 2026</p>
 
   <div class="legal-tldr">
-    <p><strong>The short version.</strong> Blanc is built to collect as little as possible. Your browsing history, downloads, and favorites stay on your device — we never receive them. The installed app sends one small usage ping you can switch off, and nothing else leaves your device unless you opt in. This website uses analytics only if you allow it.</p>
+    <p><strong>The short version.</strong> Blanc is built to collect as little as possible. Your browsing history, downloads, and favorites stay on your device — we never receive them. The installed app sends one small usage ping you can switch off, and nothing else leaves your device unless you opt in. This website uses analytics only if you allow it, and its newsletter only ever knows your email address if you choose to give it.</p>
   </div>
 
   <h2>Who this covers</h2>
@@ -89,6 +89,15 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </ul>
   <p>We run no advertising networks and no cross-site trackers here, and we don't sell your data.</p>
 
+  <h3>Newsletter (optional)</h3>
+  <p>The site's footer has a small form where you can leave your email address to get Blanc's release notes by email. If you use it, here is everything that happens:</p>
+  <ul>
+    <li>We store <strong>your email address and the time you signed up — nothing else.</strong> No name, no IP address, and nothing about your visit is kept alongside it.</li>
+    <li>The list lives in our own storage (a Cloudflare Workers datastore we operate) — no newsletter service or marketing platform receives it.</li>
+    <li>We use it only to send occasional release notes. It's never shared, sold, or linked to any other data — including the app's usage ping.</li>
+    <li>Every email we send includes an unsubscribe path, and you can also just write to <a href="mailto:support@blancbrowser.com">support@blancbrowser.com</a> — we'll delete your address promptly either way.</li>
+  </ul>
+
   <h2>Children</h2>
   <p>Blanc isn't directed at children under 13, and we don't knowingly collect personal information from them.</p>
 
@@ -100,6 +109,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <li>Reset your install ID with the "Reset install ID" button in Settings, or by clearing the app's data.</li>
     <li>Clear your history, downloads, and favorites from within Blanc.</li>
     <li>Allow or decline analytics on this site, and change your mind by clearing the site's stored choice in your browser.</li>
+    <li>Skip the newsletter entirely, or unsubscribe any time — your address is deleted, not just muted.</li>
   </ul>
   <p>If you're in the European Union, the United Kingdom, California, or a similar place, you have rights over your personal data, including the right to access or delete it. We don't sell personal data. Because we hold so little — a pseudonymous install ping and, only if you enable sync, encrypted data we can't read — there's usually very little to act on, but you're welcome to email us at <a href="mailto:support@blancbrowser.com">support@blancbrowser.com</a> with any request.</p>
 

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -396,7 +396,7 @@ a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outlin
 .download-note + .download-details { margin-top: 128px; }
 .download-note > p:not(.section-kicker) a { color: inherit; border-bottom: 1px solid var(--border); padding-bottom: 1px; text-decoration: none; transition: color 0.15s, border-color 0.15s; }
 .download-note > p:not(.section-kicker) a:hover { color: var(--accent); border-color: var(--accent); }
-.compact-footer { display: flex; flex-direction: row; justify-content: space-between; gap: 14px 30px; padding: 22px max(24px, calc((100vw - 1132px) / 2)); border-top: 1px solid var(--border); font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); opacity: 0.8; }
+.compact-footer { display: flex; flex-direction: row; flex-wrap: wrap; justify-content: space-between; gap: 14px 30px; padding: 22px max(24px, calc((100vw - 1132px) / 2)); border-top: 1px solid var(--border); font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); opacity: 0.8; }
 .compact-footer b { color: var(--accent); font-weight: 400; }
 
 /* ---------- changelog ---------- */
@@ -524,6 +524,20 @@ footer .foot-ic svg { width: 14px; height: 14px; display: block; fill: currentCo
    of the fill (path geometry untouched) so the two brand marks sit closer
    in visual weight without turning bold. */
 footer .foot-ic.ig svg path { stroke: currentColor; stroke-width: 0.35; stroke-linejoin: round; stroke-linecap: round; }
+
+/* Footer newsletter signup (both footer variants) — posts to the
+   blanc-newsletter Worker; see site/src/components/NewsletterForm.astro. */
+.foot-news { display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 8px 10px; font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); }
+.compact-footer .foot-news { flex-basis: 100%; justify-content: flex-start; }
+.foot-news-controls { display: inline-flex; align-items: center; gap: 8px; }
+.foot-news [hidden] { display: none; }
+.foot-news input[type="email"] { width: 200px; padding: 6px 10px; font-family: var(--font-mono); font-size: 12px; color: var(--text); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); transition: border-color 0.15s, background 0.15s; }
+.foot-news input[type="email"]::placeholder { color: var(--text-dim); }
+.foot-news input[type="email"]:focus { outline: none; border-color: var(--accent); background: var(--bg); }
+.foot-news button { font-family: var(--font-mono); font-size: 12px; padding: 6px 12px; border-radius: var(--radius); border: 1px solid var(--accent); background: var(--accent); color: var(--bg); cursor: pointer; }
+.foot-news button:disabled { opacity: 0.6; cursor: default; }
+.foot-news-hp { position: absolute; left: -9999px; width: 1px; height: 1px; opacity: 0; }
+.foot-news-status:empty { display: none; }
 
 @media (max-width: 480px) {
   html { scroll-padding-top: 64px; }

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -596,6 +596,7 @@ footer .foot-ic.ig svg path { stroke: currentColor; stroke-width: 0.35; stroke-l
   .download-details { grid-template-columns: 1fr; gap: 36px; padding-bottom: 72px; }
   .download-footnote { grid-template-columns: 1fr; gap: 14px; }
   .compact-footer { flex-direction: column; padding: 20px 18px; text-align: center; }
+  .compact-footer .foot-news { justify-content: center; }
   .feature-page { padding: 0 18px 72px; }
   .breadcrumb { padding-top: 24px; }
   .feature-hero--hub { padding: 78px 0 58px; }


### PR DESCRIPTION
Adds a privacy-respecting newsletter signup system for blancbrowser.com's footer, consisting of a new Cloudflare Worker and corresponding frontend form component.

## Summary

Implements an email newsletter signup that stores only the subscriber's email address and signup timestamp in Workers KV, with no IP logging at rest, no names, and no tracking. The system includes anti-abuse measures (CORS restriction, honeypot field, per-IP rate limiting) and token-gated admin endpoints for exporting the subscriber list and removing addresses.

## Key changes

- **New Worker (`cloudflare/newsletter-worker/`):** Handles `POST /subscribe` to collect signups, `GET /subscribers` to export the list (token-gated), and `DELETE /subscriber` for unsubscribe/deletion requests (token-gated). Stores `sub:<email>` → `{ts}` in KV; honeypot-caught addresses go to `hp:<email>` with a 30-day TTL instead of the list, visible in exports so autofill false-positives can be rescued by re-posting without the honeypot field.

- **Newsletter form component (`site/src/components/NewsletterForm.astro`):** Visually-hidden honeypot field (off-screen, untabbable, `aria-hidden`), client-side form submission to the Worker, and user-friendly status messages. Integrated into both footer variants.

- **Privacy policy update (`site/src/pages/privacy.astro`):** New "Newsletter (optional)" section documenting the exact data collected (email + timestamp only), no double opt-in yet, and manual unsubscribe via support email until a sending provider is chosen.

- **Footer layout adjustment (`site/src/styles/site.css`):** Added `flex-wrap: wrap` to `.compact-footer` to accommodate the newsletter form, plus styling for `.foot-news` and related elements.

- **Documentation (`cloudflare/newsletter-worker/README.md`):** Complete deploy/export/unsubscribe runbook, including 1Password credential setup via `op` and honeypot quarantine explanation.

- **Configuration files:** `wrangler.toml` for the Worker, `package.json` for the Worker package, and `.env.1password` for Cloudflare API token resolution.

## Notable implementation details

- **Honeypot quarantine:** Addresses that trigger the honeypot are stored under `hp:` with a 30-day TTL instead of being discarded, because the only way a real person trips it is via browser/password-manager autofill. They see "subscribed" but are silently not stored; the quarantine makes the miss visible in exports so plausible entries can be rescued.

- **Idempotent signup:** Re-subscribing an existing address keeps the original record (first-seen timestamp survives) and returns the same 200, preventing information leakage about whether an address was already on the list.

- **Rate limiting:** Per-IP limit of 6 subscribes per minute; the IP appears only in a rate-limit key that expires within two minutes, never in subscriber records.

- **Admin token:** Stored as a secret in 1Password (vault Dev, item "Blanc Newsletter Admin"), piped into `wrangler secret put` via `op read` — no unauthenticated fallback, fails loudly if the token can't be resolved.

- **CORS:** Restricted to `https://blancbrowser.com` and `http://localhost:4321` (Astro dev server).

https://claude.ai/code/session_01AcQDDdd7J8XmjEgXCANSSW