### PR TITLE
Rasterize ICO and SVG favicons for tab sync

### DIFF
--- a/docs/superpowers/specs/2026-07-21-tab-sync-design.md
+++ b/docs/superpowers/specs/2026-07-21-tab-sync-design.md
@@ -1,6 +1,6 @@
 # Tab Sync — open tabs from your other devices
 
-**Date:** 2026-07-21 (revised 2026-07-23)
+**Date:** 2026-07-21 (revised 2026-07-24)
 **Status:** Approved
 **Builds on:** [2026-07-07-profile-sync-design.md](2026-07-07-profile-sync-design.md) — this is the "session" store that spec deferred (§4, v2+) and the worker reserved (`// history/session added in a later phase`).
 
@@ -66,9 +66,15 @@ must be successful, declare an image content type, arrive within three
 seconds, and stay under 256 KB. Redirects are disabled, and localhost,
 `.local`, loopback, link-local, RFC1918/unique-local, and other reserved
 literal targets are rejected before fetch so capture cannot become a new LAN
-probe. The source is then decoded and rasterized to a 16×16 PNG; only a
-bounded `data:image/png;base64,...` value with a valid PNG signature/IHDR and
-16×16 dimensions can enter the sidecar or renderer projection. Receiving
+probe. A PNG source is decoded natively after a cheap header/dimension guard;
+other formats (ICO — usually BMP-framed — SVG, GIF, …), which `nativeImage`
+cannot decode, are drawn into a 16×16 canvas inside a locked-down, detached
+`WebContentsView` (`icon-raster.js`) — an SVG loaded via `<img>` runs no scripts
+and fetches no external resources, so untrusted vectors stay inert, and the
+renderer only ever sees inert `data:` bytes, never a live URL. Either path
+rasterizes to a 16×16 PNG; only a bounded `data:image/png;base64,...` value
+with a valid PNG signature/IHDR and 16×16 dimensions can enter the sidecar or
+renderer projection. Receiving
 chrome never contacts a remote tab's site merely to draw the list. The
 sidecar has its own 256 KB plaintext budget and discards cosmetic icon records
 before its limit; it can never evict a tab or device from the primary session
@@ -124,7 +130,7 @@ Unit tests (`test/unit/`, node --test) — most of the surface lives in the pure
 - Account binding: a changed `accountId` discards all cached remote entries (and only then); `deviceId` survives the rebind.
 - Snapshot builder (`session-snapshot.js`): private-tab exclusion, private-only group exclusion, error-URL unwrapping in `persistableEntries`; HTTP(S)-only filter, URL-length skip, and caps in `syncSnapshot`; `persistableEntries` output unchanged from today's `persistSession` behavior. Its exact tab keys are regression-pinned so icon work cannot drift the mixed-version wire schema.
 - Session fingerprint: identical snapshots hash equal; blocked-count/loading-flag-only changes don't alter it; url/title changes, group membership/order moves, tab reorders, and device renames all do; `updatedAt` alone never does. The icon sidecar has its own content fingerprint and clock.
-- Icon sidecar: accepts only bounded PNG data URLs with PNG structure, sanitizes/deduplicates remote records, preserves LWW/retraction/pruning semantics, trims icons without touching session tabs, and joins data only into the trusted renderer projection. Capture tests pin cookie-free/referrer-free fetching, rejection of non-PNG responses, cancellation on consent changes, and newest-source survival through queue pressure. An older Worker rejecting the optional store does not fail profile sync or overwrite required-store status.
+- Icon sidecar: accepts only bounded PNG data URLs with PNG structure, sanitizes/deduplicates remote records, preserves LWW/retraction/pruning semantics, trims icons without touching session tabs, and joins data only into the trusted renderer projection. Capture tests pin cookie-free/referrer-free fetching, rejection of non-image responses, rasterization of non-PNG image formats (ICO/SVG) through the sandboxed canvas, cancellation on consent changes, and newest-source survival through queue pressure. An older Worker rejecting the optional store does not fail profile sync or overwrite required-store status.
 - Repair comparison: a remote map missing our unchanged entry → differs → PUT; identical maps → no write.
 - Heartbeat: an own entry older than 24 h is due for republish even with an unchanged fingerprint.
 - Size budget: own-tabs trimming first, stale-other-device dropping second, output always under the plaintext budget.

