### PR TITLE
Sync tab favicons safely

### DIFF
--- a/cloudflare/sync-worker/README.md
+++ b/cloudflare/sync-worker/README.md
@@ -24,8 +24,9 @@ data — no IPs, no ids, no browsing data, consistent with `../ping-worker`.
 - `DELETE /v1/blob/:accountId` → 204 (account wipe)
 
 `accountId` is 64 hex chars; `store` is one of `bookmarks`, `settings`,
-`session` (tab sync — per-device open-tab snapshots, ciphertext like the
-rest). No
+`session` (tab sync — per-device open-tab snapshots), or `icons` (optional
+source-rasterized tab favicons, kept separate for mixed-client compatibility
+and budget isolation). Every store is ciphertext like the rest. No
 secrets or tokens: possession of the (unguessable) `accountId` is the
 capability. A per-client-IP limit (120/min, all methods) is the anti-guessing
 throttle — each passphrase guess derives a fresh `accountId`, so the

--- a/cloudflare/sync-worker/src/index.js
+++ b/cloudflare/sync-worker/src/index.js
@@ -4,7 +4,7 @@
 // cloudflare/ping-worker: no IPs, no ids, no browsing data. See the design
 // spec in the main repo (docs/superpowers/specs/2026-07-07-profile-sync-design.md).
 
-const STORES = new Set(['bookmarks', 'settings', 'session']); // history may follow later
+const STORES = new Set(['bookmarks', 'settings', 'session', 'icons']); // history may follow later
 const MAX_BLOB_BYTES = 512 * 1024;                 // favorites+settings are tiny; raise for history
 const RATE_LIMIT = 30;                             // GETs per accountId per minute — anti-hammering of one account
 const IP_RATE_LIMIT = 120;                         // requests per client IP per minute — the anti-guessing throttle

--- a/docs/superpowers/specs/2026-07-21-tab-sync-design.md
+++ b/docs/superpowers/specs/2026-07-21-tab-sync-design.md
@@ -1,12 +1,12 @@
 # Tab Sync — open tabs from your other devices
 
-**Date:** 2026-07-21 (revised 2026-07-22)
+**Date:** 2026-07-21 (revised 2026-07-23)
 **Status:** Approved
 **Builds on:** [2026-07-07-profile-sync-design.md](2026-07-07-profile-sync-design.md) — this is the "session" store that spec deferred (§4, v2+) and the worker reserved (`// history/session added in a later phase`).
 
 ## 1. What this is
 
-Profile Sync grows a third store: each device publishes a snapshot of its open tabs (with groups and pinned state), and every other synced device can browse that snapshot read-only and open individual tabs locally. This is the Firefox/Safari "tabs from other devices" model — **not** a merged live session. Nothing ever force-opens or closes a tab on another machine; the snapshot is a menu, not a mirror.
+Profile Sync grows a third store: each device publishes a snapshot of its open tabs (with groups and pinned state), and every other synced device can browse that snapshot read-only and open individual tabs locally. An optional fourth `icons` store supplies inert favicon pixels without changing the already-deployed session schema. This is the Firefox/Safari "tabs from other devices" model — **not** a merged live session. Nothing ever force-opens or closes a tab on another machine; the snapshot is a menu, not a mirror.
 
 Chosen over two alternatives during brainstorming:
 - **Workspace hand-off** (explicit push/pull of the whole session) — rejected as less ambient; the passive list covers the hand-off case (open the tabs you want) without a new verb.
@@ -44,11 +44,45 @@ devices: {
 }
 ```
 
+Favicons deliberately do **not** extend this deployed shape. Older clients
+rebuild every tab from known fields and re-upload the whole map, so an
+additive field here would be stripped and repaired forever in a mixed-version
+account. Updated clients instead use an optional, separately encrypted
+`icons` sidecar:
+
+```
+devices: {
+  <deviceId>: {
+    updatedAt,
+    retracted?,
+    icons: [{ url, data }], // data:image/png only
+  }
+}
+```
+
+The publishing device resolves the favicon in the browsing session that
+already has the page open, but sends no cookies or referrer. HTTP responses
+must be successful, declare an image content type, arrive within three
+seconds, and stay under 256 KB. Redirects are disabled, and localhost,
+`.local`, loopback, link-local, RFC1918/unique-local, and other reserved
+literal targets are rejected before fetch so capture cannot become a new LAN
+probe. The source is then decoded and rasterized to a 16×16 PNG; only a
+bounded `data:image/png;base64,...` value with a valid PNG signature/IHDR and
+16×16 dimensions can enter the sidecar or renderer projection. Receiving
+chrome never contacts a remote tab's site merely to draw the list. The
+sidecar has its own 256 KB plaintext budget and discards cosmetic icon records
+before its limit; it can never evict a tab or device from the primary session
+snapshot. Workers deployed before the sidecar return 404 for `icons`; clients
+treat that optional-store rejection as a quiet no-op and retain the normal
+fallback glyph. Capture work is globally bounded, queued sources are replaced
+per tab so URL/favicon churn keeps only the newest state, and changing the sync
+account or tab-sharing consent drains queued work and aborts active requests.
+
 - **`deviceId`** is a random UUID minted lazily, stored in `sync.json`. It is deliberately **not** the telemetry `installId` — nothing may attach to that identifier (CLAUDE.md), and browsing data least of all.
 - **Account binding:** the store records the `accountId` its `devices` map was merged against. Whenever the current sync `accountId` differs (credentials changed — disable/re-enable with a new handle or passphrase), all cached remote entries are **discarded** before the first export, merge, **or read** (`getRemoteDevices`/`heartbeatDue` rebind too — a mismatched file pair must never render another account's cache; PR #41 review). The local `deviceId` survives the rebind; our own entry is rebuilt from live tabs anyway.
 - **In-flight isolation:** every sync pass snapshots a credential/consent **generation** plus one immutable tab-sync context at start; the generation is re-checked after every await and the pass aborts ("stranded") the moment credentials, account, or the share toggle change — so a response from the old account is never merged, exported, or re-uploaded under the new one (PR #41 review, P1). Checkpoints alone can't recall a PUT already on the wire, so **`disable()` additionally drains**: it suspends new passes, strands the active one, and awaits its full settlement — network included — before issuing the wipe DELETE or clearing credentials. This applies to plain disable too, not just wipes — a deliberate tradeoff: turning sync off may wait on a stalled request, in exchange for the stronger guarantee that once `disable()` returns, no write ever lands under the old identity. Pinned by a deferred-fetch regression test (`test/unit/sync-wipe-race.test.js`) that runs the real `sync.js` under node with `electron` stubbed.
 - **Snapshot contents** derive from the same entry-building logic `persistSession` uses, extracted into a small **pure module `src/main/session-snapshot.js`** (no `electron` import — `main.js` isn't loadable under `node --test`; `sync-wipe.js` is the precedent). It exposes two shapes: `persistableEntries(tabs)` — exactly today's `persistSession` semantics (private tabs and private-only groups excluded, `blanc://error` unwrapped), used unchanged for `session.json` — and `syncSnapshot(entries, groups)`, which additionally applies the portability filter for the synced copy.
-- **Portability filter (sync snapshot only):** `http:`/`https:` URLs only — `file://` paths don't exist on other machines and `blanc://` internal pages aren't worth a row; URLs longer than 2048 chars are skipped; titles truncated to 200 chars; at most 500 tabs per device. `session.json` keeps persisting everything it does today; only the synced snapshot is filtered.
+- **Portability filter (sync snapshot only):** `http:`/`https:` URLs only — `file://` paths don't exist on other machines and `blanc://` internal pages aren't worth a row; URLs longer than 2048 chars are skipped; titles truncated to 200 chars; at most 500 tabs per device. `session.json` keeps persisting everything it does today; only the synced snapshot is filtered. Icon-source URLs never enter this shape.
 - Snapshots mirror `session.json`'s persistable data but flow through their own store; `session.json` itself is untouched.
 
 ## 5. Merge semantics
@@ -63,21 +97,22 @@ Union by `deviceId`, last-writer-wins per entry on `updatedAt`. Each device only
 
 ## 6. Sync integration
 
-- `sync.js`'s `STORES` gains `{ name: 'session', export: tabsync.exportForSync, merge: tabsync.mergeFromSync }`. Order still doesn't matter.
-- **Scheduling — separate timer, fingerprint-gated.** `sync.js` has one trailing timer today, and `schedule()` clears it on every call — so high-churn tab events routed through it would keep postponing a pending 4s favorites/settings sync indefinitely. Tab-driven syncs therefore get their **own trailing timer** (15s debounce) that never touches the existing one. And because `persistSession` runs inside `broadcastTabs()` — which also fires for blocked-count ticks and loading-flag flips (~10/s during loads) — the tab trigger is gated by a **snapshot fingerprint**: a hash of the canonical serialization of the **complete publishable snapshot** — device name and platform, ordered tabs with `url`/`title`/`groupId`/`pinned`, and the groups list with ids, names, and order — excluding only transient fields (`updatedAt`). Moving a tab between groups, reordering tabs or groups, or a hostname rename all change it and schedule; blocked-count ticks and loading-flag flips don't.
-- **Freshness — pull on focus/panel-open.** Local-change triggers alone never make another device's tabs appear on an *idle* machine (it would only pull at launch or after its own edits). So the receiving side gets a **session-store-only refresh** — pull + merge — triggered when the window regains focus (`browser-window-focus`) and when the ⌘L panel opens (`showOverlay('panel'|'palette')`), throttled to at most once per 60 s, only while sync is enabled. The PUT decision after the pull is **not** "did our fingerprint change" — that would never repair a remote blob that lost our unchanged entry in a race (e.g. another device's budget drop). Instead: compare the canonical bounded export against the decrypted remote map and **PUT whenever they differ**; skip only a true no-op. The fingerprint gates *scheduling*; the export-vs-remote comparison gates the *write*. Session-only keeps the refresh off the bookmarks/settings blobs and well inside the worker's 30 GETs/min per-account limit.
-- **Heartbeat:** while sharing is enabled, republish our entry (an `updatedAt` bump through the normal session sync path) once per **24 h** even when nothing changed — otherwise a continuously running device with stable tabs would silently age past the 30-day prune on every other device.
+- `sync.js`'s `STORES` gains `{ name: 'session', export: tabsync.exportForSync, merge: tabsync.mergeFromSync }` plus the optional `icons` descriptor. Order still doesn't matter.
+- **Scheduling — isolated timers, fingerprint-gated.** `sync.js` has one trailing timer today, and `schedule()` clears it on every call — so high-churn tab events routed through it would keep postponing a pending 4s favorites/settings sync indefinitely. Primary `session` publishes and cosmetic `icons` publishes therefore get their **own trailing timers** (15s debounce) that never touch the existing one or each other; a page rotating favicons cannot postpone the required session snapshot or consent retraction. And because `persistSession` runs inside `broadcastTabs()` — which also fires for blocked-count ticks and loading-flag flips (~10/s during loads) — the tab trigger is gated by a **snapshot fingerprint**: a hash of the canonical serialization of the **complete publishable snapshot** — device name and platform, ordered tabs with `url`/`title`/`groupId`/`pinned`, and the groups list with ids, names, and order — excluding only transient fields (`updatedAt`). Moving a tab between groups, reordering tabs or groups, or a hostname rename all change it and schedule; blocked-count ticks and loading-flag flips don't. The sidecar separately fingerprints rasterized icon records.
+- **Freshness — pull on focus/panel-open.** Local-change triggers alone never make another device's tabs appear on an *idle* machine (it would only pull at launch or after its own edits). So the receiving side gets a **session + icon-sidecar refresh** — pull + merge — triggered when the window regains focus (`browser-window-focus`) and when the ⌘L panel opens (`showOverlay('panel'|'palette')`), throttled to at most once per 60 s, only while sync is enabled. The PUT decision after the pull is **not** "did our fingerprint change" — that would never repair a remote blob that lost our unchanged entry in a race (e.g. another device's budget drop). Instead: compare each canonical bounded export against its decrypted remote map and **PUT whenever they differ**; skip only a true no-op. The fingerprints gate *scheduling*; export-vs-remote comparisons gate writes. This keeps refreshes off the bookmarks/settings blobs and well inside the worker's 30 GETs/min per-account limit.
+- **Heartbeat:** while sharing is enabled, republish our entries (an `updatedAt` bump in each store that is due) once per **24 h** even when nothing changed — otherwise a continuously running device with stable tabs would silently age past the 30-day prune on every other device. The hourly session check schedules both stores, and each model independently decides whether its clock is due.
 - Sync-on-launch (already present) publishes a fresh snapshot after session restore.
 - **Quit:** a best-effort fire-and-forget `syncNow()` in `before-quit`. A change made in the final seconds before quitting may not upload until that device next launches — an accepted, documented limitation; no blocking of quit on network.
 
 ## 7. Worker (`cloudflare/sync-worker/`)
 
