### PR TITLE
Add View Page Source to the tab context menu

### DIFF
--- a/src/main/context-menu.js
+++ b/src/main/context-menu.js
@@ -1,5 +1,6 @@
 const { Menu, clipboard } = require('electron');
 const settings = require('./settings');
+const { VIEW_SOURCE_PREFIX, canViewSource } = require('./view-source');
 
 /**
  * Right-click menu for tab web content. Electron ships NO default context
@@ -66,6 +67,20 @@ function attachContextMenu(wc, actions) {
       push({ label: 'Back', enabled: wc.navigationHistory.canGoBack(), click: () => wc.navigationHistory.goBack() });
       push({ label: 'Forward', enabled: wc.navigationHistory.canGoForward(), click: () => wc.navigationHistory.goForward() });
       push({ label: 'Reload', click: () => wc.reload() });
+      // New tab, NOT in-place — and don't "simplify" this to wc.loadURL().
+      // Chromium REPLACES the current history entry when navigating to
+      // view-source: of the page you're already on (measured: entry count
+      // stays flat), so Back would silently skip the article you were
+      // reading and land on whatever preceded it. A fresh tab leaves Back
+      // dead instead, which the pill's "source" chip exists to escape.
+      // `pageURL` is the top-level document even when the right-click
+      // landed inside a subframe.
+      if (canViewSource(params.pageURL)) {
+        push({
+          label: 'View Page Source',
+          click: () => actions.openTab(`${VIEW_SOURCE_PREFIX}${params.pageURL}`),
+        });
+      }
       sep();
     }
 

--- a/src/main/view-source.js
+++ b/src/main/view-source.js
@@ -1,0 +1,36 @@
+// Pure policy behind the context menu's "View Page Source" item — extracted
+// so it's unit-testable without Electron (context-menu.js reaches settings.js,
+// which needs electron's `app`). Same pattern as external-protocols.js and
+// utility-pages.js.
+//
+// Chromium serves `view-source:` itself: line numbers, syntax highlighting,
+// and the raw bytes the server sent, which is what makes it worth having
+// alongside Inspect Element (DevTools shows the live DOM, so it hides
+// comments and anything the page's own scripts rewrote).
+
+const VIEW_SOURCE_PREFIX = 'view-source:';
+
+/**
+ * May this URL be offered as "View Page Source"?
+ *
+ * http(s) ONLY, and that restriction is load-bearing rather than cosmetic:
+ * a main-process `view-source:file:///…` navigation genuinely loads, so
+ * without this gate the item would expose local files on any page Blanc
+ * opened from disk. `blanc://` internal pages ship with the app and the
+ * blank new tab has no source at all — Chrome excludes its own `chrome://`
+ * pages the same way. Already-wrapped `view-source:` URLs are excluded too,
+ * so the item can't nest on itself. Anything unparseable falls through.
+ *
+ * @param {string} url - the page URL the context menu was invoked on
+ * @returns {boolean}
+ */
+function canViewSource(url) {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { VIEW_SOURCE_PREFIX, canViewSource };

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -21,6 +21,9 @@
         <button id="pillPrivateChip" title="Leave private mode — closes this tab" hidden>private
           <svg viewBox="0 0 16 16"><path d="M4.75 4.75l6.5 6.5M11.25 4.75l-6.5 6.5"/></svg>
         </button>
+        <button id="pillSourceChip" title="Close this page source view" hidden>source
+          <svg viewBox="0 0 16 16"><path d="M4.75 4.75l6.5 6.5M11.25 4.75l-6.5 6.5"/></svg>
+        </button>
         <span id="pillShield" class="shield" hidden>0</span>
         <span class="pill-sep"></span>
         <div id="pillActions" class="pill-btns"></div>

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -150,13 +150,24 @@
     }
   }
 
