### PR TITLE
Fix RC release architecture and migration gates

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,20 +105,8 @@
         ]
       },
       "target": [
-        {
-          "target": "dmg",
-          "arch": [
-            "arm64",
-            "x64"
-          ]
-        },
-        {
-          "target": "zip",
-          "arch": [
-            "arm64",
-            "x64"
-          ]
-        }
+        "dmg",
+        "zip"
       ]
     },
     "win": {

--- a/test/desktop/packaged-migration-smoke.mjs
+++ b/test/desktop/packaged-migration-smoke.mjs
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { _electron } from 'playwright';
+import { evaluateElectronAppWithRetry } from './support/electron-evaluate.mjs';
 
 const stableExecutable = process.env.BLANC_STABLE_EXECUTABLE;
 const candidateExecutable =
@@ -42,8 +43,10 @@ const waitForRestoredUrls = async () => {
   const deadline = Date.now() + 15_000;
   let urls = [];
   while (Date.now() < deadline) {
-    urls = await app.evaluate(({ webContents }) =>
-      webContents.getAllWebContents().map((candidate) => candidate.getURL())
+    urls = await evaluateElectronAppWithRetry(
+      app,
+      ({ webContents }) =>
+        webContents.getAllWebContents().map((candidate) => candidate.getURL())
     );
     if (sessionUrls.every((expected) => urls.includes(expected))) return urls;
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/test/desktop/support/electron-evaluate.mjs
+++ b/test/desktop/support/electron-evaluate.mjs
@@ -1,0 +1,25 @@
+const sleep = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export function isTransientElectronEvaluationError(error) {
+  return /Execution context was destroyed/i.test(String(error?.message || error));
+}
+
+export async function evaluateElectronAppWithRetry(
+  electronApp,
+  evaluator,
+  { timeoutMs = 2_000, retryMs = 50 } = {}
+) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    try {
+      return await electronApp.evaluate(evaluator);
+    } catch (error) {
+      if (!isTransientElectronEvaluationError(error) || Date.now() >= deadline) {
+        throw error;
+      }
+      await sleep(retryMs);
+    }
+  }
+}

--- a/test/unit/electron-evaluate.test.js
+++ b/test/unit/electron-evaluate.test.js
@@ -1,0 +1,49 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const helper = import('../desktop/support/electron-evaluate.mjs');
+
+test('Electron main-process evaluation retries a navigation-destroyed context', async () => {
+  const { evaluateElectronAppWithRetry } = await helper;
+  let attempts = 0;
+  const electronApp = {
+    async evaluate() {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error(
+          'Execution context was destroyed, most likely because of a navigation.'
+        );
+      }
+      return ['https://example.com/'];
+    },
+  };
+
+  const result = await evaluateElectronAppWithRetry(
+    electronApp,
+    () => [],
+    { timeoutMs: 100, retryMs: 0 }
+  );
+
+  assert.deepEqual(result, ['https://example.com/']);
+  assert.equal(attempts, 2);
+});
+
+test('Electron main-process evaluation does not hide permanent failures', async () => {
+  const { evaluateElectronAppWithRetry } = await helper;
+  let attempts = 0;
+  const electronApp = {
+    async evaluate() {
+      attempts += 1;
+      throw new Error('candidate process exited');
+    },
+  };
+
+  await assert.rejects(
+    evaluateElectronAppWithRetry(electronApp, () => [], {
+      timeoutMs: 100,
+      retryMs: 0,
+    }),
+    /candidate process exited/
+  );
+  assert.equal(attempts, 1);
+});

--- a/test/unit/release-manifest.test.js
+++ b/test/unit/release-manifest.test.js
@@ -97,6 +97,9 @@ test('detects checksum tampering', () => {
 
 test('release policy stages a draft and refuses unsigned or unexpected Windows publishers', () => {
   const releaseScript = fs.readFileSync(path.join(root, 'scripts/release.sh'), 'utf8');
+  const packageConfig = JSON.parse(
+    fs.readFileSync(path.join(root, 'package.json'), 'utf8')
+  );
   const releaseWorkflow = fs.readFileSync(
     path.join(root, '.github/workflows/release-windows-linux.yml'),
     'utf8'
@@ -112,6 +115,10 @@ test('release policy stages a draft and refuses unsigned or unexpected Windows p
   assert.match(releaseWorkflow, /Refusing to build an unsigned press artifact/);
   assert.match(releaseWorkflow, /Unexpected Windows publisher/);
   assert.match(releaseWorkflow, /Get-AuthenticodeSignature/);
+  assert.deepEqual(packageConfig.build.mac.target, ['dmg', 'zip']);
+  assert.match(releaseScript, /MAC_BUILD_ARGS=\(\)/);
+  assert.match(releaseScript, /MAC_BUILD_ARGS\+=\(--arm64\)/);
+  assert.match(releaseScript, /MAC_BUILD_ARGS\+=\(--x64\)/);
   assert.doesNotMatch(allWorkflows, /actions\/(?:checkout|setup-node)@v7/);
   assert.match(allWorkflows, /actions\/checkout@v6/);
   assert.match(allWorkflows, /actions\/setup-node@v6/);


### PR DESCRIPTION
## Summary
- let the explicit release-script architecture flags control Electron Builder instead of hardcoding both Mac architectures
- retry only Playwright evaluation contexts destroyed by startup navigation
- keep permanent migration failures fail-closed
- add regression coverage for both paths

## Verification
- complete npm run release:verify:press passed: 243 unit tests, 47 Electron scenarios / 285 steps, OAuth, DNS, audit, and site build
- real v0.22.0 -> signed 1.0.0-rc.1 same-profile migration passed
- unpacked --arm64 build emitted mac-arm64 only and passed signature/profile/entitlement verification
- no v1.0.0-rc.1 tag or release exists