-- `'session'` joins the `STORES` whitelist — the one-line change the code comment reserved. `handleDelete` already iterates `STORES`, so account-wide wipe covers the new blob automatically.
-- `MAX_BLOB_BYTES` stays 512 KB — but note it caps the **combined, encrypted multi-device map** (`JSON.stringify` of the base64 blob), so the per-device tab cap alone doesn't bound it. The client enforces an **account-level plaintext budget of 320 KB** at export (≈ 440 KB once encrypted + base64'd, safely under the worker cap): first trim our own tab list from the end until under budget, then — only if still over, a pathological many-device account — drop the stalest *other* devices' entries from the pushed map. A dropped device resurrects on its own next push or focus-refresh repair (§6 — its local copy still holds its entry, so export-vs-remote differs); only third-device visibility is briefly affected. Rate limits unchanged; one extra GET+PUT per sync cycle plus the throttled focus refresh is well inside them.
+- `'session'` and `'icons'` join the `STORES` whitelist. `handleDelete` already iterates `STORES`, so account-wide wipe covers both blobs automatically.
+- `MAX_BLOB_BYTES` stays 512 KB per encrypted store. The session client enforces an **account-level plaintext budget of 320 KB** at export (≈ 440 KB once encrypted + base64'd, safely under the worker cap): first trim our own tab list from the end until under budget, then — only if still over, a pathological many-device account — drop the stalest *other* devices' entries from the pushed map. The icon sidecar independently caps plaintext at 256 KB and trims cosmetic records without touching session data. A dropped device resurrects on its own next push or focus-refresh repair (§6 — its local copy still holds its entry, so export-vs-remote differs); only third-device visibility is briefly affected. Rate limits unchanged; the sidecar's extra GET+PUT per tab-sync cycle plus the throttled focus refresh remain inside them.
 
 ## 8. Privacy & threat model
 
 - Tab URLs and titles ride E2EE exactly like favorites: AES-256-GCM client-side, the worker sees only ciphertext under an opaque `accountId`.
+- Favicon source URLs never cross devices. A receiving device is given only a revalidated, embedded PNG produced on the source device, so opening the remote-tab surfaces cannot trigger a request—credentialed or otherwise—to a URL chosen by another device's page.
 - This payload is a step toward the original spec's "payload grows teeth" note (§ threat model): open tabs ≈ a slice of live browsing history. The stance holds — **confidentiality-only claims; availability and rollback remain explicit non-goals** — and the original spec's hardening path (auth token on PUT/DELETE, AAD-bound counter) remains the trigger if the payload deepens further (full history, credentials — the latter still "never").
 - Private tabs never enter the snapshot (inherited from the `persistSession` filter; pinned by a unit test).
 - `syncTabs` and `deviceId` are device-local and never synced. The telemetry `installId` is untouched.
@@ -87,8 +122,9 @@ Union by `deviceId`, last-writer-wins per entry on `updatedAt`. Each device only
 Unit tests (`test/unit/`, node --test) — most of the surface lives in the pure modules (`session-snapshot.js`, `tabsync-model.js`) precisely so it's testable without Electron:
 - Merge: per-device LWW; retraction beats stale copies and cannot be resurrected by an older entry; 30-day pruning; tab cap and title truncation enforced on export.
 - Account binding: a changed `accountId` discards all cached remote entries (and only then); `deviceId` survives the rebind.
-- Snapshot builder (`session-snapshot.js`): private-tab exclusion, private-only group exclusion, error-URL unwrapping in `persistableEntries`; HTTP(S)-only filter, URL-length skip, and caps in `syncSnapshot`; `persistableEntries` output unchanged from today's `persistSession` behavior.
-- Fingerprint: identical snapshots hash equal; blocked-count/loading-flag-only changes don't alter it; url/title changes, group membership/order moves, tab reorders, and device renames all do; `updatedAt` alone never does.
+- Snapshot builder (`session-snapshot.js`): private-tab exclusion, private-only group exclusion, error-URL unwrapping in `persistableEntries`; HTTP(S)-only filter, URL-length skip, and caps in `syncSnapshot`; `persistableEntries` output unchanged from today's `persistSession` behavior. Its exact tab keys are regression-pinned so icon work cannot drift the mixed-version wire schema.
+- Session fingerprint: identical snapshots hash equal; blocked-count/loading-flag-only changes don't alter it; url/title changes, group membership/order moves, tab reorders, and device renames all do; `updatedAt` alone never does. The icon sidecar has its own content fingerprint and clock.
+- Icon sidecar: accepts only bounded PNG data URLs with PNG structure, sanitizes/deduplicates remote records, preserves LWW/retraction/pruning semantics, trims icons without touching session tabs, and joins data only into the trusted renderer projection. Capture tests pin cookie-free/referrer-free fetching, rejection of non-PNG responses, cancellation on consent changes, and newest-source survival through queue pressure. An older Worker rejecting the optional store does not fail profile sync or overwrite required-store status.
 - Repair comparison: a remote map missing our unchanged entry → differs → PUT; identical maps → no write.
 - Heartbeat: an own entry older than 24 h is due for republish even with an unchanged fingerprint.
 - Size budget: own-tabs trimming first, stale-other-device dropping second, output always under the plaintext budget.

--- a/spec/features.md
+++ b/spec/features.md
@@ -386,8 +386,10 @@ From the desktop `DEFAULTS`:
 - With Profile Sync enabled and the per-device **"share this device's open
   tabs"** toggle on (**off by default** — a device's tabs never upload without
   an explicit act on that device), each device publishes an E2EE snapshot of
-  its open tabs (url, title, group, pinned; http(s) only, bounded) under the
-  sync account. Other devices browse it **read-only** — ⌘L panel (folded
+  its open tabs (url, title, group, pinned; http(s) only, bounded) plus a
+  separately-budgeted E2EE sidecar of source-rasterized, bounded PNG favicons
+  under the sync account. Favicon source URLs never cross devices and remote
+  surfaces never load them. Other devices browse it **read-only** — ⌘L panel (folded
   per-device sections), Quick Switcher (ranked below local tabs and
   favorites), start page — and open individual tabs locally. Never a merged
   live session: nothing force-opens or closes remotely. Private tabs never

--- a/spec/parity-matrix.md
+++ b/spec/parity-matrix.md
@@ -37,7 +37,7 @@ See [`README.md`](./README.md#status-legend) for meanings.
 | F22 | Distribution & updates | SHIPPED | N/A | N/A | User gets updates; no in-app updater fighting the OS store. | D9 |
 | F23 | Zoom / page scaling | SHIPPED | DIVERGENT (D10) | DIVERGENT (D10) | Page can be scaled; desktop discrete zoom vs mobile pinch/native reflow. | D10 |
 | F24 | Password AutoFill / passkeys | N/A | PLANNED | PLANNED | On mobile, native credential provider + platform passkeys work in-webview. | D12 |
-| F27 | Tab Sync (other-device tab list) | SHIPPED | PLANNED | PLANNED | Per-device opt-in, off by default, publish-only gating; read-only browsing in panel/switcher/start page; http(s)-only bounded snapshots; retraction + 30-day prune + 24 h heartbeat; rides the E2EE sync store. | — |
+| F27 | Tab Sync (other-device tab list) | SHIPPED | PLANNED | PLANNED | Per-device opt-in, off by default, publish-only gating; read-only browsing in panel/switcher/start page; http(s)-only bounded snapshots plus a separately-budgeted E2EE icon sidecar; retraction + 30-day prune + 24 h heartbeat. Optional favicons are inert bounded PNG bytes—never remote URLs loaded by a receiving device. | — |
 
 ## Notes on the "mobile-only wins"
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -17,6 +17,7 @@ const { setupAutoUpdater, checkForUpdatesManually } = require('./updater');
 const { sendLaunchPing } = require('./telemetry');
 const sync = require('./sync');
 const tabsync = require('./tabsync');
+const tabicons = require('./tabicons');
 const { setupDownloads, downloadsActivity, acknowledgeDownloads } = require('./downloads');
 const { attachContextMenu } = require('./context-menu');
 const { promptForCredentials } = require('./auth-dialog');
@@ -814,6 +815,7 @@ async function upgradeFavicon(tab) {
       tab.favicon = best;
       if (tab.bookmarked) bookmarks.updateFavicon(tab.url, best);
       scheduleBroadcastTabs();
+      sync.captureTabIcon(tab).catch(() => {});
     }
   } catch {
     /* page gone mid-query — Chromium's default pick stands */
@@ -1120,10 +1122,19 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
     tab.favicon = favicons[0] ?? null; // immediate, possibly low-res
     if (tab.bookmarked) bookmarks.updateFavicon(tab.url, tab.favicon);
     broadcastTabs();
+    sync.captureTabIcon(tab).catch(() => {});
     upgradeFavicon(tab); // async refinement to the sharpest declared icon
   });
   wc.on('did-start-loading', () => { tab.isLoading = true; broadcastTabs(); });