+  /** The page URL behind a `view-source:` URL, else null. Chromium's
+   * view-source: is a non-special scheme, so `new URL(...).host` is '' and
+   * the row would fall back to the literal "new tab".
+   * (Keep in sync with renderer.js.) */
+  function viewSourceTarget(url) {
+    if (!url?.startsWith('view-source:')) return null;
+    // A bare "view-source:" has no page behind it — null, not '', so callers
+    // can trust a truthy result to be a URL worth parsing.
+    return url.slice('view-source:'.length) || null;
+  }
+
   /** Short label for a tab's location: host for web pages (sans the noise
    * "www." carries in a list this dense), page name for internal ones,
    * empty for a blank new tab. */
   function tabDomain(tab) {
     if (!tab?.url || tab.url.startsWith('blanc://newtab')) return '';
     try {
-      const u = new URL(tab.url);
+      const u = new URL(viewSourceTarget(tab.url) ?? tab.url);
       return u.protocol === 'blanc:' ? `blanc://${u.host}` : u.host.replace(/^www\./, '');
     } catch {
       return tab.url;

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -20,6 +20,7 @@
   const pillShield = document.getElementById('pillShield');
   const pillInsecure = document.getElementById('pillInsecure');
   const pillPrivateChip = document.getElementById('pillPrivateChip');
+  const pillSourceChip = document.getElementById('pillSourceChip');
   const windowControls = document.getElementById('windowControls');
   const permissionBar = document.getElementById('permissionBar');
   const permissionText = document.getElementById('permissionText');
@@ -132,12 +133,23 @@
     return `Blanc blocked ${blocked} ${blocked === 1 ? 'ad or tracker' : 'ads & trackers'} on this page`;
   }
 
+  /** The page URL behind a `view-source:` URL, else null. Chromium's
+   * view-source: is a non-special scheme, so `new URL(...).host` is '' and
+   * the pill would fall back to the literal "new tab".
+   * (Keep in sync with overlay.js.) */
+  function viewSourceTarget(url) {
+    if (!url?.startsWith('view-source:')) return null;
+    // A bare "view-source:" has no page behind it — null, not '', so callers
+    // can trust a truthy result to be a URL worth parsing.
+    return url.slice('view-source:'.length) || null;
+  }
+
   /** Short label for a tab's location: host for web pages, page name for
    * internal ones, empty for a blank new tab. */
   function tabDomain(tab) {
     if (!tab?.url || tab.url.startsWith('blanc://newtab')) return '';
     try {
-      const u = new URL(tab.url);
+      const u = new URL(viewSourceTarget(tab.url) ?? tab.url);
       return u.protocol === 'blanc:' ? `blanc://${u.host}` : u.host;
     } catch {
       return tab.url;
@@ -371,6 +383,12 @@
     pillInsecure.hidden = !tab || tab.isLoading || !connectionInsecure(tab.url);
 
     pillPrivateChip.hidden = !tab?.private;
+    // A view-source tab is opened fresh, so Back is dead and the island has
+    // no per-tab close control — without this chip the tab is a dead end.
+    // Suppressed on a private tab (view-source inherits the opener's privacy):
+    // the private chip already closes the tab, and two adjacent ✕ chips doing
+    // the same thing is noise.
+    pillSourceChip.hidden = !viewSourceTarget(tab?.url) || !!tab?.private;
 
     const blocked = tab?.blockedCount ?? 0;
     pillShield.hidden = blocked === 0;
@@ -392,11 +410,15 @@
     stripEl.classList.toggle('drag-suspended', islandMode === 'panel' || islandMode === 'palette');
   }
 
-  // Quick exit: clicking the pill's private chip closes the private tab.
-  pillPrivateChip.addEventListener('click', (e) => {
-    e.stopPropagation();
-    if (state.activeTabId) window.browserAPI.closeTab(state.activeTabId);
-  });
+  // Quick exit: either chip closes the active tab — the private chip leaves
+  // private mode, the source chip is the way back out of a page-source tab
+  // (whose Back is dead). One shared handler so the two can't drift apart.
+  for (const chip of [pillPrivateChip, pillSourceChip]) {
+    chip.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (state.activeTabId) window.browserAPI.closeTab(state.activeTabId);
+    });
+  }
 
   islandPill.addEventListener('click', () => window.browserAPI.openIsland());
   islandPill.addEventListener('keydown', (e) => {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -800,7 +800,12 @@ body.mac .vertical-tabs-toolbar {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-dim);
-  flex: 0 1 12ch;
+  /* `auto` basis, not `12ch`: a 12ch basis RESERVES twelve characters even
+     for a short name ("news ·" claimed 57px for 40px of text), and the
+     deficit came out of #pillDomain — the only freely-shrinkable sibling —
+     so the URL truncated with the pill nowhere near its max-width. The
+     max-width still caps long group names at 12ch. */
+  flex: 0 1 auto;
   min-width: 0;
   max-width: 12ch;
   overflow: hidden;
@@ -811,21 +816,32 @@ body.mac .vertical-tabs-toolbar {
 
 [data-theme="private"] #islandPill { border: 1px dashed var(--text-dim); }
 
-/* Quick exit chip on private tabs — clicking it closes the tab. */
-#pillPrivateChip {
+/* Quick exit chips — clicking one closes the tab. Shared geometry; the
+   private chip keeps the dashed accent treatment that marks the mode, while
+   the source chip stays quiet (solid, dim) since it's only a view. */
+#pillPrivateChip,
+#pillSourceChip {
   display: flex;
   align-items: center;
   gap: 4px;
   font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--accent);
-  border: 1px dashed var(--accent);
   border-radius: 999px;
   padding: 0 6px;
   flex: 0 0 auto;
 }
-#pillPrivateChip[hidden] { display: none; }
-#pillPrivateChip svg { width: 8px; height: 8px; stroke-width: 2; }
+#pillPrivateChip {
+  color: var(--accent);
+  border: 1px dashed var(--accent);
+}
+#pillSourceChip {
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+}
+#pillPrivateChip[hidden],
+#pillSourceChip[hidden] { display: none; }
+#pillPrivateChip svg,
+#pillSourceChip svg { width: 8px; height: 8px; stroke-width: 2; }
 
 .shield {
   font-family: var(--font-mono);

--- a/test/unit/view-source.test.js
+++ b/test/unit/view-source.test.js
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { VIEW_SOURCE_PREFIX, canViewSource } = require('../../src/main/view-source');
+
+test('canViewSource: ordinary web pages qualify', () => {
+  assert.equal(canViewSource('https://example.com/'), true);
+  assert.equal(canViewSource('http://example.com/'), true);
+  assert.equal(canViewSource('https://example.com/a/b?c=d#e'), true);
+  assert.equal(canViewSource('http://127.0.0.1:8080/x'), true);
+  assert.equal(canViewSource('http://localhost:3000/'), true);
+});
+
+// The http(s) restriction is a real boundary, not tidiness: a main-process
+// `view-source:file:///…` navigation loads successfully, so admitting file:
+// here would surface local files from any page Blanc opened off disk.
+test('canViewSource: local and privileged schemes are refused', () => {
+  assert.equal(canViewSource('file:///etc/passwd'), false);
+  assert.equal(canViewSource('file:///Users/me/notes.html'), false);
+  assert.equal(canViewSource('blanc://settings/'), false);
+  assert.equal(canViewSource('blanc://newtab/'), false);
+  assert.equal(canViewSource('blanc://newtab/?private=1'), false);
+});
+
+test('canViewSource: script-executing and opaque schemes are refused', () => {
+  assert.equal(canViewSource('javascript:alert(1)'), false);
+  assert.equal(canViewSource('data:text/html,<b>x'), false);
+  assert.equal(canViewSource('vbscript:x'), false);
+  assert.equal(canViewSource('about:blank'), false);
+  assert.equal(canViewSource('mailto:a@b.c'), false);
+});
+
+test('canViewSource: cannot nest on an existing view-source page', () => {
+  assert.equal(canViewSource('view-source:https://example.com/'), false);
+  assert.equal(canViewSource(`${VIEW_SOURCE_PREFIX}http://127.0.0.1:8080/`), false);
+});
+
+test('canViewSource: unparseable input falls through to false', () => {
+  assert.equal(canViewSource('not a url'), false);
+  assert.equal(canViewSource('example.com'), false); // scheme-less, not yet normalized
+  assert.equal(canViewSource(''), false);
+  assert.equal(canViewSource(undefined), false);
+  assert.equal(canViewSource(null), false);
+});
+
+test('VIEW_SOURCE_PREFIX composes a URL Chromium accepts', () => {
+  assert.equal(VIEW_SOURCE_PREFIX, 'view-source:');
+  assert.equal(
+    `${VIEW_SOURCE_PREFIX}https://example.com/`,
+    'view-source:https://example.com/'
+  );
+});


### PR DESCRIPTION
Right-clicking a page background now offers **View Page Source**, opening Chromium's own `view-source:` document. Blanc had no way to do this — Electron ships no default context menu, and the hand-written one in `context-menu.js` only went as far as Inspect Element. DevTools renders the live DOM, so it hides comments and anything the page's scripts rewrote; `view-source:` shows the bytes the server actually sent.

## Decisions worth reviewing

**New tab, not in place.** Chromium *replaces* the current history entry when navigating to `view-source:` of the page you're already on. Measured: control `/one`→`/two` goes 1→2 entries, but `/two`→`view-source:/two` stays at 2. An in-place load would make Back silently skip the page you were reading and land on whatever preceded it. A fresh tab leaves Back dead instead, which is what the chip below is for. There's a comment at the call site so this isn't "simplified" into a bug later.

**The `source` chip.** A fresh tab has no history and Blanc's island has no per-tab close control, so a view-source tab was a dead end. The pill now shows a quiet `source ✕` chip that closes it — the same quick-exit pattern private tabs already use. Suppressed on private tabs, where the private chip already does the job, so you never get two adjacent ✕ chips.

**`canViewSource` is http(s)-only, and that gate is load-bearing.** A main-initiated `view-source:file:///etc/hosts` navigation genuinely loads, so without the gate the item would expose local files on any page Blanc opened from disk. It lives in its own Electron-free module (`src/main/view-source.js`) so it's unit-testable, matching `external-protocols.js` and `utility-pages.js`.

## Security

`will-navigate` guards `blanc:` by protocol, and `view-source:blanc://settings/` reads as protocol `view-source:` — so I checked whether hostile page content could wrap a privileged URL to slip past it. All three attempts (`blanc://settings/`, `blanc://newtab/`, `file:///etc/hosts`) were **blocked by Chromium**, which refuses renderer-initiated `view-source:` navigations. No new hole and no pre-existing one exposed. No injection surface otherwise: `params.pageURL` is browser-supplied and already parsed by `URL` before use.

## Unrelated bug fixed along the way

The new chip made a pre-existing pill layout bug visible. `#pillGroupName` had `flex-basis: 12ch`, reserving twelve characters even for a short name — `"news ·"` claimed 57px for 40px of text — and `#pillDomain`, the only freely-shrinkable sibling, absorbed the deficit and truncated the URL while the pill sat at 379px of a 1243px budget. Controls confirm it tracks the group name, not the chip: no group + chip on = no truncation; group + chip off = truncation. Basis is now `auto`; the `12ch` cap still bounds long names.

This matches the intent of the commit that introduced it (`7e0a588`), which added `max-width: 12ch` and ellipsis to cap long names — the basis was incidental.

## Testing

- `test/unit/view-source.test.js` — 6 new tests covering http(s), refused local/privileged schemes, script-executing schemes, no self-nesting, and unparseable input. Unit suite 259 → **265, all passing**.
- `substrate:check` 4/4, acceptance dry-run 52 scenarios — clean.
- Verified in the running app via Playwright-Electron: menu contents on http vs `blanc://` vs with-a-selection; chip visible on normal view-source and hidden on private; both chips still close their tab through the shared handler; pill renders the full URL without truncation.

## Known gaps, deliberately not addressed

- Typed `view-source:` URLs still break in the address bar — `normalizeAddressInput`'s scheme regex requires `://`, so it falls through to the domain branch. Pre-existing limitation of that heuristic.
- These tabs are recorded in history (measured), so they surface in the Quick Switcher. Chrome does this too.
- No `⌘⌥U` binding. I dropped an accelerator label rather than advertise a shortcut nothing binds.
- No menu item on `file://` pages, though Blanc supports local documents and Chrome offers it there. Widening the gate means separating "files the user opened" from "files reachable via a page" — a different piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)