--- a/src/main/icon-raster.js
+++ b/src/main/icon-raster.js
@@ -1,0 +1,104 @@
+// Rasterize arbitrary favicon bytes into a fixed 16x16 PNG using Chromium's own
+// image decoders. `nativeImage.createFromBuffer` only decodes PNG/JPEG, so ICO
+// (BMP-framed), SVG, GIF, WEBP, and friends — the majority of real favicons —
+// cannot be rendered that way and never synced. This draws the bytes into a
+// canvas inside a locked-down, detached WebContentsView instead.
+//
+// Only inert `data:` bytes are ever handed in (fetched in the main process with
+// the SSRF/cookie/redirect guards in tabicons.js), never a live URL — so this
+// view makes no network requests of its own. An SVG loaded through `<img>`
+// additionally runs no scripts and fetches no external resources, keeping
+// untrusted vector sources inert. The output is re-validated as a bounded 16x16
+// PNG by the caller (`validIconData`) before it can enter the sidecar.
+
+const { WebContentsView } = require('electron');
+
+const ICON_SIZE = 16;
+const RASTER_TIMEOUT_MS = 3000;
+
+let view = null;
+let ready = null;
+
+function ensureView() {
+  if (view && !view.webContents.isDestroyed()) return ready;
+  view = new WebContentsView({
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      // Detached and never shown: keep timers/decoding live regardless.
+      backgroundThrottling: false,
+    },
+  });
+  const wc = view.webContents;
+  wc.once('destroyed', () => { view = null; ready = null; });
+  ready = wc.loadURL('about:blank').then(() => {}, () => {});
+  return ready;
+}
+
+// Serialized to a string and evaluated inside the sandboxed page — must stay
+// self-contained (no closure references). Returns a PNG data URL, or null when
+// the source fails to decode or renders fully transparent (a blank draw is
+// worse than falling back to the glyph).
+function drawInPage(dataUrl, size, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (value) => { if (!settled) { settled = true; resolve(value); } };
+    const timer = setTimeout(() => done(null), timeoutMs);
+    try {
+      const img = new Image();
+      img.onload = () => {
+        clearTimeout(timer);
+        try {
+          const canvas = document.createElement('canvas');
+          canvas.width = size;
+          canvas.height = size;
+          const ctx = canvas.getContext('2d');
+          if (!ctx) return done(null);
+          ctx.clearRect(0, 0, size, size);
+          ctx.drawImage(img, 0, 0, size, size);
+          const { data } = ctx.getImageData(0, 0, size, size);
+          let opaque = false;
+          for (let i = 3; i < data.length; i += 4) {
+            if (data[i] !== 0) { opaque = true; break; }
+          }
+          done(opaque ? canvas.toDataURL('image/png') : null);
+        } catch (err) {
+          done(null);
+        }
+      };
+      img.onerror = () => { clearTimeout(timer); done(null); };
+      img.src = dataUrl;
+    } catch (err) {
+      clearTimeout(timer);
+      done(null);
+    }
+  });
+}
+
+/** Draw a bounded image `data:` URL down to a 16x16 PNG data URL, or null. */
+async function rasterize(dataUrl, signal) {
+  if (typeof dataUrl !== 'string' || signal?.aborted) return null;
+  try {
+    await ensureView();
+  } catch {
+    return null;
+  }
+  if (signal?.aborted || !view || view.webContents.isDestroyed()) return null;
+  const code = `(${drawInPage.toString()})(${JSON.stringify(dataUrl)},${ICON_SIZE},${RASTER_TIMEOUT_MS})`;
+  try {
+    const out = await view.webContents.executeJavaScript(code, true);
+    if (signal?.aborted) return null;
+    return typeof out === 'string' ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+function dispose() {
+  if (view && !view.webContents.isDestroyed()) view.webContents.close();
+  view = null;
+  ready = null;
+}
+
+module.exports = { rasterize, dispose };

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -23,6 +23,7 @@ const { sendLaunchPing } = require('./telemetry');
 const sync = require('./sync');
 const tabsync = require('./tabsync');
 const tabicons = require('./tabicons');
+const iconRaster = require('./icon-raster');
 const { setupDownloads, downloadsActivity, acknowledgeDownloads } = require('./downloads');
 const { attachContextMenu } = require('./context-menu');
 const { promptForCredentials } = require('./auth-dialog');
@@ -2534,6 +2535,10 @@ function createMainWindow() {
     if (utilitySheetView && !utilitySheetView.webContents.isDestroyed()) utilitySheetView.webContents.close();
     utilitySheetView = null;
     utilitySheetUrl = null;
+    // The detached favicon rasterizer view isn't a BrowserWindow, so it would
+    // otherwise linger past the last window (blocking `window-all-closed` quit
+    // on Windows/Linux). Recreated lazily on the next non-PNG capture.
+    iconRaster.dispose();
     flushPermissionPrompts();
   });
 

--- a/src/main/tabicons-model.js
+++ b/src/main/tabicons-model.js
@@ -91,6 +91,52 @@ function sourcePngFromDataUrl(source) {
   return validSourcePngBytes(bytes);
 }
 
+// Non-PNG favicons (ICO, SVG, GIF, …) can't be decoded by nativeImage, so they
+// take the renderer-canvas path (icon-raster.js) instead of the native PNG
+// guard above. The model's job for these is only to confirm an image MIME type
+// and bound the payload; Chromium's own <img> decoder does the parsing, and the
+// canvas output is re-validated as a 16x16 PNG before it can be stored.
+const IMAGE_MEDIA_TYPE = /^image\/[a-z0-9][a-z0-9.+-]*$/;
+// A base64 image data URL can't exceed this many chars for MAX_SOURCE_BYTES of
+// bytes; percent-encoded inline SVG favicons stay well under it too.
+const MAX_SOURCE_DATA_URL = Math.ceil(MAX_SOURCE_BYTES / 3) * 4 + 64;
+
+function normalizeImageMediaType(contentType) {
+  if (typeof contentType !== 'string') return null;
+  const type = contentType.split(';', 1)[0].trim().toLowerCase();
+  return IMAGE_MEDIA_TYPE.test(type) ? type : null;
+}
+
+const isImageMediaType = (contentType) => normalizeImageMediaType(contentType) !== null;
+
+/** The image MIME type of a `data:` URL, or null when it isn't an image. */
+function dataUrlMediaType(source) {
+  if (typeof source !== 'string') return null;
+  const comma = source.indexOf(',');
+  if (comma < 0) return null;
+  const match = /^data:([a-z0-9][a-z0-9.+-]*\/[a-z0-9][a-z0-9.+-]*)(?:;[^,]*)?$/i.exec(source.slice(0, comma));
+  return match && IMAGE_MEDIA_TYPE.test(match[1].toLowerCase()) ? match[1].toLowerCase() : null;
+}
+
+/** Wrap fetched non-PNG image bytes into a base64 data URL for the renderer. */
+function imageSourceToDataUrl(contentType, raw) {
+  const type = normalizeImageMediaType(contentType);
+  if (!type) return null;
+  if (!Buffer.isBuffer(raw) && !(raw instanceof Uint8Array)) return null;
+  const bytes = Buffer.isBuffer(raw)
+    ? raw
+    : Buffer.from(raw.buffer, raw.byteOffset, raw.byteLength);
+  if (bytes.length < 1 || bytes.length > MAX_SOURCE_BYTES) return null;
+  return `data:${type};base64,${bytes.toString('base64')}`;
+}
+
+/** Accept a favicon that is itself an inert, bounded image `data:` URL. The
+ * original encoding is preserved for the renderer's <img> to decode. */
+function boundedImageDataUrl(source) {
+  if (typeof source !== 'string' || source.length > MAX_SOURCE_DATA_URL) return null;
+  return dataUrlMediaType(source) ? source : null;
+}
+
 function isPrivateIpv4(host) {
   const parts = host.split('.').map(Number);
   if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
@@ -324,6 +370,10 @@ module.exports = {
   validIconData,
   validSourcePngBytes,
   sourcePngFromDataUrl,
+  isImageMediaType,
+  dataUrlMediaType,
+  imageSourceToDataUrl,
+  boundedImageDataUrl,
   sanitizeIcon,
   sanitizeEntry,
   fingerprint,

--- a/src/main/tabicons.js
+++ b/src/main/tabicons.js
@@ -8,6 +8,17 @@ const { nativeImage } = require('electron');
 const { JsonStore } = require('./store');
 const { validFavicon } = require('./bookmark-validate');
 const model = require('./tabicons-model');
+const iconRaster = require('./icon-raster');
+
+// Non-PNG favicons rasterize through a live WebContentsView (icon-raster.js).
+// Keeping that behind an injectable seam lets the capture orchestration below
+// stay unit-testable under `node --test`, where no Electron renderer exists.
+let raster = (dataUrl, signal) => iconRaster.rasterize(dataUrl, signal);
+function setRasterizer(fn) {
+  raster = typeof fn === 'function'
+    ? fn
+    : (dataUrl, signal) => iconRaster.rasterize(dataUrl, signal);
+}
 
 const FETCH_TIMEOUT_MS = 3000;
 const MAX_SOURCE_CACHE = 256;
@@ -129,9 +140,14 @@ async function rasterizeSource(source, browsingSession, signal) {
   try {
     if (signal?.aborted) return null;
     if (source.toLowerCase().startsWith('data:image/')) {
-      const bytes = model.sourcePngFromDataUrl(source);
-      if (signal?.aborted) return null;
-      return bytes ? pngData(nativeImage.createFromBuffer(bytes)) : null;
+      // An inline favicon. PNG keeps the dimension-guarded native decode; any
+      // other image type (svg, gif, …) is rasterized in the sandboxed renderer.
+      if (/^data:image\/png[;,]/i.test(source)) {
+        const bytes = model.sourcePngFromDataUrl(source);
+        return bytes ? pngData(nativeImage.createFromBuffer(bytes)) : null;
+      }
+      const dataUrl = model.boundedImageDataUrl(source);
+      return dataUrl ? model.validIconData(await raster(dataUrl, signal)) : null;
     }
     if (!browsingSession?.fetch || !model.isPublicHttpSource(source)) return null;
     const timeoutController = new AbortController();
@@ -151,11 +167,21 @@ async function rasterizeSource(source, browsingSession, signal) {
       });
       if (!response.ok || requestSignal.aborted) return null;
       const contentType = response.headers?.get?.('content-type')?.split(';', 1)[0]?.trim()?.toLowerCase();
-      if (contentType !== 'image/png') return null;
+      const isPng = contentType === 'image/png';
+      // Reject non-image responses before reading the body at all.
+      if (!isPng && !model.isImageMediaType(contentType)) return null;
       const bytes = await readBounded(response);
-      if (requestSignal.aborted) return null;
-      const png = model.validSourcePngBytes(bytes);
-      return png ? pngData(nativeImage.createFromBuffer(png)) : null;
+      if (requestSignal.aborted || !bytes) return null;
+      if (isPng) {
+        // PNG: cheap header/dimension guard, then decode natively — unchanged.
+        const png = model.validSourcePngBytes(bytes);
+        return png ? pngData(nativeImage.createFromBuffer(png)) : null;
+      }
+      // ICO/SVG/GIF/…: hand the bounded bytes to the renderer canvas. The fetch
+      // guards above (public-only, cookie/referrer-free, redirect-off) still
+      // gate what gets here; the renderer only ever sees inert `data:` bytes.
+      const dataUrl = model.imageSourceToDataUrl(contentType, bytes);
+      return dataUrl ? model.validIconData(await raster(dataUrl, signal)) : null;
     } finally {
       clearTimeout(timeout);
     }
@@ -499,6 +525,7 @@ function onSyncDisabled() {
 
 module.exports = {
   setSnapshotProvider,
+  setRasterizer,
   onChanged,
   onRemoteChanged,
   cancelCaptures,

--- a/test/unit/icon-raster.test.js
+++ b/test/unit/icon-raster.test.js
@@ -1,0 +1,31 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+// The renderer canvas path needs a live WebContentsView, which node --test
+// can't provide. Stub the class so its construction is observable: reaching it
+// would throw, proving the input guards short-circuit first.
+const electronId = require.resolve('electron');
+require.cache[electronId] = {
+  id: electronId,
+  filename: electronId,
+  loaded: true,
+  exports: {
+    WebContentsView: class {
+      constructor() {
+        throw new Error('WebContentsView should not be constructed for guarded input');
+      }
+    },
+  },
+};
+
+const iconRaster = require('../../src/main/icon-raster');
+
+test('rasterize rejects invalid or cancelled input without spawning a renderer', async () => {
+  assert.equal(await iconRaster.rasterize(null), null);
+  assert.equal(await iconRaster.rasterize(123), null);
+  assert.equal(await iconRaster.rasterize('data:image/svg+xml,<svg/>', { aborted: true }), null);
+});
+
+test('dispose is a safe no-op when no view has been created', () => {
+  assert.doesNotThrow(() => iconRaster.dispose());
+});

--- a/test/unit/tabicons-model.test.js
+++ b/test/unit/tabicons-model.test.js
@@ -44,6 +44,61 @@ test('source PNG guard rejects alternate formats and dimension bombs before deco
   );
 });
 
+test('image media type detection accepts real favicon MIME types and rejects others', () => {
+  for (const ok of [
+    'image/png', 'image/svg+xml', 'image/x-icon', 'image/vnd.microsoft.icon',
+    'image/webp', 'IMAGE/GIF', 'image/jpeg; charset=binary',
+  ]) {
+    assert.equal(m.isImageMediaType(ok), true, ok);
+  }
+  for (const bad of [
+    'text/html', 'application/octet-stream', 'image', 'image/', '',
+    null, undefined, 'text/html; image/png',
+  ]) {
+    assert.equal(m.isImageMediaType(bad), false, String(bad));
+  }
+});
+
+test('dataUrlMediaType reads the image type from base64 and percent-encoded data URLs', () => {
+  assert.equal(m.dataUrlMediaType('data:image/svg+xml;base64,PHN2Zy8+'), 'image/svg+xml');
+  assert.equal(m.dataUrlMediaType('data:image/png,AAAA'), 'image/png');
+  assert.equal(m.dataUrlMediaType('data:IMAGE/X-Icon;base64,AAAA'), 'image/x-icon');
+  assert.equal(m.dataUrlMediaType('data:text/html;base64,AAAA'), null);
+  assert.equal(m.dataUrlMediaType('https://a.example/icon.svg'), null);
+  assert.equal(m.dataUrlMediaType('data:,AAAA'), null);
+});
+
+test('imageSourceToDataUrl wraps only bounded image bytes', () => {
+  const bytes = Buffer.from('<svg viewBox="0 0 16 16"/>');
+  assert.equal(
+    m.imageSourceToDataUrl('image/svg+xml; charset=utf-8', bytes),
+    `data:image/svg+xml;base64,${bytes.toString('base64')}`
+  );
+  assert.equal(m.imageSourceToDataUrl('text/html', bytes), null);
+  assert.equal(m.imageSourceToDataUrl('image/png', Buffer.alloc(0)), null, 'empty rejected');
+  assert.equal(
+    m.imageSourceToDataUrl('image/png', Buffer.alloc(m.MAX_SOURCE_BYTES + 1)),
+    null,
+    'oversized rejected'
+  );
+  assert.equal(m.imageSourceToDataUrl('image/png', 'not-bytes'), null);
+});
+
+test('boundedImageDataUrl passes inert image data URLs and bounds their size', () => {
+  const svg = 'data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTYgMTYiLz4=';
+  const percent = 'data:image/svg+xml,%3Csvg%2F%3E';
+  assert.equal(m.boundedImageDataUrl(svg), svg);
+  assert.equal(m.boundedImageDataUrl(percent), percent, 'percent-encoded inline SVG is preserved');
+  assert.equal(m.boundedImageDataUrl('data:text/html;base64,AAAA'), null);
+  assert.equal(
+    m.boundedImageDataUrl(`data:image/png;base64,${'A'.repeat(m.MAX_SOURCE_BYTES * 2)}`),
+    null,
+    'oversized length rejected'
+  );
+  assert.equal(m.boundedImageDataUrl('https://a.example/i.svg'), null);
+  assert.equal(m.boundedImageDataUrl(null), null);
+});
+
 test('network icon sources reject obvious local and private-network targets', () => {
   assert.equal(m.isPublicHttpSource('https://cdn.example/icon.png'), true);
   assert.equal(m.isPublicHttpSource('http://8.8.8.8/icon.png'), true);

--- a/test/unit/tabicons.test.js
+++ b/test/unit/tabicons.test.js
@@ -96,25 +96,20 @@ test('capture rejects non-image responses before decoding or serializing them', 
   assert.equal(payload.devices['device-a'].icons.some((icon) => icon.url === tab.url), false);
 });
 
-test('capture validates PNG format and dimensions before nativeImage decode, including data URLs', async () => {
+test('PNG sources are format- and dimension-guarded before nativeImage decode', async () => {
   const before = decodeCount;
   const huge = Buffer.from(PNG_BYTES);
   huge.writeUInt32BE(1025, 16);
   const cases = [
     {
-      favicon: 'https://unsafe.example/vector.svg',
-      fetch: async () => response('image/svg+xml', Buffer.from('<svg/>')),
-    },
-    {
+      // An image/png label over non-PNG bytes must not smuggle another format
+      // past the guard into the decoder.
       favicon: 'https://unsafe.example/spoofed.png',
       fetch: async () => response('image/png', Buffer.from('<svg/>')),
     },
     {
+      // A PNG whose IHDR claims oversized dimensions is rejected pre-decode.
       favicon: `data:image/png;base64,${huge.toString('base64')}`,
-      fetch: null,
-    },
-    {
-      favicon: 'data:image/svg+xml;base64,PHN2Zy8+',
       fetch: null,
     },
   ];
@@ -129,6 +124,75 @@ test('capture validates PNG format and dimensions before nativeImage decode, inc
     assert.equal(await tabicons.captureTab(tab, ctx), false, item.favicon);
   }
   assert.equal(decodeCount, before);
+});
+
+test('non-PNG favicons rasterize through the renderer seam and store the result', async () => {
+  const seen = [];
+  tabicons.setRasterizer(async (dataUrl) => {
+    seen.push(dataUrl);
+    return PNG_DATA;
+  });
+  try {
+    const httpSvg = {
+      url: 'https://vector-page.example/',
+      favicon: 'https://vector-page.example/icon.svg',
+      private: false,
+      view: {
+        webContents: {
+          session: {
+            fetch: async () => response('image/svg+xml', Buffer.from('<svg viewBox="0 0 16 16"/>')),
+          },
+        },
+      },
+    };
+    const inlineSvg = {
+      url: 'https://inline-page.example/',
+      favicon: 'data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTYgMTYiLz4=',
+      private: false,
+      view: null,
+    };
+    tabicons.setSnapshotProvider(() => ({ tabList: [httpSvg, inlineSvg] }));
+
+    assert.equal(await tabicons.captureTab(httpSvg, ctx), true);
+    assert.equal(await tabicons.captureTab(inlineSvg, ctx), true);
+
+    assert.equal(seen.length, 2);
+    assert.ok(
+      seen[0].startsWith('data:image/svg+xml;base64,'),
+      'fetched non-PNG bytes are wrapped as an image data URL for the renderer'
+    );
+    assert.equal(seen[1], inlineSvg.favicon, 'an inline image data URL passes through unchanged');
+
+    const icons = tabicons.exportForSync(ctx).devices['device-a'].icons;
+    assert.ok(icons.some((i) => i.url === httpSvg.url && i.data === PNG_DATA));
+    assert.ok(icons.some((i) => i.url === inlineSvg.url && i.data === PNG_DATA));
+  } finally {
+    tabicons.setRasterizer(null);
+  }
+});
+
+test('a rasterizer result that is not a bounded 16x16 PNG is discarded', async () => {
+  tabicons.setRasterizer(async () => 'data:image/svg+xml,<svg/>'); // not a PNG data URL
+  try {
+    const tab = {
+      url: 'https://bad-raster.example/',
+      favicon: 'https://bad-raster.example/icon.svg',
+      private: false,
+      view: {
+        webContents: {
+          session: { fetch: async () => response('image/svg+xml', Buffer.from('<svg/>')) },
+        },
+      },
+    };
+    tabicons.setSnapshotProvider(() => ({ tabList: [tab] }));
+    assert.equal(await tabicons.captureTab(tab, ctx), false);
+    assert.equal(
+      tabicons.exportForSync(ctx).devices['device-a'].icons.some((i) => i.url === tab.url),
+      false
+    );
+  } finally {
+    tabicons.setRasterizer(null);
+  }
 });
 
 test('capture never fetches obvious localhost, LAN, or link-local sources', async () => {


### PR DESCRIPTION
## Problem

Tabs synced from other devices showed no favicons for most sites (e.g. `postelmail.com`, `blancbrowser.com`). The tab-favicon sync from #47 only ever worked for sites whose favicon Chromium happened to hand Blanc as a **PNG**.

## Root cause

The capture could only produce an icon from a PNG source. The decisive gate: `nativeImage.createFromBuffer` — the rasterizer — **only decodes PNG/JPEG**. Verified empirically that `blancbrowser.com`'s `.ico` (BMP-framed), `claude.ai`'s `.ico`, `github.com`'s `.ico`, and SVG favicons all decode to an empty image.

Real-world favicons are dominated by **ICO** (`image/vnd.microsoft.icon`, `image/x-icon`) and **SVG** (`image/svg+xml`), so most never synced. Confirmed against the live sync store: PNG-favicon sites synced; ICO/SVG sites — including `postelmail.com`, which is SVG-only — did not, even with the tab open locally.

## Fix

Draw the fetched, bounded favicon bytes into a 16×16 `<canvas>` inside a locked-down, **detached `WebContentsView`** (`icon-raster.js`), covering every format Chromium can decode. An SVG loaded via `<img>` runs no scripts and fetches no external resources, so untrusted vector sources stay inert.

- **PNG keeps its existing dimension-guarded native decode**; only non-PNG formats take the renderer.
- All existing fetch guards are unchanged: public-host-only (SSRF), cookie/referrer-free, redirect-off, size/time-bounded. The renderer only ever sees inert `data:` bytes — never a live URL.
- The output invariant is unchanged: only a bounded **16×16 `data:image/png`** (`validIconData`) can enter the sidecar / renderer projection.

Favicons are captured by the **source** device, so a remote device's rows populate once that device runs a build containing this fix.

## Verification

- All **259 unit tests pass**; new coverage for the non-PNG routing (injectable rasterizer seam), the pure model gates, and the rasterizer input guards.
- Rasterization confirmed against the exact failing favicons (`blancbrowser.com` BMP-ICO, `postelmail.com` SVG, `blancbrowser.com` SVG) in Chromium → valid, opaque 16×16 PNGs; the real output passes `validIconData`.
- Verified end-to-end in Electron, including that the detached `WebContentsView` decodes.

## Files

`src/main/icon-raster.js` (new), `src/main/tabicons.js`, `src/main/tabicons-model.js`, `src/main/main.js` (dispose wiring), and unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