-  wc.on('did-stop-loading', () => { tab.isLoading = false; syncNavState(); broadcastTabs(); scheduleSampleTint(tab); });
+  wc.on('did-stop-loading', () => {
+    tab.isLoading = false;
+    syncNavState();
+    broadcastTabs();
+    scheduleSampleTint(tab);
+    // Same-origin navigations can retain their favicon without firing
+    // page-favicon-updated; associate the already-known icon with the new URL.
+    sync.captureTabIcon(tab).catch(() => {});
+  });
   wc.on('did-change-theme-color', (_e, color) => {
     // Chromium reports '#rrggbb' or null; validated because it feeds chrome CSS.
     tab.themeColor = typeof color === 'string' && /^#[0-9a-fA-F]{6}$/.test(color) ? color : null;
@@ -1161,6 +1172,7 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
     syncNavState();
     if (isMainFrame && tab.historyEligible) history.addVisit(url, wc.getTitle());
     broadcastTabs();
+    if (isMainFrame) sync.captureTabIcon(tab).catch(() => {});
     // Deliberately no scheduleMenuRebuild() here — unlike did-navigate,
     // this fires on every hash change/pushState and can be sustained and
     // frequent on SPA-heavy sites (exactly the rebuild-storm case Task 1
@@ -2391,9 +2403,12 @@ app.whenReady().then(async () => {
     tabList: tabOrder.map((id) => tabs.get(id)).filter(Boolean),
     groups,
   }));
+  tabicons.setSnapshotProvider(() => ({
+    tabList: tabOrder.map((id) => tabs.get(id)).filter(Boolean),
+  }));
   // A pull changed the cached device map: push the fresh list to the open
   // surfaces (overlay panel; any tab currently on the start page).
-  tabsync.onRemoteChanged(() => {
+  const pushRemoteDevices = () => {
     const devices = sync.listRemoteDevices();
     overlayView?.webContents.send('chrome:remote-tabs-updated', devices);
     for (const tab of tabs.values()) {
@@ -2401,7 +2416,9 @@ app.whenReady().then(async () => {
         tab.view.webContents.send('pages:start:remote-tabs', devices);
       }
     }
-  });
+  };
+  tabsync.onRemoteChanged(pushRemoteDevices);
+  tabicons.onRemoteChanged(pushRemoteDevices);
   // Profile sync: sync-on-launch if configured, then follow local changes.
   // Runs after stores + setupPages so its triggers see a live app; failures
   // are swallowed and surfaced only in Settings (never block startup).

--- a/src/main/sync.js
+++ b/src/main/sync.js
@@ -5,6 +5,7 @@ const { JsonStore } = require('./store');
 const settings = require('./settings');
 const bookmarks = require('./bookmarks');
 const tabsync = require('./tabsync');
+const tabicons = require('./tabicons');
 const { deriveKeys, encrypt, decrypt } = require('./sync-crypto');
 const { wipeDecision } = require('./sync-wipe');
 
@@ -47,9 +48,19 @@ const STORES = [
     // — including a remote blob that lost our unchanged entry — uploads.
     equals: (exported, remote) => tabsync.equalsRemote(exported, remote),
   },
+  {
+    // Optional sidecar: older deployed Workers return 404 on PUT, which the
+    // sync pipeline treats as a quiet no-op until the store is available.
+    // Keeping this separate preserves the mixed-version `session` schema.
+    name: 'icons',
+    optional: true,
+    export: (ctx) => tabicons.exportForSync(ctx),
+    merge: (remote, ctx) => tabicons.mergeFromSync(remote, ctx),
+    equals: (exported, remote) => tabicons.equalsRemote(exported, remote),
+  },
 ];
 
-let syncing = false, timer = null, tabTimer = null;
+let syncing = false, timer = null, sessionTimer = null, iconTimer = null;
 /** Coalesced re-run request while a sync is in flight: undefined = none,
  * null = all stores, array = just those names. */
 let pendingNames;
@@ -110,9 +121,11 @@ async function enable({ handle, passphrase }) {
   }
   const { accountId, key } = deriveKeys(h, p);
   syncGen += 1; // new identity — strand any in-flight run from the old one
+  tabicons.cancelCaptures();
   ensureStore().update((d) => {
     d.enabled = true; d.handle = h; d.accountId = accountId; d.key = key.toString('base64'); d.lastError = null;
   });
+  refreshTabIcons().catch(() => {});
   // Joining existing data, or starting fresh? A mistyped passphrase derives a
   // *different* accountId → 404 → a silent new account, so the UI warns when
   // nothing was found. null = couldn't tell (offline).
@@ -128,8 +141,10 @@ async function enable({ handle, passphrase }) {
 async function disable({ wipeRemote = false } = {}) {
   clearTimeout(timer);
   timer = null;
-  clearTimeout(tabTimer);
-  tabTimer = null;
+  clearTimeout(sessionTimer);
+  sessionTimer = null;
+  clearTimeout(iconTimer);
+  iconTimer = null;
   // Barrier (PR #41 re-review): a dispatched PUT can't be recalled, and a
   // stale check after its response can't undo the server mutation. So before
   // touching the server or the credentials: (1) block new passes, (2) strand
@@ -137,6 +152,7 @@ async function disable({ wipeRemote = false } = {}) {
   // network included. Only then is the DELETE (or the credential clear) safe.
   suspended = true;
   syncGen += 1;
+  tabicons.cancelCaptures();
   try {
     await passSettled;
     const d = ensureStore().data;
@@ -166,6 +182,7 @@ async function disable({ wipeRemote = false } = {}) {
     // (syncTabs and deviceId survive: consent and identity are per-device,
     // not per-account.)
     tabsync.onSyncDisabled();
+    tabicons.onSyncDisabled();
     return { ok: true, status: status() };
   } finally {
     suspended = false; // a failed wipe keeps sync enabled — future passes must run
@@ -212,6 +229,7 @@ async function syncOne(accountId, key, desc, run, attempt = 0) {
     return syncOne(accountId, key, desc, run, attempt + 1); // re-pull-merge
   }
   if (putRes.status === 409) throw new SyncError('conflict');
+  if (desc.optional && putRes.status === 404) return;
   if (!putRes.ok) throw new SyncError(`http-${putRes.status}`);
 }
 
@@ -236,22 +254,27 @@ async function syncNow(names = null) {
     // credential/consent change mid-flight strands it at the next checkpoint.
     const gen = syncGen;
     const run = { ctx: tabSyncContext(), stale: () => gen !== syncGen };
-    let firstError = null, stranded = false;
+    let firstError = null, stranded = false, ranRequiredStore = false;
     try {
       for (const desc of STORES) {
         if (names && !names.includes(desc.name)) continue;
         if (!ensureStore().data.enabled) break; // disabled mid-flight — stop
+        if (!desc.optional) ranRequiredStore = true;
         try { await syncOne(accountId, key, desc, run); }
         catch (err) {
           if (err instanceof SyncError && err.message === 'stale') { stranded = true; break; }
-          firstError ??= err;
+          // Cosmetic sidecars degrade to fallback UI; they must never make
+          // Favorites/settings/session sync report a failure.
+          if (!desc.optional) firstError ??= err;
         }
       }
     } finally { syncing = false; }
     // If sync was turned off mid-flight, don't stamp status onto a disabled store.
     if (!ensureStore().data.enabled) return { ok: false, message: 'Sync is off.' };
     // A stranded pass stamps nothing: its results belong to a dead generation.
-    if (!stranded) {
+    // Cosmetic-only passes must not erase a real required-store error or make
+    // lastSyncedAt imply that Favorites/settings/session were refreshed.
+    if (!stranded && ranRequiredStore) {
       ensureStore().update((s) => {
         if (firstError) s.lastError = describe(firstError);
         else { s.lastError = null; s.lastSyncedAt = Date.now(); }
@@ -272,42 +295,91 @@ function schedule(delay = 4000) {
   timer = setTimeout(() => { syncNow().catch(() => {}); }, delay);
 }
 
-/** Tab churn gets its OWN trailing timer (spec §6): schedule() clears the
- * shared one on every call, so routing 15s tab debounces through it would
- * keep postponing a pending 4s favorites/settings sync. Session-only. */
+/** Tab churn gets timers separate from both favorites/settings and cosmetic
+ * icon work. A page rotating favicons must never postpone the primary session
+ * snapshot (especially the prompt consent-change retraction/publication). */
+function scheduleSession(delay = 15000) {
+  clearTimeout(sessionTimer);
+  sessionTimer = setTimeout(() => { syncNow(['session']).catch(() => {}); }, delay);
+}
+
+function scheduleIcons(delay = 15000) {
+  clearTimeout(iconTimer);
+  iconTimer = setTimeout(() => { syncNow(['icons']).catch(() => {}); }, delay);
+}
+
 function scheduleTabs(delay = 15000) {
-  clearTimeout(tabTimer);
-  tabTimer = setTimeout(() => { syncNow(['session']).catch(() => {}); }, delay);
+  scheduleSession(delay);
+  scheduleIcons(delay);
 }
 
 /** The per-device "share this device's open tabs" consent (spec §3). Turning
  * it off publishes a retraction on the prompt sync below. */
 function setSyncTabs(on) {
   syncGen += 1; // consent changed — a stale in-flight export must not publish under the old setting
+  tabicons.cancelCaptures();
   ensureStore().update((d) => { d.syncTabs = !!on; });
   if (ensureStore().data.enabled) scheduleTabs(1000);
+  if (on) refreshTabIcons().catch(() => {});
   return status();
 }
 
 let lastSessionRefresh = 0;
 /** Freshness pull on window focus / panel open (spec §6), throttled to one
- * per minute. Session-only: keeps it off the other blobs and inside the
- * worker's per-account GET limit. Errors stay silent — this is a background
- * freshness path, not a user-initiated sync. */
+ * per minute. Session + icon-sidecar only: keeps it off favorites/settings
+ * and inside the worker's per-account GET limit. Errors stay silent — this
+ * is a background freshness path, not a user-initiated sync. */
 function refreshSession() {
   const d = ensureStore().data;
   if (!d.enabled) return;
   const now = Date.now();
   if (now - lastSessionRefresh < 60_000) return;
   lastSessionRefresh = now;
-  syncNow(['session']).catch(() => {});
+  syncNow(['session', 'icons']).catch(() => {});
 }
 
-/** Other devices' tabs for the UI ([] whenever sync is off). */
+/** A generation-bound capture run. Favicon rasterization is asynchronous,
+ * so credentials/consent must still match before its result enters a store. */
+function iconCaptureRun() {
+  const d = ensureStore().data;
+  if (!d.enabled || !d.syncTabs) return null;
+  const gen = syncGen;
+  const ctx = tabSyncContext();
+  return {
+    ctx,
+    isCurrent: () => {
+      const current = ensureStore().data;
+      return gen === syncGen &&
+        current.enabled &&
+        current.syncTabs &&
+        current.accountId === ctx.accountId &&
+        current.deviceId === ctx.deviceId;
+    },
+  };
+}
+
+function captureTabIcon(tab) {
+  const run = iconCaptureRun();
+  return run
+    ? tabicons.captureTab(tab, run.ctx, { isCurrent: run.isCurrent })
+    : Promise.resolve(false);
+}
+
+function refreshTabIcons() {
+  const run = iconCaptureRun();
+  return run
+    ? tabicons.refreshCurrent(run.ctx, { isCurrent: run.isCurrent })
+    : Promise.resolve(false);
+}
+
+/** Other devices' tabs for the UI ([] whenever sync is off). The sidecar is
+ * joined only for the trusted renderer projection; the session wire format
+ * remains unchanged. */
 function listRemoteDevices() {
   const d = ensureStore().data;
   if (!d.enabled) return [];
-  return tabsync.getRemoteDevices(tabSyncContext());
+  const ctx = tabSyncContext();
+  return tabicons.attachToRemoteDevices(tabsync.getRemoteDevices(ctx), ctx);
 }
 
 function init() {
@@ -325,13 +397,31 @@ function init() {
     const d = ensureStore().data;
     if (d.enabled && d.syncTabs) scheduleTabs();
   });
+  tabicons.onChanged(() => {
+    const d = ensureStore().data;
+    if (d.enabled && d.syncTabs) scheduleIcons();
+  });
+  refreshTabIcons().catch(() => {});
   // Heartbeat (spec §6): hourly check; republishes once our entry is 24h old
   // so a long-running device with stable tabs never ages past the 30-day
   // prune on other devices.
   setInterval(() => {
     const d = ensureStore().data;
-    if (d.enabled && d.syncTabs && tabsync.heartbeatDue(tabSyncContext())) scheduleTabs(5000);
+    if (!d.enabled || !d.syncTabs) return;
+    const ctx = tabSyncContext();
+    if (tabsync.heartbeatDue(ctx)) scheduleSession(5000);
+    if (tabicons.heartbeatDue(ctx)) scheduleIcons(5000);
   }, 60 * 60 * 1000);
 }
 
-module.exports = { init, enable, disable, syncNow, status, setSyncTabs, refreshSession, listRemoteDevices };
+module.exports = {
+  init,
+  enable,
+  disable,
+  syncNow,
+  status,
+  setSyncTabs,
+  refreshSession,
+  listRemoteDevices,
+  captureTabIcon,
+};

--- a/src/main/tabicons-model.js
+++ b/src/main/tabicons-model.js
@@ -1,0 +1,341 @@
+// Pure model for the optional E2EE tab-icon sidecar. Keeping icon bytes out
+// of the `session` store preserves that store's deployed schema: older Blanc
+// clients rebuild every device entry from known fields and would otherwise
+// strip a newly-added favicon field, causing repair-write ping-pong.
+
+const PRUNE_MS = 30 * 24 * 60 * 60 * 1000;
+const HEARTBEAT_MS = 24 * 60 * 60 * 1000;
+const BUDGET_BYTES = 256 * 1024;
+const MAX_ICONS = 500;
+const MAX_URL = 2048;
+const MAX_ICON_DATA = 4096;
+const ICON_SIZE = 16;
+const MAX_SOURCE_BYTES = 256 * 1024;
+const MAX_SOURCE_DIMENSION = 1024;
+const MAX_SOURCE_PIXELS = 512 * 512;
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PNG_DATA_PREFIX = 'data:image/png;base64,';
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((k) => `${JSON.stringify(k)}:${canonical(value[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+function validIconData(data) {
+  if (
+    typeof data !== 'string' ||
+    data.length > MAX_ICON_DATA ||
+    !data.toLowerCase().startsWith(PNG_DATA_PREFIX)
+  ) return null;
+  const encoded = data.slice(PNG_DATA_PREFIX.length);
+  // Buffer.from(base64) is deliberately forgiving. Require a canonical
+  // encoding here so junk following valid base64 cannot hitch a ride into
+  // privileged chrome under an image MIME type.
+  if (!encoded || encoded.length % 4 !== 0 || !/^[a-z0-9+/]+={0,2}$/i.test(encoded)) return null;
+  const bytes = Buffer.from(encoded, 'base64');
+  if (
+    bytes.toString('base64') !== encoded ||
+    bytes.length < 24 ||
+    !bytes.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE) ||
+    bytes.subarray(12, 16).toString('ascii') !== 'IHDR' ||
+    bytes.readUInt32BE(16) !== ICON_SIZE ||
+    bytes.readUInt32BE(20) !== ICON_SIZE
+  ) return null;
+  return data;
+}
+
+/** Validate the cheap, fixed-size PNG header before handing untrusted source
+ * bytes to Chromium's image decoder. Icons are cosmetic, so accepting PNG
+ * only is preferable to expanding the native decoder attack surface for ICO,
+ * SVG, animated formats, or dimension bombs. */
+function validSourcePngBytes(raw) {
+  if (!Buffer.isBuffer(raw) && !(raw instanceof Uint8Array)) return null;
+  const bytes = Buffer.isBuffer(raw)
+    ? raw
+    : Buffer.from(raw.buffer, raw.byteOffset, raw.byteLength);
+  if (
+    bytes.length < 24 ||
+    bytes.length > MAX_SOURCE_BYTES ||
+    !bytes.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE) ||
+    bytes.readUInt32BE(8) !== 13 ||
+    bytes.subarray(12, 16).toString('ascii') !== 'IHDR'
+  ) return null;
+  const width = bytes.readUInt32BE(16);
+  const height = bytes.readUInt32BE(20);
+  if (
+    width < 1 ||
+    height < 1 ||
+    width > MAX_SOURCE_DIMENSION ||
+    height > MAX_SOURCE_DIMENSION ||
+    width * height > MAX_SOURCE_PIXELS
+  ) return null;
+  return bytes;
+}
+
+function sourcePngFromDataUrl(source) {
+  if (typeof source !== 'string') return null;
+  const comma = source.indexOf(',');
+  if (comma < 0 || source.slice(0, comma).toLowerCase() !== 'data:image/png;base64') return null;
+  const encoded = source.slice(comma + 1);
+  if (
+    !encoded ||
+    encoded.length % 4 !== 0 ||
+    encoded.length > Math.ceil(MAX_SOURCE_BYTES / 3) * 4 ||
+    !/^[a-z0-9+/]+={0,2}$/i.test(encoded)
+  ) return null;
+  const bytes = Buffer.from(encoded, 'base64');
+  if (bytes.toString('base64') !== encoded) return null;
+  return validSourcePngBytes(bytes);
+}
+
+function isPrivateIpv4(host) {
+  const parts = host.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+  const [a, b] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224
+  );
+}
+
+function isPrivateIpv6(host) {
+  const value = host.toLowerCase();
+  // Unique-local, link-local, loopback/unspecified, and IPv4-mapped literals
+  // are never valid icon origins.
+  if (value === '::' || value === '::1' || value.startsWith('::ffff:')) return true;
+  const first = Number.parseInt(value.split(':', 1)[0], 16);
+  return (
+    (first & 0xfe00) === 0xfc00 || // fc00::/7
+    (first & 0xffc0) === 0xfe80 || // fe80::/10
+    (first & 0xffc0) === 0xfec0 || // deprecated site-local fec0::/10
+    (first & 0xff00) === 0xff00    // multicast ff00::/8
+  );
+}
+
+/** Network favicon capture is cosmetic and must not become a new LAN probe.
+ * URL canonicalization collapses unusual IPv4 spellings before these checks.
+ * DNS rebinding is outside this lightweight guard, so the fetch also remains
+ * cookie/referrer-free and redirect-disabled as defense in depth. */
+function isPublicHttpSource(source) {
+  if (typeof source !== 'string' || source.length > MAX_URL) return false;
+  let parsed;
+  try {
+    parsed = new URL(source);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+  let host = parsed.hostname.toLowerCase().replace(/\.$/, '');
+  if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1);
+  if (!host || host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) return false;
+  if (host.includes(':')) return !isPrivateIpv6(host);
+  if (/^\d+(?:\.\d+){3}$/.test(host)) return !isPrivateIpv4(host);
+  return true;
+}
+
+function sanitizeIcon(raw) {
+  if (!raw || typeof raw.url !== 'string') return null;
+  if (!/^https?:\/\//.test(raw.url) || raw.url.length > MAX_URL) return null;
+  const data = validIconData(raw.data);
+  return data ? { url: raw.url, data } : null;
+}
+
+function sanitizeIcons(rawIcons) {
+  const seen = new Set();
+  const icons = [];
+  for (const raw of Array.isArray(rawIcons) ? rawIcons : []) {
+    const icon = sanitizeIcon(raw);
+    if (!icon || seen.has(icon.url)) continue;
+    seen.add(icon.url);
+    icons.push(icon);
+    if (icons.length >= MAX_ICONS) break;
+  }
+  return icons;
+}
+
+function sanitizeEntry(raw) {
+  if (!raw || !Number.isFinite(raw.updatedAt)) return null;
+  if (raw.retracted) return { retracted: true, updatedAt: raw.updatedAt };
+  return {
+    updatedAt: raw.updatedAt,
+    icons: sanitizeIcons(raw.icons),
+  };
+}
+
+const fingerprint = ({ icons }) => canonical({ icons: sanitizeIcons(icons) });
+
+function winner(local, remote, isOwn) {
+  if (remote.updatedAt !== local.updatedAt) return remote.updatedAt > local.updatedAt ? remote : local;
+  if (isOwn) return local;
+  if (!!remote.retracted !== !!local.retracted) return remote.retracted ? remote : local;
+  return canonical(remote) < canonical(local) ? remote : local;
+}
+
+function mergeDevices(local, remote, { now, ownId }) {
+  const out = {};
+  for (const [id, raw] of Object.entries(local ?? {})) {
+    const entry = sanitizeEntry(raw);
+    if (entry) out[id] = entry;
+  }
+  for (const [id, raw] of Object.entries(remote ?? {})) {
+    const entry = sanitizeEntry(raw);
+    if (!entry) continue;
+    const current = out[id];
+    out[id] = current ? winner(current, entry, id === ownId) : entry;
+  }
+  for (const [id, entry] of Object.entries(out)) {
+    if (now - entry.updatedAt > PRUNE_MS) delete out[id];
+  }
+  return out;
+}
+
+function rebindDevices(stored, accountId) {
+  if (stored.accountId === accountId) return stored;
+  return { accountId, devices: {} };
+}
+
+function buildOwnEntry({ prev, snapshot, now }) {
+  const next = { updatedAt: now, icons: sanitizeIcons(snapshot?.icons) };
+  if (
+    prev && !prev.retracted &&
+    fingerprint(prev) === fingerprint(next) &&
+    now - prev.updatedAt < HEARTBEAT_MS
+  ) {
+    return { ...next, updatedAt: prev.updatedAt };
+  }
+  return next;
+}
+
+function retractedEntry(prev, now) {
+  if (!prev) return null;
+  if (prev.retracted) return prev;
+  return { retracted: true, updatedAt: now };
+}
+
+function ownEntryFor({ syncTabs, prev, snapshot, now }) {
+  return syncTabs && snapshot
+    ? buildOwnEntry({ prev, snapshot, now })
+    : retractedEntry(prev, now);
+}
+
+const heartbeatDue = (entry, now) =>
+  !!entry && !entry.retracted && now - entry.updatedAt >= HEARTBEAT_MS;
+
+const devicesEqual = (a, b) => canonical(a ?? {}) === canonical(b ?? {});
+
+/** Icons are cosmetic and live in their own store, so the budget can discard
+ * icon records without ever removing a tab from the primary session store.
+ * The full local map remains intact; only the upload copy is trimmed. */
+function applyBudget(devices, ownId, { maxBytes = BUDGET_BYTES } = {}) {
+  const out = structuredClone(devices ?? {});
+  const over = () => Buffer.byteLength(canonical(out), 'utf8') > maxBytes;
+  if (!over()) return out;
+
+  const trim = (entry) => {
+    while (entry?.icons?.length && over()) {
+      entry.icons.splice(-Math.max(1, Math.ceil(entry.icons.length / 4)));
+    }
+  };
+  trim(out[ownId]);
+
+  const others = Object.entries(out)
+    .filter(([id, entry]) => id !== ownId && !entry?.retracted)
+    .sort(([, a], [, b]) => a.updatedAt - b.updatedAt);
+  for (const [id, entry] of others) {
+    if (!over()) break;
+    trim(entry);
+    if (!entry.icons.length) delete out[id];
+  }
+  for (const [id, entry] of Object.entries(out)) {
+    if (!over()) break;
+    if (id !== ownId && entry?.retracted) delete out[id];
+  }
+  return out;
+}
+
+function exportDevices({ devices, deviceId, syncTabs, snapshot, now, maxBytes }) {
+  const next = { ...(devices ?? {}) };
+  const own = ownEntryFor({
+    syncTabs,
+    prev: next[deviceId] ?? null,
+    snapshot,
+    now,
+  });
+  if (own) next[deviceId] = own;
+  else delete next[deviceId];
+  const store = mergeDevices(next, {}, { now, ownId: deviceId });
+  const upload = applyBudget(store, deviceId, maxBytes ? { maxBytes } : {});
+  return { store, upload };
+}
+
+function displayDevices(devices, ownId, { now }) {
+  return Object.fromEntries(
+    Object.entries(devices ?? {})
+      .filter(([id, entry]) =>
+        id !== ownId && entry && !entry.retracted &&
+        Array.isArray(entry.icons) && entry.icons.length > 0 &&
+        now - entry.updatedAt <= PRUNE_MS)
+      .map(([id, entry]) => [id, sanitizeIcons(entry.icons)])
+  );
+}
+
+/** Add safe data URLs to the renderer projection only. The synchronized
+ * session object itself remains unchanged and never carries favicon fields. */
+function attachIcons(remoteDevices, iconDevices) {
+  return (remoteDevices ?? []).map((device) => {
+    const icons = Array.isArray(iconDevices?.[device.deviceId])
+      ? iconDevices[device.deviceId]
+      : [];
+    const byUrl = new Map(icons.map((icon) => [icon.url, validIconData(icon.data)]));
+    return {
+      ...device,
+      tabs: (Array.isArray(device.tabs) ? device.tabs : []).map((tab) => ({
+        ...tab,
+        favicon: validIconData(byUrl.get(tab.url)),
+      })),
+    };
+  });
+}
+
+module.exports = {
+  PRUNE_MS,
+  HEARTBEAT_MS,
+  BUDGET_BYTES,
+  MAX_ICONS,
+  MAX_URL,
+  MAX_ICON_DATA,
+  ICON_SIZE,
+  MAX_SOURCE_BYTES,
+  MAX_SOURCE_DIMENSION,
+  MAX_SOURCE_PIXELS,
+  PNG_DATA_PREFIX,
+  isPublicHttpSource,
+  canonical,
+  validIconData,
+  validSourcePngBytes,
+  sourcePngFromDataUrl,
+  sanitizeIcon,
+  sanitizeEntry,
+  fingerprint,
+  mergeDevices,
+  rebindDevices,
+  buildOwnEntry,
+  retractedEntry,
+  ownEntryFor,
+  heartbeatDue,
+  devicesEqual,
+  applyBudget,
+  exportDevices,
+  displayDevices,
+  attachIcons,
+};

--- a/src/main/tabicons.js
+++ b/src/main/tabicons.js
@@ -1,0 +1,514 @@
+// Optional E2EE tab-icon sidecar. The primary `session` sync schema stays
+// unchanged for mixed-version compatibility; this module rasterizes favicon
+// resources on the device that already has the page open and synchronizes
+// only small PNG data URLs. Receiving chrome never contacts remote sites just
+// to render another device's tab list.
+
+const { nativeImage } = require('electron');
+const { JsonStore } = require('./store');
+const { validFavicon } = require('./bookmark-validate');
+const model = require('./tabicons-model');
+
+const FETCH_TIMEOUT_MS = 3000;
+const MAX_SOURCE_CACHE = 256;
+const MAX_REFRESH_ICONS = 256;
+const CAPTURE_CONCURRENCY = 4;
+const MAX_PENDING_CAPTURES = 64;
+
+let store = null;
+const ensureStore = () => (store ??= new JsonStore('tab-icons', { accountId: '', devices: {} }));
+
+let snapshotProvider = null; // () => ({ tabList })
+let localContextKey = '';
+const localIcons = new Map(); // page URL -> PNG data URL
+// Favicon source URL -> { promise, settled }. Pending entries are never
+// evicted: eviction would let duplicate live events start unbounded work.
+const sourceCache = new Map();
+const captureQueue = [];
+// Stable tab identity -> pending cache entry. A tab can rotate its URL or
+// favicon repeatedly while earlier work is pending; replacing this link keeps
+// one consumer/predicate and one queue slot for that tab's latest state.
+const pendingByTab = new Map();
+const activeEntries = new Set();
+let activeCaptures = 0;
+let captureGeneration = 0;
+
+const changeListeners = new Set();
+const remoteListeners = new Set();
+const onChanged = (fn) => changeListeners.add(fn);
+const onRemoteChanged = (fn) => remoteListeners.add(fn);
+
+function setSnapshotProvider(fn) {
+  snapshotProvider = fn;
+}
+
+function bindContext(ctx) {
+  const s = ensureStore();
+  const bound = model.rebindDevices(s.data, ctx.accountId);
+  if (bound !== s.data) {
+    s.update((data) => {
+      data.accountId = bound.accountId;
+      data.devices = bound.devices;
+    });
+  }
+  const key = `${ctx.accountId}:${ctx.deviceId}`;
+  if (key !== localContextKey) {
+    localContextKey = key;
+    localIcons.clear();
+    const own = s.data.devices[ctx.deviceId];
+    if (own && !own.retracted) {
+      for (const icon of own.icons ?? []) {
+        const clean = model.sanitizeIcon(icon);
+        if (clean) localIcons.set(clean.url, clean.data);
+      }
+    }
+  }
+  return s;
+}
+
+function currentSnapshot(ctx) {
+  bindContext(ctx);
+  const tabs = snapshotProvider?.().tabList ?? [];
+  pruneLocalIcons(tabs);
+  const seen = new Set();
+  const icons = [];
+  for (const tab of tabs) {
+    if (
+      !tab || tab.private ||
+      typeof tab.url !== 'string' ||
+      !/^https?:\/\//.test(tab.url) ||
+      tab.url.length > model.MAX_URL ||
+      seen.has(tab.url)
+    ) continue;
+    seen.add(tab.url);
+    const data = model.validIconData(localIcons.get(tab.url));
+    if (data) icons.push({ url: tab.url, data });
+    if (icons.length >= model.MAX_ICONS) break;
+  }
+  return { icons };
+}
+
+async function readBounded(response) {
+  const declared = Number(response.headers?.get?.('content-length'));
+  if (Number.isFinite(declared) && declared > model.MAX_SOURCE_BYTES) return null;
+  if (!response.body?.getReader) {
+    const bytes = Buffer.from(await response.arrayBuffer());
+    return bytes.byteLength <= model.MAX_SOURCE_BYTES ? bytes : null;
+  }
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = Buffer.from(value);
+      total += chunk.byteLength;
+      if (total > model.MAX_SOURCE_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(chunk);
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+  return Buffer.concat(chunks, total);
+}
+
+function pngData(image) {
+  if (!image || image.isEmpty()) return null;
+  const resized = image.resize({ width: model.ICON_SIZE, height: model.ICON_SIZE, quality: 'best' });
+  if (resized.isEmpty()) return null;
+  const data = `data:image/png;base64,${resized.toPNG().toString('base64')}`;
+  return model.validIconData(data);
+}
+
+async function rasterizeSource(source, browsingSession, signal) {
+  try {
+    if (signal?.aborted) return null;
+    if (source.toLowerCase().startsWith('data:image/')) {
+      const bytes = model.sourcePngFromDataUrl(source);
+      if (signal?.aborted) return null;
+      return bytes ? pngData(nativeImage.createFromBuffer(bytes)) : null;
+    }
+    if (!browsingSession?.fetch || !model.isPublicHttpSource(source)) return null;
+    const timeoutController = new AbortController();
+    const timeout = setTimeout(() => timeoutController.abort(), FETCH_TIMEOUT_MS);
+    const requestSignal = signal
+      ? AbortSignal.any([signal, timeoutController.signal])
+      : timeoutController.signal;
+    try {
+      const response = await browsingSession.fetch(source, {
+        // This is a best-effort cosmetic copy, not a page request. Never send
+        // cookies or a referring page while resolving it, even when the
+        // favicon URL points at another origin.
+        credentials: 'omit',
+        referrerPolicy: 'no-referrer',
+        redirect: 'error',
+        signal: requestSignal,
+      });
+      if (!response.ok || requestSignal.aborted) return null;
+      const contentType = response.headers?.get?.('content-type')?.split(';', 1)[0]?.trim()?.toLowerCase();
+      if (contentType !== 'image/png') return null;
+      const bytes = await readBounded(response);
+      if (requestSignal.aborted) return null;
+      const png = model.validSourcePngBytes(bytes);
+      return png ? pngData(nativeImage.createFromBuffer(png)) : null;
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch {
+    return null;
+  }
+}
+
+function predicateIsCurrent(predicate) {
+  try {
+    return predicate();
+  } catch {
+    return false;
+  }
+}
+
+const entryIsNeeded = (entry) =>
+  entry.generation === captureGeneration &&
+  [...entry.consumers.values()].some(predicateIsCurrent);
+
+function unlinkPendingTabs(entry) {
+  for (const tabKey of entry.consumers.keys()) {
+    if (pendingByTab.get(tabKey) === entry) pendingByTab.delete(tabKey);
+  }
+}
+
+function settleEntry(entry, data) {
+  if (entry.settled) return;
+  entry.settled = true;
+  entry.state = 'settled';
+  entry.controller = null;
+  unlinkPendingTabs(entry);
+  entry.consumers.clear();
+  if (!data && sourceCache.get(entry.source) === entry) {
+    sourceCache.delete(entry.source);
+  }
+  entry.resolve(data);
+}
+
+function discardQueuedEntry(entry) {
+  if (entry.settled || entry.state !== 'queued') return false;
+  const index = captureQueue.findIndex((job) => job.entry === entry);
+  if (index < 0) return false;
+  captureQueue.splice(index, 1);
+  settleEntry(entry, null);
+  return true;
+}
+
+function discardIfUnused(entry) {
+  if (entry.settled || entry.consumers.size > 0) return;
+  if (discardQueuedEntry(entry)) return;
+  if (entry.state === 'active') {
+    if (sourceCache.get(entry.source) === entry) sourceCache.delete(entry.source);
+    entry.controller?.abort();
+  }
+}
+
+function detachPendingTab(tabKey, except = null) {
+  const prior = pendingByTab.get(tabKey);
+  if (!prior || prior === except) return;
+  pendingByTab.delete(tabKey);
+  prior.consumers.delete(tabKey);
+  discardIfUnused(prior);
+}
+
+function compactCaptureQueue() {
+  for (let index = captureQueue.length - 1; index >= 0; index -= 1) {
+    const entry = captureQueue[index].entry;
+    if (entryIsNeeded(entry)) continue;
+    captureQueue.splice(index, 1);
+    settleEntry(entry, null);
+  }
+}
+
+function trimSourceCache() {
+  const settled = [];
+  for (const [source, entry] of sourceCache) {
+    if (entry.settled) settled.push(source);
+  }
+  while (settled.length > MAX_SOURCE_CACHE) {
+    sourceCache.delete(settled.shift());
+  }
+}
+
+function pumpCaptureQueue() {
+  while (activeCaptures < CAPTURE_CONCURRENCY && captureQueue.length > 0) {
+    const job = captureQueue.shift();
+    if (!entryIsNeeded(job.entry)) {
+      settleEntry(job.entry, null);
+      continue;
+    }
+    activeCaptures += 1;
+    activeEntries.add(job.entry);
+    job.entry.state = 'active';
+    job.entry.controller = new AbortController();
+    rasterizeSource(job.source, job.browsingSession, job.entry.controller.signal)
+      .then((data) => {
+        settleEntry(job.entry, data);
+      }, () => {
+        settleEntry(job.entry, null);
+      })
+      .finally(() => {
+        activeCaptures -= 1;
+        activeEntries.delete(job.entry);
+        trimSourceCache();
+        pumpCaptureQueue();
+      });
+  }
+}
+
+function cachedRaster(source, browsingSession, tabKey, isCurrent) {
+  const existing = sourceCache.get(source);
+  detachPendingTab(tabKey, existing);
+  if (existing) {
+    if (existing.settled) {
+      // Refresh insertion order so completed cache eviction is approximate LRU.
+      sourceCache.delete(source);
+      sourceCache.set(source, existing);
+    } else {
+      existing.consumers.set(tabKey, isCurrent);
+      pendingByTab.set(tabKey, existing);
+    }
+    return existing.promise;
+  }
+  compactCaptureQueue();
+  // Aborted/superseded requests still occupy a physical concurrency slot
+  // until their promise settles, but they no longer consume the logical work
+  // budget. This leaves room for the current source that replaced them.
+  const currentActive = [...activeEntries].filter(entryIsNeeded).length;
+  if (currentActive + captureQueue.length >= MAX_PENDING_CAPTURES) {
+    return Promise.resolve(null);
+  }
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  const entry = {
+    source,
+    promise,
+    resolve,
+    settled: false,
+    state: 'queued',
+    controller: null,
+    generation: captureGeneration,
+    consumers: new Map([[tabKey, isCurrent]]),
+  };
+  sourceCache.set(source, entry);
+  pendingByTab.set(tabKey, entry);
+  captureQueue.push({ source, browsingSession, entry });
+  pumpCaptureQueue();
+  return promise;
+}
+
+/** Strand every capture from the previous account/consent generation. Queued
+ * work resolves without starting, and active network requests are aborted.
+ * Completed pixel-only cache entries may remain reusable. */
+function cancelCaptures() {
+  captureGeneration += 1;
+  for (const job of captureQueue.splice(0)) settleEntry(job.entry, null);
+  pendingByTab.clear();
+  for (const entry of sourceCache.values()) {
+    if (entry.settled) continue;
+    entry.consumers.clear();
+    if (sourceCache.get(entry.source) === entry) sourceCache.delete(entry.source);
+    entry.controller?.abort();
+  }
+}
+
+function notifyChanged() {
+  for (const fn of changeListeners) fn();
+}
+
+function syncablePageUrl(tab) {
+  return (
+    tab &&
+    !tab.private &&
+    typeof tab.url === 'string' &&
+    /^https?:\/\//.test(tab.url) &&
+    tab.url.length <= model.MAX_URL
+  ) ? tab.url : null;
+}
+
+/** Keep the device-local working set aligned with actual open tabs. This
+ * bounds memory independently of the serialized sidecar budget and removes
+ * navigation/closed-tab residue before any subsequent publish. */
+function pruneLocalIcons(tabs = snapshotProvider?.().tabList ?? []) {
+  const live = new Set();
+  for (const tab of tabs) {
+    const url = syncablePageUrl(tab);
+    if (url) live.add(url);
+  }
+  let changed = false;
+  for (const url of localIcons.keys()) {
+    if (!live.has(url)) {
+      localIcons.delete(url);
+      changed = true;
+    }
+  }
+  while (localIcons.size > model.MAX_ICONS) {
+    localIcons.delete(localIcons.keys().next().value);
+    changed = true;
+  }
+  return { live, changed };
+}
+
+function setLocalIcon(url, data) {
+  const existing = localIcons.get(url);
+  if (existing === data) return false;
+  if (existing !== undefined) localIcons.delete(url);
+  while (localIcons.size >= model.MAX_ICONS) {
+    localIcons.delete(localIcons.keys().next().value);
+  }
+  localIcons.set(url, data);
+  return true;
+}
+
+async function captureTab(tab, ctx, { isCurrent = () => true } = {}) {
+  if (!syncablePageUrl(tab)) return false;
+
+  const pageUrl = tab.url;
+  const source = validFavicon(tab.favicon);
+  if (!source) {
+    if (!isCurrent()) return false;
+    bindContext(ctx);
+    const pruned = pruneLocalIcons();
+    const changed = localIcons.delete(pageUrl) || pruned.changed;
+    if (changed) notifyChanged();
+    return changed;
+  }
+
+  const captureIsCurrent = () =>
+    isCurrent() &&
+    tab.url === pageUrl &&
+    validFavicon(tab.favicon) === source;
+  // Production tabs have stable UUIDs. The object fallback keeps direct
+  // module callers/tests bounded without conflating distinct tab objects that
+  // happen to show the same page URL.
+  const tabKey = tab.id ?? tab;
+  const data = await cachedRaster(
+    source,
+    tab.view?.webContents?.session,
+    tabKey,
+    captureIsCurrent
+  );
+  // A later page-favicon-updated event may supersede this source while its
+  // bounded fetch is still queued or running. Never let the older completion
+  // overwrite the newer icon for the same page.
+  if (
+    !data ||
+    !isCurrent() ||
+    tab.url !== pageUrl ||
+    validFavicon(tab.favicon) !== source
+  ) return false;
+  bindContext(ctx);
+  const pruned = pruneLocalIcons();
+  if (snapshotProvider && !pruned.live.has(pageUrl)) {
+    if (pruned.changed) notifyChanged();
+    return pruned.changed;
+  }
+  const changed = setLocalIcon(pageUrl, data) || pruned.changed;
+  if (!changed) return false;
+  notifyChanged();
+  return true;
+}
+
+async function refreshCurrent(ctx, { isCurrent = () => true } = {}) {
+  if (!isCurrent()) return false;
+  bindContext(ctx);
+  const allTabs = snapshotProvider?.().tabList ?? [];
+  const pruned = pruneLocalIcons(allTabs);
+  if (pruned.changed) notifyChanged();
+  const tabs = allTabs
+    .filter((tab) => tab && !tab.private && /^https?:\/\//.test(tab.url) && tab.favicon)
+    // A cold enable must not fan out hundreds of duplicate favicon reads at
+    // once. Live favicon events still fill later rows opportunistically.
+    .slice(0, MAX_REFRESH_ICONS);
+  let cursor = 0;
+  let changed = pruned.changed;
+  const worker = async () => {
+    while (cursor < tabs.length && isCurrent()) {
+      const tab = tabs[cursor++];
+      changed = (await captureTab(tab, ctx, { isCurrent })) || changed;
+    }
+  };
+  await Promise.all(Array.from(
+    { length: Math.min(CAPTURE_CONCURRENCY, tabs.length) },
+    () => worker()
+  ));
+  return changed;
+}
+
+function exportForSync(ctx) {
+  const s = bindContext(ctx);
+  const { store: next, upload } = model.exportDevices({
+    devices: s.data.devices,
+    deviceId: ctx.deviceId,
+    syncTabs: ctx.syncTabs,
+    snapshot: snapshotProvider ? currentSnapshot(ctx) : null,
+    now: Date.now(),
+  });
+  s.update((data) => { data.devices = next; });
+  return { devices: upload };
+}
+
+function mergeFromSync(remote, ctx) {
+  const s = bindContext(ctx);
+  const before = model.canonical(s.data.devices);
+  s.update((data) => {
+    data.devices = model.mergeDevices(data.devices, remote?.devices, {
+      now: Date.now(),
+      ownId: ctx.deviceId,
+    });
+  });
+  if (model.canonical(s.data.devices) !== before) {
+    for (const fn of remoteListeners) fn();
+  }
+}
+
+const equalsRemote = (exported, remote) =>
+  model.devicesEqual(exported?.devices, remote?.devices);
+
+const getRemoteIcons = (ctx) =>
+  model.displayDevices(bindContext(ctx).data.devices, ctx.deviceId, { now: Date.now() });
+
+const attachToRemoteDevices = (devices, ctx) =>
+  model.attachIcons(devices, getRemoteIcons(ctx));
+
+const heartbeatDue = (ctx) =>
+  model.heartbeatDue(bindContext(ctx).data.devices[ctx.deviceId], Date.now());
+
+function onSyncDisabled() {
+  cancelCaptures();
+  const s = ensureStore();
+  const hadDevices = Object.keys(s.data.devices).length > 0;
+  s.update((data) => {
+    data.accountId = '';
+    data.devices = {};
+  });
+  localContextKey = '';
+  localIcons.clear();
+  if (hadDevices) for (const fn of remoteListeners) fn();
+}
+
+module.exports = {
+  setSnapshotProvider,
+  onChanged,
+  onRemoteChanged,
+  cancelCaptures,
+  captureTab,
+  refreshCurrent,
+  exportForSync,
+  mergeFromSync,
+  equalsRemote,
+  getRemoteIcons,
+  attachToRemoteDevices,
+  heartbeatDue,
+  onSyncDisabled,
+};

--- a/src/main/tabsync-model.js
+++ b/src/main/tabsync-model.js
@@ -72,11 +72,15 @@ function winner(local, remote, isOwn) {
 /** Union by deviceId, last-writer-wins per entry on updatedAt with the
  * deterministic tie rule above (each device only ever rewrites its own
  * entry, so this is commutative and idempotent across peers — spec §5).
- * Remote entries are sanitized; both sides prune at 30 days. */
+ * Both cached and remote entries are sanitized; this also migrates away any
+ * unknown tab fields written by an experimental/newer client, keeping the
+ * deployed session shape stable across mixed-version accounts. Both sides
+ * prune at 30 days. */
 function mergeDevices(local, remote, { now, ownId }) {
   const out = {};
-  for (const [id, e] of Object.entries(local ?? {})) {
-    if (e && Number.isFinite(e.updatedAt)) out[id] = e;
+  for (const [id, raw] of Object.entries(local ?? {})) {
+    const e = sanitizeEntry(raw);
+    if (e) out[id] = e;
   }
   for (const [id, raw] of Object.entries(remote ?? {})) {
     const e = sanitizeEntry(raw);

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -436,7 +436,7 @@
     const row = document.createElement('div');
     row.className = 'island-row tab-row';
     const favicon = document.createElement('span');
-    setFavicon(favicon, null); // snapshots carry no favicon — default glyph
+    setFavicon(favicon, tab);
     const title = document.createElement('span');
     title.className = 'row-title';
     title.textContent = tab.title || tab.url;
@@ -630,7 +630,7 @@
     for (const device of remoteDevices) {
       for (const t of device.tabs) {
         const s = matchScore(query, matchableText(t.title, t.url));
-        if (s) results.push({ kind: 'remote', title: t.title || t.url, sub: `${hostOfUrl(t.url)} · ${device.name}`, url: t.url, score: s + 0.05 });
+        if (s) results.push({ kind: 'remote', title: t.title || t.url, sub: `${hostOfUrl(t.url)} · ${device.name}`, url: t.url, tab: t, score: s + 0.05 });
       }
     }
     for (const h of historyEntries) {

--- a/test/unit/session-snapshot.test.js
+++ b/test/unit/session-snapshot.test.js
@@ -38,15 +38,21 @@ test('persistableEntries keeps id/groupId/pinned aligned per entry', () => {
 
 test('syncSnapshot: http(s)-only, url-length skip, title truncation, private excluded', () => {
   const snap = syncSnapshot([
-    tab({ title: 'x'.repeat(500) }),
+    tab({ title: 'x'.repeat(500), favicon: 'https://a.example/icon.svg' }),
     tab({ id: 'b', url: 'file:///etc/hosts' }),
     tab({ id: 'c', url: 'blanc://settings/' }),
     tab({ id: 'd', private: true }),
     tab({ id: 'e', url: 'https://long.example/' + 'p'.repeat(2100) }),
-    tab({ id: 'f', url: 'blanc://error/?url=' + encodeURIComponent('https://fail.example/') }),
+    tab({
+      id: 'f',
+      url: 'blanc://error/?url=' + encodeURIComponent('https://fail.example/'),
+      favicon: 'javascript:alert(1)',
+    }),
   ], []);
   assert.deepEqual(snap.tabs.map((t) => t.url), ['https://a.example/x', 'https://fail.example/']);
   assert.equal(snap.tabs[0].title.length, 200);
+  // Mixed-version contract: icon metadata lives in the optional sidecar and
+  // must never change the deployed session-tab shape.
   assert.deepEqual(Object.keys(snap.tabs[0]).sort(), ['groupId', 'pinned', 'title', 'url']);
 });
 

--- a/test/unit/sync-icon-scheduling.test.js
+++ b/test/unit/sync-icon-scheduling.test.js
@@ -1,0 +1,104 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+test('cosmetic icon churn never postpones the primary session timer', (t) => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-sync-timers-'));
+  fs.writeFileSync(path.join(tmp, 'sync.json'), JSON.stringify({
+    enabled: true,
+    handle: 'timer-test',
+    accountId: 'a'.repeat(64),
+    key: Buffer.alloc(32, 3).toString('base64'),
+    lastSyncedAt: 0,
+    lastError: null,
+    deviceId: 'timer-device',
+    syncTabs: true,
+  }));
+
+  let tabChanged;
+  let iconChanged;
+  const stub = (request, exports) => {
+    const id = require.resolve(request);
+    require.cache[id] = { id, filename: id, loaded: true, exports };
+    return id;
+  };
+  const cached = [
+    stub('electron', {
+      app: { getPath: () => tmp, on: () => {}, isPackaged: false },
+      net: { fetch: async () => ({ status: 404, ok: false }) },
+    }),
+    stub('../../src/main/settings', {
+      exportForSync: () => ({}),
+      mergeFromSync: () => {},
+      onSettingsChanged: () => {},
+    }),
+    stub('../../src/main/bookmarks', {
+      exportForSync: () => ({}),
+      mergeFromSync: () => {},
+      onChanged: () => {},
+    }),
+    stub('../../src/main/tabsync', {
+      exportForSync: () => ({ devices: {} }),
+      mergeFromSync: () => {},
+      equalsRemote: () => true,
+      onSyncDisabled: () => {},
+      onChanged: (fn) => { tabChanged = fn; },
+      heartbeatDue: () => false,
+      getRemoteDevices: () => [],
+    }),
+    stub('../../src/main/tabicons', {
+      exportForSync: () => ({ devices: {} }),
+      mergeFromSync: () => {},
+      equalsRemote: () => true,
+      onSyncDisabled: () => {},
+      onChanged: (fn) => { iconChanged = fn; },
+      refreshCurrent: async () => false,
+      heartbeatDue: () => false,
+      attachToRemoteDevices: (devices) => devices,
+      captureTab: async () => false,
+    }),
+  ];
+
+  const original = {
+    setTimeout: global.setTimeout,
+    clearTimeout: global.clearTimeout,
+    setInterval: global.setInterval,
+    clearInterval: global.clearInterval,
+  };
+  let nextId = 0;
+  const timers = [];
+  const cleared = [];
+  global.setTimeout = (fn, delay) => {
+    const timer = { id: ++nextId, fn, delay };
+    timers.push(timer);
+    return timer;
+  };
+  global.clearTimeout = (timer) => {
+    if (timer?.id) cleared.push(timer.id);
+  };
+  global.setInterval = () => ({ id: ++nextId });
+  global.clearInterval = () => {};
+
+  t.after(() => {
+    Object.assign(global, original);
+    for (const id of cached) delete require.cache[id];
+    delete require.cache[require.resolve('../../src/main/sync')];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const sync = require('../../src/main/sync');
+  sync.init();
+  assert.equal(typeof tabChanged, 'function');
+  assert.equal(typeof iconChanged, 'function');
+
+  tabChanged();
+  const scheduled = timers.filter(({ delay }) => delay === 15_000);
+  assert.equal(scheduled.length, 2, 'tab change schedules session and icon stores');
+  const [sessionTimer, firstIconTimer] = scheduled;
+
+  iconChanged();
+  assert.ok(cleared.includes(firstIconTimer.id), 'new icon work replaces its cosmetic timer');
+  assert.ok(!cleared.includes(sessionTimer.id), 'the required session deadline stays intact');
+});

--- a/test/unit/sync-optional-icons.test.js
+++ b/test/unit/sync-optional-icons.test.js
@@ -1,0 +1,56 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-sync-icons-'));
+const requests = [];
+let responseStatus = 404;
+const electronId = require.resolve('electron');
+require.cache[electronId] = {
+  id: electronId,
+  filename: electronId,
+  loaded: true,
+  exports: {
+    nativeImage: {},
+    net: {
+      fetch: async (url, opts = {}) => {
+        requests.push({ url: String(url), method: opts.method ?? 'GET' });
+        return { status: responseStatus, ok: responseStatus >= 200 && responseStatus < 300 };
+      },
+    },
+    app: { getPath: () => tmp, on: () => {} },
+  },
+};
+
+fs.writeFileSync(path.join(tmp, 'sync.json'), JSON.stringify({
+  enabled: true,
+  handle: 'compat-test',
+  accountId: 'a'.repeat(64),
+  key: Buffer.alloc(32, 7).toString('base64'),
+  lastSyncedAt: 1234,
+  lastError: 'A required store failed earlier.',
+  deviceId: 'compat-device',
+  syncTabs: true,
+}));
+
+const sync = require('../../src/main/sync');
+
+test('an older Worker rejecting the optional icons store does not fail profile sync', async () => {
+  const result = await sync.syncNow(['icons']);
+  assert.equal(result.ok, true);
+  assert.deepEqual(requests.map(({ method }) => method), ['GET', 'PUT']);
+  assert.equal(sync.status().lastSyncedAt, 1234);
+  assert.equal(sync.status().lastError, 'A required store failed earlier.');
+});
+
+test('an optional icon-store outage cannot overwrite the primary profile sync status', async () => {
+  requests.length = 0;
+  responseStatus = 500;
+  const result = await sync.syncNow(['icons']);
+  assert.equal(result.ok, true);
+  assert.deepEqual(requests.map(({ method }) => method), ['GET']);
+  assert.equal(sync.status().lastSyncedAt, 1234);
+  assert.equal(sync.status().lastError, 'A required store failed earlier.');
+});

--- a/test/unit/tabicons-model.test.js
+++ b/test/unit/tabicons-model.test.js
@@ -1,0 +1,181 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const m = require('../../src/main/tabicons-model');
+
+const NOW = 1_800_000_000_000;
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const PNG_A = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGElEQVR42mNgGAWjYBSMglEwCkbBqAABBgAE/wABeV0FzgAAAABJRU5ErkJggg==';
+const pngBBytes = Buffer.from(PNG_A.split(',')[1], 'base64');
+pngBBytes[pngBBytes.length - 1] ^= 1;
+const PNG_B = `data:image/png;base64,${pngBBytes.toString('base64')}`;
+const icon = (over = {}) => ({ url: 'https://a.example/', data: PNG_A, ...over });
+const entry = (over = {}) => ({ updatedAt: NOW - HOUR, icons: [icon()], ...over });
+
+test('validIconData accepts only bounded, structurally identified PNG data URLs', () => {
+  const fakePng = `data:image/png;base64,${Buffer.from('<svg/>').toString('base64')}`;
+  const oversized = `${PNG_A}${'A'.repeat(m.MAX_ICON_DATA)}`;
+  assert.equal(m.validIconData(PNG_A), PNG_A);
+  assert.equal(m.validIconData('https://a.example/icon.png'), null);
+  assert.equal(m.validIconData('data:image/svg+xml,<svg/>'), null);
+  assert.equal(m.validIconData(fakePng), null, 'MIME label alone cannot smuggle another format');
+  assert.equal(m.validIconData('data:image/png;base64,AAAA'), null, 'truncated PNG rejected');
+  assert.equal(m.validIconData(oversized), null);
+});
+
+test('source PNG guard rejects alternate formats and dimension bombs before decode', () => {
+  const bytes = Buffer.from(PNG_A.slice(m.PNG_DATA_PREFIX.length), 'base64');
+  assert.equal(m.validSourcePngBytes(bytes), bytes);
+  assert.deepEqual(m.sourcePngFromDataUrl(PNG_A), bytes);
+
+  const hugeWidth = Buffer.from(bytes);
+  hugeWidth.writeUInt32BE(m.MAX_SOURCE_DIMENSION + 1, 16);
+  const hugePixels = Buffer.from(bytes);
+  hugePixels.writeUInt32BE(m.MAX_SOURCE_DIMENSION, 16);
+  hugePixels.writeUInt32BE(m.MAX_SOURCE_DIMENSION, 20);
+  assert.equal(m.validSourcePngBytes(Buffer.from('<svg/>')), null);
+  assert.equal(m.validSourcePngBytes(hugeWidth), null);
+  assert.equal(m.validSourcePngBytes(hugePixels), null);
+  assert.equal(m.sourcePngFromDataUrl('data:image/svg+xml;base64,PHN2Zy8+'), null);
+  assert.equal(
+    m.sourcePngFromDataUrl(`data:image/png;base64,${hugeWidth.toString('base64')}`),
+    null
+  );
+});
+
+test('network icon sources reject obvious local and private-network targets', () => {
+  assert.equal(m.isPublicHttpSource('https://cdn.example/icon.png'), true);
+  assert.equal(m.isPublicHttpSource('http://8.8.8.8/icon.png'), true);
+  for (const source of [
+    'http://localhost/icon.png',
+    'http://sub.localhost/icon.png',
+    'http://printer.local./icon.png',
+    'http://127.1/icon.png',
+    'http://10.0.0.1/icon.png',
+    'http://100.64.0.1/icon.png',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://172.31.255.255/icon.png',
+    'http://192.168.1.1/icon.png',
+    'http://[::1]/icon.png',
+    'http://[fd00::1]/icon.png',
+    'http://[fe80::1]/icon.png',
+    'http://[fec0::1]/icon.png',
+    'http://[ff02::1]/icon.png',
+    'http://[::ffff:127.0.0.1]/icon.png',
+  ]) {
+    assert.equal(m.isPublicHttpSource(source), false, source);
+  }
+});
+
+test('sanitizeEntry validates, deduplicates, caps, and preserves retractions', () => {
+  assert.equal(m.sanitizeEntry(null), null);
+  assert.equal(m.sanitizeEntry({ icons: [] }), null);
+  assert.deepEqual(
+    m.sanitizeEntry({ retracted: true, updatedAt: NOW, junk: true }),
+    { retracted: true, updatedAt: NOW }
+  );
+  const clean = m.sanitizeEntry({
+    updatedAt: NOW,
+    icons: [
+      icon(),
+      icon({ data: PNG_B }),
+      icon({ url: 'file:///tmp/icon', data: PNG_A }),
+      icon({ url: 'https://b.example/', data: 'https://b.example/icon.png' }),
+    ],
+  });
+  assert.deepEqual(clean.icons, [icon()]);
+});
+
+test('buildOwnEntry clocks icon changes and heartbeat, not identical rebuilds', () => {
+  const first = m.buildOwnEntry({ prev: null, snapshot: { icons: [icon()] }, now: NOW });
+  assert.equal(first.updatedAt, NOW);
+  const same = m.buildOwnEntry({ prev: first, snapshot: { icons: [icon()] }, now: NOW + HOUR });
+  assert.equal(same.updatedAt, NOW);
+  const changed = m.buildOwnEntry({
+    prev: first,
+    snapshot: { icons: [icon({ data: PNG_B })] },
+    now: NOW + HOUR,
+  });
+  assert.equal(changed.updatedAt, NOW + HOUR);
+  const heartbeat = m.buildOwnEntry({ prev: first, snapshot: { icons: [icon()] }, now: NOW + DAY });
+  assert.equal(heartbeat.updatedAt, NOW + DAY);
+});
+
+test('merge is LWW, retractions win stale data, and old devices prune', () => {
+  const retracted = { retracted: true, updatedAt: NOW };
+  const out = m.mergeDevices(
+    {
+      live: entry({ updatedAt: NOW - 2 * HOUR }),
+      gone: entry({ updatedAt: NOW - HOUR }),
+      old: entry({ updatedAt: NOW - 31 * DAY }),
+    },
+    {
+      live: entry({ updatedAt: NOW - HOUR, icons: [icon({ data: PNG_B })] }),
+      gone: retracted,
+    },
+    { now: NOW, ownId: 'me' }
+  );
+  assert.equal(out.live.icons[0].data, PNG_B);
+  assert.deepEqual(out.gone, retracted);
+  assert.equal(out.old, undefined);
+});
+
+test('icon budget trims only the sidecar while the session keeps every tab', () => {
+  // The model's format cap keeps each record small. Repeating valid icons
+  // under distinct, bounded page URLs still exercises the account-level budget.
+  const icons = Array.from({ length: 500 }, (_, i) =>
+    icon({ url: `https://a.example/${'p'.repeat(600)}/${i}`, data: PNG_A }));
+  const iconDevices = { own: entry({ updatedAt: NOW, icons }) };
+  const sessionDevices = [{
+    deviceId: 'own',
+    tabs: icons.map(({ url }) => ({ url, title: url, groupId: null, pinned: false })),
+    groups: [],
+  }];
+
+  const bounded = m.applyBudget(iconDevices, 'own');
+  assert.ok(Buffer.byteLength(m.canonical(bounded), 'utf8') <= m.BUDGET_BYTES);
+  assert.ok(bounded.own.icons.length < icons.length);
+  assert.equal(iconDevices.own.icons.length, 500, 'input keeps the full icon cache');
+  assert.equal(sessionDevices[0].tabs.length, 500, 'primary tab snapshot is structurally isolated');
+});
+
+test('budget trimming does not advance the icon clock or cause repeat repairs', () => {
+  const icons = Array.from({ length: 100 }, (_, i) =>
+    icon({ url: `https://a.example/${'p'.repeat(600)}/${i}` }));
+  const args = {
+    deviceId: 'me',
+    syncTabs: true,
+    snapshot: { icons },
+    maxBytes: 24 * 1024,
+  };
+  const first = m.exportDevices({ devices: {}, ...args, now: NOW });
+  assert.equal(first.store.me.icons.length, 100);
+  assert.ok(first.upload.me.icons.length < 100);
+  const second = m.exportDevices({ devices: first.store, ...args, now: NOW + HOUR });
+  assert.equal(second.store.me.updatedAt, NOW);
+  assert.deepEqual(second.store, first.store);
+  assert.equal(m.devicesEqual(second.upload, first.upload), true);
+});
+
+test('attachIcons exposes safe data only in the renderer projection', () => {
+  const remote = [{
+    deviceId: 'other',
+    name: 'Other Mac',
+    tabs: [
+      { url: 'https://a.example/', title: 'A', groupId: null, pinned: false },
+      { url: 'https://missing.example/', title: 'Missing', groupId: null, pinned: false },
+    ],
+    groups: [],
+  }];
+  const projected = m.attachIcons(remote, {
+    other: [
+      icon(),
+      { url: 'https://missing.example/', data: 'https://tracker.example/icon.png' },
+    ],
+  });
+  assert.equal(projected[0].tabs[0].favicon, PNG_A);
+  assert.equal(projected[0].tabs[1].favicon, null);
+  assert.equal(projected[0].tabs.every((tab) => !/^https?:/.test(tab.favicon ?? '')), true);
+  assert.equal('favicon' in remote[0].tabs[0], false, 'wire/session object is not mutated');
+});

--- a/test/unit/tabicons.test.js
+++ b/test/unit/tabicons.test.js
@@ -1,0 +1,469 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const PNG_DATA = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGElEQVR42mNgGAWjYBSMglEwCkbBqAABBgAE/wABeV0FzgAAAABJRU5ErkJggg==';
+const PNG_BYTES = Buffer.from(PNG_DATA.split(',')[1], 'base64');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-tabicons-'));
+const requests = [];
+let decodeCount = 0;
+
+const image = {
+  isEmpty: () => false,
+  resize: () => image,
+  toPNG: () => PNG_BYTES,
+};
+const electronId = require.resolve('electron');
+require.cache[electronId] = {
+  id: electronId,
+  filename: electronId,
+  loaded: true,
+  exports: {
+    app: { getPath: () => tmp, on: () => {} },
+    nativeImage: {
+      createFromBuffer: () => {
+        decodeCount += 1;
+        return image;
+      },
+      createFromDataURL: () => image,
+    },
+  },
+};
+
+const tabicons = require('../../src/main/tabicons');
+const ctx = {
+  accountId: 'account-a',
+  deviceId: 'device-a',
+  syncTabs: true,
+};
+
+function response(contentType, bytes = PNG_BYTES) {
+  return {
+    ok: true,
+    headers: {
+      get: (name) => name === 'content-type' ? contentType : null,
+    },
+    arrayBuffer: async () => Uint8Array.from(bytes).buffer,
+  };
+}
+
+test('capture rasterizes on the source device without cookies or a referrer', async () => {
+  const session = {
+    fetch: async (url, options) => {
+      requests.push({ url, options });
+      return response('image/png');
+    },
+  };
+  const tab = {
+    url: 'https://page.example/',
+    favicon: 'https://cdn.example/icon.png',
+    private: false,
+    view: { webContents: { session } },
+  };
+  tabicons.setSnapshotProvider(() => ({ tabList: [tab] }));
+
+  assert.equal(await tabicons.captureTab(tab, ctx), true);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].options.credentials, 'omit');
+  assert.equal(requests[0].options.referrerPolicy, 'no-referrer');
+  assert.equal(requests[0].options.redirect, 'error');
+
+  const payload = tabicons.exportForSync(ctx);
+  assert.deepEqual(payload.devices['device-a'].icons, [{
+    url: 'https://page.example/',
+    data: PNG_DATA,
+  }]);
+});
+
+test('capture rejects non-image responses before decoding or serializing them', async () => {
+  const before = decodeCount;
+  const tab = {
+    url: 'https://other.example/',
+    favicon: 'https://other.example/not-an-image',
+    private: false,
+    view: {
+      webContents: {
+        session: { fetch: async () => response('text/html; charset=utf-8') },
+      },
+    },
+  };
+
+  assert.equal(await tabicons.captureTab(tab, ctx), false);
+  assert.equal(decodeCount, before);
+  const payload = tabicons.exportForSync(ctx);
+  assert.equal(payload.devices['device-a'].icons.some((icon) => icon.url === tab.url), false);
+});
+
+test('capture validates PNG format and dimensions before nativeImage decode, including data URLs', async () => {
+  const before = decodeCount;
+  const huge = Buffer.from(PNG_BYTES);
+  huge.writeUInt32BE(1025, 16);
+  const cases = [
+    {
+      favicon: 'https://unsafe.example/vector.svg',
+      fetch: async () => response('image/svg+xml', Buffer.from('<svg/>')),
+    },
+    {
+      favicon: 'https://unsafe.example/spoofed.png',
+      fetch: async () => response('image/png', Buffer.from('<svg/>')),
+    },
+    {
+      favicon: `data:image/png;base64,${huge.toString('base64')}`,
+      fetch: null,
+    },
+    {
+      favicon: 'data:image/svg+xml;base64,PHN2Zy8+',
+      fetch: null,
+    },
+  ];
+  for (const [index, item] of cases.entries()) {
+    const tab = {
+      url: `https://unsafe-page-${index}.example/`,
+      favicon: item.favicon,
+      private: false,
+      view: item.fetch ? { webContents: { session: { fetch: item.fetch } } } : null,
+    };
+    tabicons.setSnapshotProvider(() => ({ tabList: [tab] }));
+    assert.equal(await tabicons.captureTab(tab, ctx), false, item.favicon);
+  }
+  assert.equal(decodeCount, before);
+});
+
+test('capture never fetches obvious localhost, LAN, or link-local sources', async () => {
+  let fetched = false;
+  const session = {
+    fetch: async () => {
+      fetched = true;
+      return response('image/png');
+    },
+  };
+  for (const [index, favicon] of [
+    'http://localhost/icon.png',
+    'http://printer.local/icon.png',
+    'http://127.0.0.1/icon.png',
+    'http://169.254.169.254/icon.png',
+    'http://192.168.1.1/icon.png',
+    'http://[::1]/icon.png',
+    'http://[fd00::1]/icon.png',
+  ].entries()) {
+    const tab = {
+      url: `https://public-${index}.example/`,
+      favicon,
+      private: false,
+      view: { webContents: { session } },
+    };
+    assert.equal(await tabicons.captureTab(tab, ctx), false, favicon);
+  }
+  assert.equal(fetched, false);
+});
+
+test('live captures share a globally bounded scheduler and queue', async () => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  let active = 0;
+  let maxActive = 0;
+  let started = 0;
+  const session = {
+    fetch: async () => {
+      started += 1;
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await gate;
+      active -= 1;
+      return response('image/png');
+    },
+  };
+  const tabs = Array.from({ length: 72 }, (_, index) => ({
+    url: `https://queue-page-${index}.example/`,
+    favicon: `https://queue-icons.example/${index}.png`,
+    private: false,
+    view: { webContents: { session } },
+  }));
+  tabicons.setSnapshotProvider(() => ({ tabList: tabs }));
+
+  const captures = tabs.map((tab) => tabicons.captureTab(tab, ctx));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(started, 4, 'only the global concurrency cap starts');
+  assert.equal(maxActive, 4);
+  release();
+  const results = await Promise.all(captures);
+  assert.equal(maxActive, 4);
+  assert.equal(results.filter(Boolean).length, 64, 'work beyond the hard pending cap is dropped');
+});
+
+test('cancelling a capture generation aborts active work and never starts queued requests', async () => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const started = [];
+  const signals = [];
+  const session = {
+    fetch: async (url, options) => {
+      started.push(url);
+      signals.push(options.signal);
+      await gate;
+      return response('image/png');
+    },
+  };
+  const tabs = Array.from({ length: 8 }, (_, index) => ({
+    url: `https://cancel-page-${index}.example/`,
+    favicon: `https://cancel-icons.example/${index}.png`,
+    private: false,
+    view: { webContents: { session } },
+  }));
+  tabicons.setSnapshotProvider(() => ({ tabList: tabs }));
+  let current = true;
+
+  const captures = tabs.map((tab) =>
+    tabicons.captureTab(tab, ctx, { isCurrent: () => current })
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(started.length, 4);
+
+  current = false;
+  tabicons.cancelCaptures();
+  assert.ok(signals.every((signal) => signal.aborted), 'active fetch signals are aborted');
+  release();
+
+  assert.deepEqual(await Promise.all(captures), Array(8).fill(false));
+  assert.equal(started.length, 4, 'queued work was resolved without issuing a request');
+});
+
+test('more than 64 favicon changes retain the final source instead of filling the queue with stale work', async () => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const started = [];
+  const blockerSession = {
+    fetch: async (url) => {
+      started.push(url);
+      await gate;
+      return response('image/png');
+    },
+  };
+  const finalSession = {
+    fetch: async (url) => {
+      started.push(url);
+      return response('image/png');
+    },
+  };
+  const blockers = Array.from({ length: 4 }, (_, index) => ({
+    url: `https://latest-blocker-${index}.example/`,
+    favicon: `https://latest-blocker-icons.example/${index}.png`,
+    private: false,
+    view: { webContents: { session: blockerSession } },
+  }));
+  const changing = {
+    url: 'https://latest-changing.example/',
+    favicon: '',
+    private: false,
+    view: { webContents: { session: finalSession } },
+  };
+  tabicons.setSnapshotProvider(() => ({ tabList: [...blockers, changing] }));
+
+  const blockerCaptures = blockers.map((tab) => tabicons.captureTab(tab, ctx));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(started.length, 4);
+
+  const changingCaptures = [];
+  for (let index = 0; index < 70; index += 1) {
+    changing.favicon = `https://latest-changing-icons.example/${index}.png`;
+    changingCaptures.push(tabicons.captureTab(changing, ctx));
+  }
+  const finalSource = changing.favicon;
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(started.length, 4, 'changing sources remain queued behind the active cap');
+
+  release();
+  await Promise.all(blockerCaptures);
+  const changingResults = await Promise.all(changingCaptures);
+
+  assert.ok(started.includes(finalSource), 'the final source was eventually fetched');
+  assert.equal(
+    started.filter((url) => url.startsWith('https://latest-changing-icons.example/')).length,
+    1,
+    'superseded queued sources never started'
+  );
+  assert.equal(changingResults.at(-1), true);
+  assert.ok(
+    tabicons.exportForSync(ctx).devices['device-a'].icons.some(({ url }) => url === changing.url),
+    'the final source produced the stored icon'
+  );
+});
+
+test('replacing an active source at the exact pending cap preserves the replacement slot', async () => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const started = [];
+  const session = {
+    fetch: async (url) => {
+      started.push(url);
+      await gate;
+      return response('image/png');
+    },
+  };
+  const activeChanging = {
+    url: 'https://cap-replacement.example/',
+    favicon: 'https://cap-replacement-icons.example/old.png',
+    private: false,
+    view: { webContents: { session } },
+  };
+  const otherTabs = Array.from({ length: 63 }, (_, index) => ({
+    url: `https://cap-load-${index}.example/`,
+    favicon: `https://cap-load-icons.example/${index}.png`,
+    private: false,
+    view: { webContents: { session } },
+  }));
+  const tabs = [activeChanging, ...otherTabs];
+  tabicons.setSnapshotProvider(() => ({ tabList: tabs }));
+
+  const captures = tabs.map((tab) => tabicons.captureTab(tab, ctx));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(started.length, 4, 'four jobs are active and sixty are queued');
+
+  activeChanging.favicon = 'https://cap-replacement-icons.example/current.png';
+  const replacement = tabicons.captureTab(activeChanging, ctx);
+  release();
+
+  await Promise.all(captures);
+  assert.equal(await replacement, true);
+  assert.ok(
+    started.includes(activeChanging.favicon),
+    'the replacement starts after its superseded active request is aborted'
+  );
+  assert.ok(
+    tabicons.exportForSync(ctx).devices['device-a'].icons.some(({ url }) => url === activeChanging.url),
+    'the replacement is retained in the synchronized icon set'
+  );
+});
+
+test('same-tab pushState churn replaces one pending consumer instead of retaining every URL', async () => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const started = [];
+  const session = {
+    fetch: async (url) => {
+      started.push(url);
+      await gate;
+      return response('image/png');
+    },
+  };
+  const changing = {
+    id: 'pushstate-tab',
+    url: 'https://pushstate.example/0',
+    favicon: 'https://pushstate.example/icon.png',
+    private: false,
+    view: { webContents: { session } },
+  };
+  const probe = {
+    id: 'pushstate-probe',
+    url: 'https://pushstate-probe.example/',
+    favicon: 'https://pushstate-probe.example/icon.png',
+    private: false,
+    view: { webContents: { session } },
+  };
+  tabicons.setSnapshotProvider(() => ({ tabList: [changing, probe] }));
+
+  let predicateChecks = 0;
+  const captures = [];
+  for (let index = 0; index < 200; index += 1) {
+    changing.url = `https://pushstate.example/${index}`;
+    captures.push(tabicons.captureTab(changing, ctx, {
+      isCurrent: () => {
+        predicateChecks += 1;
+        return true;
+      },
+    }));
+  }
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(started.length, 1, 'the shared source is fetched once');
+
+  predicateChecks = 0;
+  const probeCapture = tabicons.captureTab(probe, ctx);
+  assert.equal(
+    predicateChecks,
+    1,
+    'capacity accounting evaluates only the latest predicate for the changing tab'
+  );
+
+  release();
+  const results = await Promise.all(captures);
+  await probeCapture;
+  assert.equal(results.filter(Boolean).length, 1, 'only the final navigated URL stores the icon');
+});
+
+test('a superseded live favicon fetch cannot overwrite the newer source', async () => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const tab = {
+    url: 'https://changing-icon.example/',
+    favicon: 'https://changing-icon.example/old.png',
+    private: false,
+    view: {
+      webContents: {
+        session: {
+          fetch: async () => {
+            await gate;
+            return response('image/png');
+          },
+        },
+      },
+    },
+  };
+  tabicons.setSnapshotProvider(() => ({ tabList: [tab] }));
+
+  const pending = tabicons.captureTab(tab, ctx);
+  await new Promise((resolve) => setImmediate(resolve));
+  tab.favicon = 'https://changing-icon.example/new.png';
+  release();
+
+  assert.equal(await pending, false);
+  const payload = tabicons.exportForSync(ctx);
+  assert.equal(
+    payload.devices['device-a'].icons.some(({ url }) => url === tab.url),
+    false
+  );
+});
+
+test('local icon cache purges closed tabs and re-captures them if they become live again', async () => {
+  const session = { fetch: async () => response('image/png') };
+  const first = {
+    url: 'https://purge-first.example/',
+    favicon: 'https://purge-icons.example/first.png',
+    private: false,
+    view: { webContents: { session } },
+  };
+  const second = {
+    url: 'https://purge-second.example/',
+    favicon: 'https://purge-icons.example/second.png',
+    private: false,
+    view: { webContents: { session } },
+  };
+  let tabs = [first];
+  tabicons.setSnapshotProvider(() => ({ tabList: tabs }));
+  assert.equal(await tabicons.captureTab(first, ctx), true);
+  tabs = [second];
+  assert.equal(await tabicons.captureTab(second, ctx), true);
+  tabs = [first, second];
+  assert.equal(
+    await tabicons.captureTab(first, ctx),
+    true,
+    'the first entry was purged rather than retained after its tab closed'
+  );
+});
+
+test('local icon working set has a hard MAX_ICONS bound', async () => {
+  const tabs = Array.from({ length: 501 }, (_, index) => ({
+    url: `https://bounded-${index}.example/`,
+    favicon: PNG_DATA,
+    private: false,
+    view: null,
+  }));
+  tabicons.setSnapshotProvider(() => ({ tabList: tabs }));
+  await Promise.all(tabs.map((tab) => tabicons.captureTab(tab, ctx)));
+
+  const icons = tabicons.exportForSync(ctx).devices['device-a'].icons;
+  assert.equal(icons.length, 500);
+  assert.equal(icons.some(({ url }) => url === tabs[0].url), false, 'oldest working entry is evicted');
+  assert.equal(icons.some(({ url }) => url === tabs.at(-1).url), true);
+});

--- a/test/unit/tabsync-model.test.js
+++ b/test/unit/tabsync-model.test.js
@@ -38,7 +38,13 @@ test('sanitizeEntry: drops garbage, enforces http(s)/caps, passes retractions', 
     tabs: [
       aTab(),
       { url: 'javascript:alert(1)', title: 'x' },
-      { url: 'https://ok.example/', title: 7, pinned: 'yes', groupId: 9 },
+      {
+        url: 'https://ok.example/',
+        title: 7,
+        favicon: 'data:image/png;base64,AAAA',
+        pinned: 'yes',
+        groupId: 9,
+      },
       null,
     ],
     groups: [{ id: 'g1', name: 'work' }, { id: 2, name: 'bad' }, null],
@@ -50,6 +56,23 @@ test('sanitizeEntry: drops garbage, enforces http(s)/caps, passes retractions', 
     { url: 'https://ok.example/', title: '', groupId: null, pinned: true },
   ]);
   assert.deepEqual(dirty.groups, [{ id: 'g1', name: 'work' }]);
+});
+
+test('session compatibility: inline favicon fields are removed from cached and remote entries', () => {
+  const withInlineIcon = entry({
+    tabs: [aTab({ favicon: 'https://tracker.example/device-specific.png' })],
+  });
+  const out = m.mergeDevices(
+    { cached: withInlineIcon },
+    { remote: withInlineIcon },
+    { now: NOW, ownId: 'me' }
+  );
+  for (const device of Object.values(out)) {
+    assert.deepEqual(Object.keys(device.tabs[0]).sort(), ['groupId', 'pinned', 'title', 'url']);
+  }
+  // Once cleaned, the ordinary repair comparison sees a stable deployed
+  // shape instead of an add/strip write loop between client versions.
+  assert.equal(m.devicesEqual(out, JSON.parse(JSON.stringify(out))), true);
 });
 
 test('mergeDevices: union by deviceId, LWW per entry, remote sanitized', () => {


### PR DESCRIPTION
## Summary

- sync source-rasterized tab favicons through an optional E2EE `icons` sidecar
- preserve the deployed `session` schema and isolate icon bytes behind their own budget
- render safe embedded PNG favicons in remote Island rows and Quick Switcher results
- degrade cleanly with older Workers or icon-sidecar outages

## Root cause

Remote tab snapshots carried only URL/title/group metadata. Adding favicon URLs directly would make receiving devices contact sites from another session, while extending the existing session shape would create mixed-client repair churn and allow cosmetic bytes to evict tabs under the session budget.

## Validation

- `npm run test:unit` — 193 tests passed
- `npm run test:acceptance:dry` — 35 scenarios / 169 steps resolved
- `npm run substrate:check`
- syntax and diff checks