### PR TITLE
site: render release-note markdown instead of showing its markup

### DIFF
--- a/scripts/generate-site-changelog.mjs
+++ b/scripts/generate-site-changelog.mjs
@@ -11,6 +11,9 @@ const ROOT = path.resolve(path.dirname(SCRIPT_PATH), '..');
 // src/pages/changelog.astro and src/pages/changelog.xml.js render it.
 // HTML/XML escaping happens there (Astro auto-escapes; the RSS renderer in
 // site/src/lib/rss.mjs escapes itself) — this script only produces data.
+// Each release carries `sections`, an ordered structure of headings, bullet
+// lists, and paragraphs whose text is a list of typed inline spans; see
+// parseGeneratedNotes below.
 const DEFAULT_OUTPUT_DIR = path.join(ROOT, 'site', 'src', 'data');
 const REPOSITORY_URL = 'https://github.com/bnfy/blanc';
 
@@ -92,21 +95,130 @@ function fetchReleases() {
   return parseJsonDocuments(stdout).flatMap((document) => Array.isArray(document) ? document : [document]);
 }
 
+// Inline markdown a release body may use. Most releases carry GitHub's
+// auto-generated "What's Changed" notes (plain bullets), but a hand-written
+// body — v1.0.0 was the first — uses **bold**, `code`, and [text](url), which
+// must render as elements instead of showing their markup as literal text.
+//
+// Inline markup becomes *typed spans* rather than an HTML string: bullet text
+// comes from contributor-supplied PR titles, so the renderer maps each span
+// onto a real element and lets Astro escape the value. Release-note text can
+// never introduce markup of its own — see the injection test in
+// test/unit/site-changelog.test.js.
+const INLINE_MARKDOWN = /`([^`]+)`|\*\*(.+?)\*\*|\[([^\]]+)\]\(([^)\s]+)\)/g;
+
+// Inline link targets are maintainer-authored, but the scheme is still pinned
+// to https/mailto so a `javascript:`/`data:` href can never reach an anchor.
+// Legacy names are rewritten here too (the generic scrub would capitalize the
+// "bowser" inside a URL path, which is why span text and hrefs scrub apart).
+function inlineLinkUrl(value) {
+  const github = blancGithubUrl(value);
+  if (github) return github;
+  try {
+    const url = new URL(String(value).replace(/(^|\/\/|\.)getbowser\.com\b/gi, '$1blancbrowser.com'));
+    if (url.protocol === 'https:' || url.protocol === 'mailto:') return url.href;
+  } catch { /* not a URL we can vouch for */ }
+  return null;
+}
+
+function pushText(spans, value) {
+  if (!value) return;
+  const previous = spans[spans.length - 1];
+  if (previous && previous.type === 'text') previous.value += value;
+  else spans.push({ type: 'text', value });
+}
+
+function parseInline(raw) {
+  const text = String(raw);
+  const spans = [];
+  let index = 0;
+  INLINE_MARKDOWN.lastIndex = 0;
+  for (let match = INLINE_MARKDOWN.exec(text); match; match = INLINE_MARKDOWN.exec(text)) {
+    pushText(spans, scrubLegacyName(text.slice(index, match.index)));
+    const [, code, strong, linkText, linkHref] = match;
+    if (code !== undefined) spans.push({ type: 'code', value: scrubLegacyName(code) });
+    else if (strong !== undefined) spans.push({ type: 'strong', value: scrubLegacyName(strong) });
+    else {
+      const url = inlineLinkUrl(linkHref);
+      // An unvouched target keeps its label as plain prose rather than dropping
+      // the words the release actually shipped.
+      if (url) spans.push({ type: 'link', value: scrubLegacyName(linkText), url });
+      else pushText(spans, scrubLegacyName(linkText));
+    }
+    index = match.index + match[0].length;
+  }
+  pushText(spans, scrubLegacyName(text.slice(index)));
+  return spans;
+}
+
+function spansToText(spans = []) {
+  return spans.map((span) => span.value).join('');
+}
+
+// A bullet that already links to its PR wraps all of its text in that anchor,
+// so any inline link inside it would nest an <a> in an <a>. Flatten to prose.
+function withoutLinks(spans) {
+  const flattened = [];
+  for (const span of spans) {
+    if (span.type === 'link') pushText(flattened, span.value);
+    else flattened.push(span);
+  }
+  return flattened;
+}
+
+// Release bodies are parsed into ordered sections so the page can render them
+// in the order they were written: an intro paragraph belongs above the bullets
+// it introduces, not below them, and each heading keeps its own list.
 function parseGeneratedNotes(body = '') {
-  const changes = [];
-  const extraParagraphs = [];
+  const sections = [];
   let compareUrl = null;
 
-  if (!body) return { changes, compareUrl, extraParagraphs };
+  if (!body) return { compareUrl, sections };
+
+  let current = null;
+  let list = null;
+  let seenContent = false;
+
+  const openSection = () => {
+    if (!current) sections.push(current = { heading: null, blocks: [] });
+    return current;
+  };
+  const addBlock = (block) => {
+    openSection().blocks.push(block);
+    seenContent = true;
+    return block;
+  };
+  // A blank line does not end a list (markdown's own "loose list"); only a
+  // heading or a paragraph does.
+  const endList = () => { list = null; };
 
   for (const rawLine of String(body).split(/\r?\n/)) {
     const line = rawLine.trim();
-    if (!line || /^#{1,6}\s+(?:What(?:'|’)?s Changed|New Contributors)$/i.test(line)) continue;
+    if (!line) continue;
+
+    const heading = line.match(/^(#{1,6})\s+(.*)$/);
+    if (heading) {
+      endList();
+      const title = spansToText(parseInline(heading[2].trim()));
+      // GitHub's generated headings label the boilerplate below them; the list
+      // itself is the section, so the label carries nothing on this page.
+      if (/^(?:What(?:'|’)?s Changed|New Contributors)$/i.test(title)) continue;
+      // A leading H1 restates the release title, which the entry already
+      // renders as its own heading.
+      if (heading[1].length === 1 && !seenContent) continue;
+      sections.push(current = { heading: title, blocks: [] });
+      seenContent = true;
+      continue;
+    }
 
     const compare = line.match(/^\*\*Full Changelog\*\*:\s*(\S+)$/i);
     if (compare) {
+      endList();
       compareUrl = blancGithubUrl(compare[1], ['compare']);
-      if (!compareUrl) extraParagraphs.push(scrubLegacyName(line.replace(/\*\*/g, '')));
+      // An off-repo compare link is not rendered as the entry's compare action,
+      // but the line it came from is still shown.
+      if (!compareUrl) addBlock({ type: 'paragraph', spans: parseInline(line) });
+      seenContent = true;
       continue;
     }
 
@@ -114,20 +226,27 @@ function parseGeneratedNotes(body = '') {
       const bullet = line.replace(/^[-*]\s+/, '');
       const generated = bullet.match(/^(.*?)\s+by\s+@[^\s]+\s+in\s+(https:\/\/\S+)$/i);
       const contributor = bullet.match(/^(@[^\s]+) made their first contribution in (https:\/\/\S+)$/i);
+      let item;
       if (generated) {
-        changes.push({ text: scrubLegacyName(generated[1].trim()), url: blancGithubUrl(generated[2], ['pull']) });
+        item = { spans: parseInline(generated[1].trim()), url: blancGithubUrl(generated[2], ['pull']) };
       } else if (contributor) {
-        changes.push({ text: scrubLegacyName(`${contributor[1]} made their first contribution`), url: blancGithubUrl(contributor[2], ['pull']) });
+        item = { spans: parseInline(`${contributor[1]} made their first contribution`), url: blancGithubUrl(contributor[2], ['pull']) };
       } else {
-        changes.push({ text: scrubLegacyName(bullet), url: null });
+        item = { spans: parseInline(bullet), url: null };
       }
+      if (item.url) item.spans = withoutLinks(item.spans);
+      if (!list) list = addBlock({ type: 'list', items: [] });
+      list.items.push(item);
       continue;
     }
 
-    extraParagraphs.push(scrubLegacyName(line.replace(/^#{1,6}\s+/, '').replace(/\*\*/g, '')));
+    endList();
+    addBlock({ type: 'paragraph', spans: parseInline(line) });
   }
 
-  return { changes, compareUrl, extraParagraphs };
+  // A heading whose body turned out to be boilerplate would otherwise render as
+  // a label with nothing under it.
+  return { compareUrl, sections: sections.filter((section) => section.blocks.length > 0) };
 }
 
 function normalizeReleases(raw) {
@@ -241,10 +360,12 @@ export {
   fetchReleases,
   normalizeReleases,
   parseGeneratedNotes,
+  parseInline,
   parseJsonDocuments,
   renderReleasesJson,
   run,
   scrubLegacyName,
+  spansToText,
   writeOutputs,
 };
 

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -39,6 +39,18 @@ JSON-LD `softwareVersion` imports its `version`), or the changelog generator.
 authenticated `gh`) fetches GitHub releases, scrubs the legacy "Bowser" name,
 and writes **`site/src/data/releases.json`** (committed). `src/pages/changelog.astro`
 renders it; `src/pages/changelog.xml.js` emits the RSS via `src/lib/rss.mjs`.
+Each release parses into ordered **`sections`** (`{heading, blocks}`, blocks
+being paragraphs and bullet lists) so a body renders in the order it was
+written — an intro paragraph above the bullets it introduces, each heading
+keeping its own list. Most releases are GitHub's auto-generated "What's
+Changed" notes, whose boilerplate headings are dropped and whose bullets keep
+their PR link; a hand-written body (v1.0.0 was the first) also uses `**bold**`,
+`` `code` ``, and `[text](url)`. That inline markup becomes **typed spans**
+(`text`/`strong`/`code`/`link`) that `components/ReleaseText.astro` maps onto
+real elements — never an HTML string, and never `set:html`: bullet text comes
+from contributor-supplied PR titles, so Astro's auto-escaping is what keeps
+release notes from introducing markup. Inline link hrefs are pinned to
+https/mailto. RSS flattens the same spans back to plain text.
 `npm run site:changelog` regenerates; `npm run site:changelog:check` is the
 freshness guard (release-time/manual — not in CI; needs `gh`). Never hand-edit
 `releases.json`. `release.sh` runs the regenerate step (non-fatal) but no

--- a/site/src/components/ReleaseText.astro
+++ b/site/src/components/ReleaseText.astro
@@ -1,0 +1,17 @@
+---
+// Renders one run of release-note text from the typed inline spans produced by
+// scripts/generate-site-changelog.mjs. Each span becomes a real element and its
+// value goes through Astro's auto-escaping, so release-note text — including
+// contributor-supplied PR titles — can never introduce markup of its own.
+const { spans = [] } = Astro.props;
+---
+{spans.map((span) => (
+  span.type === 'strong' ? <strong>{span.value}</strong>
+  : span.type === 'code' ? <code>{span.value}</code>
+  : span.type === 'link' ? (
+      span.url.startsWith('https:')
+        ? <a href={span.url} target="_blank" rel="noopener">{span.value}</a>
+        : <a href={span.url}>{span.value}</a>
+    )
+  : <Fragment>{span.value}</Fragment>
+))}

--- a/site/src/data/releases.json
+++ b/site/src/data/releases.json
@@ -8,84 +8,323 @@
     "machineDate": "2026-08-02",
     "url": "https://github.com/bnfy/blanc/releases/tag/v1.0.0",
     "anchor": "v1-0-0",
-    "changes": [
-      {
-        "text": "**Optional vertical tabs.** Turn on the resizable left rail from the Island, View menu, Settings, or with **Command-Option-V**. It preserves open pages and keeps the Island as Blanc's only address, search, and command surface.",
-        "url": null
-      },
-      {
-        "text": "**A first-class Island.** Press Command-L to navigate, search, switch among tabs, Favorites, history, named groups, and tabs shared by another device, or type `/` to run a browser command.",
-        "url": null
-      },
-      {
-        "text": "**A menu on the command bar.** Right-click the Island's address field for the usual editing items plus two Blanc actions. **Copy Clean Link** copies the address with known tracking parameters stripped, leaving every other parameter untouched. **Paste and Go** navigates straight from the clipboard through the same path as a typed address, then closes the Island.",
-        "url": null
-      },
-      {
-        "text": "**View Page Source.** Right-click a web page to read its source in Chromium's own highlighted view. It opens in a new tab, so Back never loses your place.",
-        "url": null
-      },
-      {
-        "text": "**Named groups and private tabs.** Groups organize tabs by name rather than color. Private tabs share a separate, non-persistent in-memory browsing session that is discarded when Blanc quits.",
-        "url": null
-      },
-      {
-        "text": "**Built-in blocking.** EasyList and EasyPrivacy filtering runs at the browser session layer rather than through an extension.",
-        "url": null
-      },
-      {
-        "text": "**Profile Sync.** Optional passphrase-based end-to-end encryption covers Favorites and settings. Per-device open-tab sharing is separate, read-only, and off by default.",
-        "url": null
-      },
-      {
-        "text": "Local browser chrome remains usable while blocking filters initialize. Failure offers **Retry** and an explicit **Continue without blocking** path.",
-        "url": null
-      },
-      {
-        "text": "A fresh profile presents Search suggestions and Help improve Blanc before either path may send; both choices can be changed before continuing.",
-        "url": null
-      },
-      {
-        "text": "Chrome and internal-page fonts are bundled locally.",
-        "url": null
-      },
-      {
-        "text": "Release publication verifies the exact signed and notarized package, updater metadata, blockmaps, and SHA-256 checksums before any asset is made public.",
-        "url": null
-      },
-      {
-        "text": "Blanc 1.0.0 is for **macOS on Apple Silicon**.",
-        "url": null
-      },
-      {
-        "text": "Blanc has no extension runtime or password import.",
-        "url": null
-      },
-      {
-        "text": "Ad and tracker blocking is best effort.",
-        "url": null
-      },
-      {
-        "text": "Copy Clean Link removes a curated list of known tracking parameters from http(s) addresses. It is not a general query-string cleaner, and it does not affect tracking that lives outside the query string.",
-        "url": null
-      },
-      {
-        "text": "The address field's menu is pointer-invoked on macOS.",
-        "url": null
-      },
-      {
-        "text": "An optional US$19 one-time Blanc Supporter purchase unlocks three cosmetic app-icon colorways; browser features remain free.",
-        "url": null
-      }
-    ],
     "compareUrl": null,
-    "extraParagraphs": [
-      "Blanc 1.0.0",
-      "Blanc 1.0 puts the browser in one small Island: navigation, search, tabs, named groups, page actions, and slash commands stay close without a permanent horizontal tab strip or conventional toolbar.",
-      "What is new in 1.0",
-      "Release hardening",
-      "Availability and boundaries",
-      "Download the Apple Silicon DMG and its `SHA256SUMS` manifest from the release assets. Product, press, and private security feedback can be sent to [support@blancbrowser.com](mailto:support@blancbrowser.com); put Security in the subject for vulnerabilities."
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Blanc 1.0 puts the browser in one small Island: navigation, search, tabs, named groups, page actions, and slash commands stay close without a permanent horizontal tab strip or conventional toolbar."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "What is new in 1.0",
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "strong",
+                    "value": "Optional vertical tabs."
+                  },
+                  {
+                    "type": "text",
+                    "value": " Turn on the resizable left rail from the Island, View menu, Settings, or with "
+                  },
+                  {
+                    "type": "strong",
+                    "value": "Command-Option-V"
+                  },
+                  {
+                    "type": "text",
+                    "value": ". It preserves open pages and keeps the Island as Blanc's only address, search, and command surface."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "strong",
+                    "value": "A first-class Island."
+                  },
+                  {
+                    "type": "text",
+                    "value": " Press Command-L to navigate, search, switch among tabs, Favorites, history, named groups, and tabs shared by another device, or type "
+                  },
+                  {
+                    "type": "code",
+                    "value": "/"
+                  },
+                  {
+                    "type": "text",
+                    "value": " to run a browser command."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "strong",
+                    "value": "A menu on the command bar."
+                  },
+                  {
+                    "type": "text",
+                    "value": " Right-click the Island's address field for the usual editing items plus two Blanc actions. "
+                  },
+                  {
+                    "type": "strong",
+                    "value": "Copy Clean Link"
+                  },
+                  {
+                    "type": "text",
+                    "value": " copies the address with known tracking parameters stripped, leaving every other parameter untouched. "
+                  },
+                  {
+                    "type": "strong",
+                    "value": "Paste and Go"
+                  },
+                  {
+                    "type": "text",
+                    "value": " navigates straight from the clipboard through the same path as a typed address, then closes the Island."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "strong",
+                    "value": "View Page Source."
+                  },
+                  {
+                    "type": "text",
+                    "value": " Right-click a web page to read its source in Chromium's own highlighted view. It opens in a new tab, so Back never loses your place."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "strong",
+                    "value": "Named groups and private tabs."
+                  },
+                  {
+                    "type": "text",
+                    "value": " Groups organize tabs by name rather than color. Private tabs share a separate, non-persistent in-memory browsing session that is discarded when Blanc quits."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "strong",
+                    "value": "Built-in blocking."
+                  },
+                  {
+                    "type": "text",
+                    "value": " EasyList and EasyPrivacy filtering runs at the browser session layer rather than through an extension."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "strong",
+                    "value": "Profile Sync."
+                  },
+                  {
+                    "type": "text",
+                    "value": " Optional passphrase-based end-to-end encryption covers Favorites and settings. Per-device open-tab sharing is separate, read-only, and off by default."
+                  }
+                ],
+                "url": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Release hardening",
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Local browser chrome remains usable while blocking filters initialize. Failure offers "
+                  },
+                  {
+                    "type": "strong",
+                    "value": "Retry"
+                  },
+                  {
+                    "type": "text",
+                    "value": " and an explicit "
+                  },
+                  {
+                    "type": "strong",
+                    "value": "Continue without blocking"
+                  },
+                  {
+                    "type": "text",
+                    "value": " path."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "A fresh profile presents Search suggestions and Help improve Blanc before either path may send; both choices can be changed before continuing."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Chrome and internal-page fonts are bundled locally."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Release publication verifies the exact signed and notarized package, updater metadata, blockmaps, and SHA-256 checksums before any asset is made public."
+                  }
+                ],
+                "url": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Availability and boundaries",
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Blanc 1.0.0 is for "
+                  },
+                  {
+                    "type": "strong",
+                    "value": "macOS on Apple Silicon"
+                  },
+                  {
+                    "type": "text",
+                    "value": "."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Blanc has no extension runtime or password import."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Ad and tracker blocking is best effort."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Copy Clean Link removes a curated list of known tracking parameters from http(s) addresses. It is not a general query-string cleaner, and it does not affect tracking that lives outside the query string."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "The address field's menu is pointer-invoked on macOS."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "An optional US$19 one-time Blanc Supporter purchase unlocks three cosmetic app-icon colorways; browser features remain free."
+                  }
+                ],
+                "url": null
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Download the Apple Silicon DMG and its "
+              },
+              {
+                "type": "code",
+                "value": "SHA256SUMS"
+              },
+              {
+                "type": "text",
+                "value": " manifest from the release assets. Product, press, and private security feedback can be sent to "
+              },
+              {
+                "type": "link",
+                "value": "support@blancbrowser.com",
+                "url": "mailto:support@blancbrowser.com"
+              },
+              {
+                "type": "text",
+                "value": "; put "
+              },
+              {
+                "type": "strong",
+                "value": "Security"
+              },
+              {
+                "type": "text",
+                "value": " in the subject for vulnerabilities."
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -97,20 +336,54 @@
     "machineDate": "2026-07-23",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.22.0",
     "anchor": "v0-22-0",
-    "changes": [
-      {
-        "text": "Add newsletter signup with honeypot and KV storage",
-        "url": "https://github.com/bnfy/blanc/pull/46"
-      },
-      {
-        "text": "Sync tab favicons safely",
-        "url": "https://github.com/bnfy/blanc/pull/47"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.21.0...v0.22.0",
-    "extraParagraphs": [
-      "Blanc v0.22.0 turns the Island into a full search surface. Start typing in ⌘L and Blanc now blends your open tabs, groups, Favorites, and history with live suggestions from the search engine you chose in Settings; arrow through the six-row list or press Enter to search exactly what you typed. Suggestions can be switched off, and private tabs, pasted text, addresses, local paths, and sensitive-looking input never leave the device for autocomplete.",
-      "Tabs synced from your other Blanc devices now carry their site icons too. The source device converts each favicon into a tiny inert PNG inside a separate end-to-end-encrypted sidecar, so another device never contacts a remote tab's site just to draw its row; strict budgets, cancellation, mixed-version compatibility, and graceful fallback keep this cosmetic layer from interfering with tab sync."
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Blanc v0.22.0 turns the Island into a full search surface. Start typing in ⌘L and Blanc now blends your open tabs, groups, Favorites, and history with live suggestions from the search engine you chose in Settings; arrow through the six-row list or press Enter to search exactly what you typed. Suggestions can be switched off, and private tabs, pasted text, addresses, local paths, and sensitive-looking input never leave the device for autocomplete."
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Tabs synced from your other Blanc devices now carry their site icons too. The source device converts each favicon into a tiny inert PNG inside a separate end-to-end-encrypted sidecar, so another device never contacts a remote tab's site just to draw its row; strict budgets, cancellation, mixed-version compatibility, and graceful fallback keep this cosmetic layer from interfering with tab sync."
+              }
+            ]
+          },
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Add newsletter signup with honeypot and KV storage"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/46"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Sync tab favicons safely"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/47"
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -122,28 +395,72 @@
     "machineDate": "2026-07-22",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.21.0",
     "anchor": "v0-21-0",
-    "changes": [
-      {
-        "text": "site: convert marketing site to Astro (F-parity, self-hosted fonts, hashed assets)",
-        "url": "https://github.com/bnfy/blanc/pull/42"
-      },
-      {
-        "text": "fix(newtab): keep the ledger footer clear of synced tab rows",
-        "url": "https://github.com/bnfy/blanc/pull/43"
-      },
-      {
-        "text": "Quiet rows for the expanded Island panel",
-        "url": "https://github.com/bnfy/blanc/pull/44"
-      },
-      {
-        "text": "Utility sheet: Favorites/History/Downloads/Settings/Shortcuts open as a sheet, not tabs",
-        "url": "https://github.com/bnfy/blanc/pull/45"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.20.0...v0.21.0",
-    "extraParagraphs": [
-      "Blanc v0.21.0 clears the clutter out of the ⌘L command panel. Favorites, History, Downloads, Settings, and Shortcuts now open as a sheet that floats over the page you're on instead of taking up a tab — open one, glance or change what you need, and dismiss it with Esc or a click, leaving your tab strip for actual browsing. Anything you open from it, like a favorite or a history entry, still opens as a normal tab.",
-      "The panel's tab list is quieter too: every row now shows just the site's icon and title at rest and reveals the address and controls when you hover or focus it, while long titles fade out softly instead of being cut off with an ellipsis. The tab you're currently on keeps its address in view, so you never lose track of where you are."
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Blanc v0.21.0 clears the clutter out of the ⌘L command panel. Favorites, History, Downloads, Settings, and Shortcuts now open as a sheet that floats over the page you're on instead of taking up a tab — open one, glance or change what you need, and dismiss it with Esc or a click, leaving your tab strip for actual browsing. Anything you open from it, like a favorite or a history entry, still opens as a normal tab."
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "The panel's tab list is quieter too: every row now shows just the site's icon and title at rest and reveals the address and controls when you hover or focus it, while long titles fade out softly instead of being cut off with an ellipsis. The tab you're currently on keeps its address in view, so you never lose track of where you are."
+              }
+            ]
+          },
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "site: convert marketing site to Astro (F-parity, self-hosted fonts, hashed assets)"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/42"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "fix(newtab): keep the ledger footer clear of synced tab rows"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/43"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Quiet rows for the expanded Island panel"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/44"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Utility sheet: Favorites/History/Downloads/Settings/Shortcuts open as a sheet, not tabs"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/45"
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -155,17 +472,54 @@
     "machineDate": "2026-07-22",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.20.0",
     "anchor": "v0-20-0",
-    "changes": [
-      {
-        "text": "Tab Sync: open tabs from your other devices (F27)",
-        "url": "https://github.com/bnfy/blanc/pull/41"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.19.0...v0.20.0",
-    "extraParagraphs": [
-      "Blanc v0.20.0 introduces Tab Sync: see your open tabs from your other devices. Turn on \"share this device's open tabs\" under Settings → Sync and each machine publishes a snapshot of its tabs — browse them from the ⌘L panel, the Quick Switcher, or the start page on any synced device, and open one locally with a click. It's a menu, not a mirror: nothing ever force-opens or closes a tab on another machine.",
-      "Sharing is off by default and per-device, private tabs never leave the machine, and like the rest of Profile Sync the snapshots are end-to-end encrypted — the sync server only ever stores ciphertext it cannot read.",
-      "This release also updates Electron to 43.2.0 for the latest Chromium stable."
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Blanc v0.20.0 introduces Tab Sync: see your open tabs from your other devices. Turn on \"share this device's open tabs\" under Settings → Sync and each machine publishes a snapshot of its tabs — browse them from the ⌘L panel, the Quick Switcher, or the start page on any synced device, and open one locally with a click. It's a menu, not a mirror: nothing ever force-opens or closes a tab on another machine."
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Sharing is off by default and per-device, private tabs never leave the machine, and like the rest of Profile Sync the snapshots are end-to-end encrypted — the sync server only ever stores ciphertext it cannot read."
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "This release also updates Electron to 43.2.0 for the latest Chromium stable."
+              }
+            ]
+          },
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Tab Sync: open tabs from your other devices (F27)"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/41"
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -177,11 +531,31 @@
     "machineDate": "2026-07-20",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.19.0",
     "anchor": "v0-19-0",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.18.0...v0.19.0",
-    "extraParagraphs": [
-      "Blanc v0.19.0 brings fully adaptive app icons to macOS 26 and later. Every Dock colorway is now an Icon Composer stack that follows the user's Icon & Widget Style — Default, Dark, Clear, or Tinted — including the system-selected tint color, while older macOS releases retain the existing flat icons.",
-      "This release also updates Electron to 43.1.1, electron-builder to 26.15.3, and Cucumber to 13.1.1, bringing the latest Chromium patch and a clean dependency audit."
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Blanc v0.19.0 brings fully adaptive app icons to macOS 26 and later. Every Dock colorway is now an Icon Composer stack that follows the user's Icon & Widget Style — Default, Dark, Clear, or Tinted — including the system-selected tint color, while older macOS releases retain the existing flat icons."
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "This release also updates Electron to 43.1.1, electron-builder to 26.15.3, and Cucumber to 13.1.1, bringing the latest Chromium patch and a clean dependency audit."
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -193,11 +567,31 @@
     "machineDate": "2026-07-12",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.18.0",
     "anchor": "v0-18-0",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.17.0...v0.18.0",
-    "extraParagraphs": [
-      "Blanc v0.18.0 sharpens the everyday chrome. The resting Island pill is larger and easier to read, and each tab dot now blooms into a small disc showing that tab's favicon when you hover or focus it — so you can see which tab you're switching to before you click.",
-      "The Favorites page gets a quieter, ledger-style layout: row and folder actions become understated text revealed on hover or focus, folder names move into their section headers, and dates line up in a right-aligned column."
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Blanc v0.18.0 sharpens the everyday chrome. The resting Island pill is larger and easier to read, and each tab dot now blooms into a small disc showing that tab's favicon when you hover or focus it — so you can see which tab you're switching to before you click."
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "The Favorites page gets a quieter, ledger-style layout: row and folder actions become understated text revealed on hover or focus, folder names move into their section headers, and dates line up in a right-aligned column."
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -209,21 +603,63 @@
     "machineDate": "2026-07-11",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.17.0",
     "anchor": "v0-17-0",
-    "changes": [
-      {
-        "text": "Add /save [folder] slash command",
-        "url": "https://github.com/bnfy/blanc/pull/38"
-      },
-      {
-        "text": "Network privacy (M2+M3): WebRTC leak protection + encrypted DNS",
-        "url": "https://github.com/bnfy/blanc/pull/39"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.16.0...v0.17.0",
-    "extraParagraphs": [
-      "Blanc v0.17.0 adds two privacy features that respect the VPN or proxy you already use: WebRTC leak protection and optional encrypted DNS (DoH).",
-      "Encrypted DNS hides your DNS lookups from the network in transit to the resolver you choose. It does not hide the sites you visit — destination IPs stay visible to your network — and choosing a provider is a trust decision. Automatic mode upgrades opportunistically and can fall back to unencrypted DNS; only the named-provider and custom positions are strict.",
-      "WebRTC leak protection keeps WebRTC from exposing addresses beyond your default connection, with an optional \"disable direct UDP\" mode for use behind an application proxy."
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Blanc v0.17.0 adds two privacy features that respect the VPN or proxy you already use: WebRTC leak protection and optional encrypted DNS (DoH)."
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Encrypted DNS hides your DNS lookups from the network in transit to the resolver you choose. It does not hide the sites you visit — destination IPs stay visible to your network — and choosing a provider is a trust decision. Automatic mode upgrades opportunistically and can fall back to unencrypted DNS; only the named-provider and custom positions are strict."
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "WebRTC leak protection keeps WebRTC from exposing addresses beyond your default connection, with an optional \"disable direct UDP\" mode for use behind an application proxy."
+              }
+            ]
+          },
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Add /save [folder] slash command"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/38"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Network privacy (M2+M3): WebRTC leak protection + encrypted DNS"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/39"
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -235,18 +671,37 @@
     "machineDate": "2026-07-11",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.16.0",
     "anchor": "v0-16-0",
-    "changes": [
-      {
-        "text": "Import favorites from other browsers + favorites folders",
-        "url": "https://github.com/bnfy/blanc/pull/36"
-      },
-      {
-        "text": "Reflect favorites folders in the native Favorites menu",
-        "url": "https://github.com/bnfy/blanc/pull/37"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.15.5...v0.16.0",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Import favorites from other browsers + favorites folders"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/36"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Reflect favorites folders in the native Favorites menu"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/37"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.15.5",
@@ -257,14 +712,28 @@
     "machineDate": "2026-07-11",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.15.5",
     "anchor": "v0-15-5",
-    "changes": [
-      {
-        "text": "fix(webauthn): Touch ID passkeys — entitlement, provisioning profile, verified signing chain",
-        "url": "https://github.com/bnfy/blanc/pull/32"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.15.4...v0.15.5",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "fix(webauthn): Touch ID passkeys — entitlement, provisioning profile, verified signing chain"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/32"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.15.4",
@@ -275,14 +744,28 @@
     "machineDate": "2026-07-10",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.15.4",
     "anchor": "v0-15-4",
-    "changes": [
-      {
-        "text": "fix(pages): private new tabs open blank — register blanc:// on the private session",
-        "url": "https://github.com/bnfy/blanc/pull/35"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.15.3...v0.15.4",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "fix(pages): private new tabs open blank — register blanc:// on the private session"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/35"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.15.3",
@@ -293,22 +776,46 @@
     "machineDate": "2026-07-10",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.15.3",
     "anchor": "v0-15-3",
-    "changes": [
-      {
-        "text": "fix(webauthn): restore Touch ID passkeys without restricted entitlement",
-        "url": "https://github.com/bnfy/blanc/pull/31"
-      },
-      {
-        "text": "fix(security): harden desktop browser boundaries",
-        "url": "https://github.com/bnfy/blanc/pull/33"
-      },
-      {
-        "text": "fix(privacy): audit follow-ups — telemetry pipeline, sync wipe, negative security tests",
-        "url": "https://github.com/bnfy/blanc/pull/34"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.15.1...v0.15.3",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "fix(webauthn): restore Touch ID passkeys without restricted entitlement"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/31"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "fix(security): harden desktop browser boundaries"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/33"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "fix(privacy): audit follow-ups — telemetry pipeline, sync wipe, negative security tests"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/34"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.15.1",
@@ -319,14 +826,28 @@
     "machineDate": "2026-07-10",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.15.1",
     "anchor": "v0-15-1",
-    "changes": [
-      {
-        "text": "fix(build): Gatekeeper rejection on fresh installs + Intel Mac support",
-        "url": "https://github.com/bnfy/blanc/pull/30"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.15.0...v0.15.1",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "fix(build): Gatekeeper rejection on fresh installs + Intel Mac support"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/30"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.15.0",
@@ -337,26 +858,55 @@
     "machineDate": "2026-07-10",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.15.0",
     "anchor": "v0-15-0",
-    "changes": [
-      {
-        "text": "feat: add macOS Touch ID passkeys",
-        "url": "https://github.com/bnfy/blanc/pull/26"
-      },
-      {
-        "text": "fix(release): guard all packaging inputs",
-        "url": "https://github.com/bnfy/blanc/pull/27"
-      },
-      {
-        "text": "iOS M6: theming, settings-lite, session restore, TestFlight prep",
-        "url": "https://github.com/bnfy/blanc/pull/28"
-      },
-      {
-        "text": "feat(site): marketing site release 1 — features, download, mobile optimization",
-        "url": "https://github.com/bnfy/blanc/pull/29"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.14.0...v0.15.0",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "feat: add macOS Touch ID passkeys"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/26"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "fix(release): guard all packaging inputs"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/27"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "iOS M6: theming, settings-lite, session restore, TestFlight prep"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/28"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "feat(site): marketing site release 1 — features, download, mobile optimization"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/29"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.14.0",
@@ -367,38 +917,82 @@
     "machineDate": "2026-07-09",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.14.0",
     "anchor": "v0-14-0",
-    "changes": [
-      {
-        "text": "test: add YouTube ad-blocking filter-list regression tests",
-        "url": "https://github.com/bnfy/blanc/pull/19"
-      },
-      {
-        "text": "ci: fix substrate job failing on the adblock-youtube unit test",
-        "url": "https://github.com/bnfy/blanc/pull/20"
-      },
-      {
-        "text": "Move new tab / private launchers into a dedicated island panel footer",
-        "url": "https://github.com/bnfy/blanc/pull/22"
-      },
-      {
-        "text": "feat(adblock): support $domain= in the WKContentRuleList converter",
-        "url": "https://github.com/bnfy/blanc/pull/21"
-      },
-      {
-        "text": "build(adblock): add --check drift guard for the generated blocklist",
-        "url": "https://github.com/bnfy/blanc/pull/23"
-      },
-      {
-        "text": "Island chrome: monochrome palette, favicon fix, and pill polish",
-        "url": "https://github.com/bnfy/blanc/pull/24"
-      },
-      {
-        "text": "fix(ios): hold ContentBlocker pending targets weakly, drop on failure",
-        "url": "https://github.com/bnfy/blanc/pull/25"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.13.4...v0.14.0",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "test: add YouTube ad-blocking filter-list regression tests"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/19"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "ci: fix substrate job failing on the adblock-youtube unit test"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/20"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Move new tab / private launchers into a dedicated island panel footer"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/22"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "feat(adblock): support $domain= in the WKContentRuleList converter"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/21"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "build(adblock): add --check drift guard for the generated blocklist"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/23"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Island chrome: monochrome palette, favicon fix, and pill polish"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/24"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "fix(ios): hold ContentBlocker pending targets weakly, drop on failure"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/25"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.13.4",
@@ -409,9 +1003,8 @@
     "machineDate": "2026-07-09",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.13.4",
     "anchor": "v0-13-4",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.13.3...v0.13.4",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.13.3",
@@ -422,14 +1015,28 @@
     "machineDate": "2026-07-09",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.13.3",
     "anchor": "v0-13-3",
-    "changes": [
-      {
-        "text": "iOS port: roadmap, M0-M1 walking skeleton, M2 design",
-        "url": "https://github.com/bnfy/blanc/pull/16"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.13.2...v0.13.3",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "iOS port: roadmap, M0-M1 walking skeleton, M2 design"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/16"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.13.2",
@@ -440,14 +1047,28 @@
     "machineDate": "2026-07-08",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.13.2",
     "anchor": "v0-13-2",
-    "changes": [
-      {
-        "text": "Fix Google sign-in \"browser may not be secure\" by matching Chrome browser signals",
-        "url": "https://github.com/bnfy/blanc/pull/18"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.13.1...v0.13.2",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Fix Google sign-in \"browser may not be secure\" by matching Chrome browser signals"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/18"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.13.1",
@@ -458,14 +1079,28 @@
     "machineDate": "2026-07-08",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.13.1",
     "anchor": "v0-13-1",
-    "changes": [
-      {
-        "text": "Patch Sec-CH-UA client hints to include Chrome brand",
-        "url": "https://github.com/bnfy/blanc/pull/17"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.13.0...v0.13.1",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Patch Sec-CH-UA client hints to include Chrome brand"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/17"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.13.0",
@@ -476,26 +1111,55 @@
     "machineDate": "2026-07-08",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.13.0",
     "anchor": "v0-13-0",
-    "changes": [
-      {
-        "text": "Add cross-platform parity spec, acceptance tests, and substrate generators",
-        "url": "https://github.com/bnfy/blanc/pull/13"
-      },
-      {
-        "text": "Document parity infrastructure in CLAUDE.md; guard settings:check against unguarded keys",
-        "url": "https://github.com/bnfy/blanc/pull/14"
-      },
-      {
-        "text": "Harden ping worker against transient KV failures; enable Workers Logs",
-        "url": "https://github.com/bnfy/blanc/pull/8"
-      },
-      {
-        "text": "Add active-user metrics to the launch ping",
-        "url": "https://github.com/bnfy/blanc/pull/15"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.12.0...v0.13.0",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Add cross-platform parity spec, acceptance tests, and substrate generators"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/13"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Document parity infrastructure in CLAUDE.md; guard settings:check against unguarded keys"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/14"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Harden ping worker against transient KV failures; enable Workers Logs"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/8"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Add active-user metrics to the launch ping"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/15"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.12.0",
@@ -506,14 +1170,28 @@
     "machineDate": "2026-07-07",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.12.0",
     "anchor": "v0-12-0",
-    "changes": [
-      {
-        "text": "Ship end-to-end encrypted profile sync (v1: Favorites + settings)",
-        "url": "https://github.com/bnfy/blanc/pull/12"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.11.0...v0.12.0",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Ship end-to-end encrypted profile sync (v1: Favorites + settings)"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/12"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.11.0",
@@ -524,14 +1202,28 @@
     "machineDate": "2026-07-06",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.11.0",
     "anchor": "v0-11-0",
-    "changes": [
-      {
-        "text": "Fix 15 code-review findings from the Supporter/monetization work",
-        "url": "https://github.com/bnfy/blanc/pull/11"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.10.0...v0.11.0",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Fix 15 code-review findings from the Supporter/monetization work"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/11"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.10.0",
@@ -542,18 +1234,37 @@
     "machineDate": "2026-07-06",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.10.0",
     "anchor": "v0-10-0",
-    "changes": [
-      {
-        "text": "Arrow-key workspace navigation + Help menu with Keyboard Shortcuts page",
-        "url": "https://github.com/bnfy/blanc/pull/9"
-      },
-      {
-        "text": "Monetization phase 1: Blanc Supporter license, support rails, grant drafts",
-        "url": "https://github.com/bnfy/blanc/pull/10"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.9.7...v0.10.0",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Arrow-key workspace navigation + Help menu with Keyboard Shortcuts page"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/9"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Monetization phase 1: Blanc Supporter license, support rails, grant drafts"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/10"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.9.7",
@@ -564,26 +1275,55 @@
     "machineDate": "2026-07-06",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.9.7",
     "anchor": "v0-9-7",
-    "changes": [
-      {
-        "text": "Add Windows and Linux release builds via CI workflow",
-        "url": "https://github.com/bnfy/blanc/pull/3"
-      },
-      {
-        "text": "Fix Windows/Linux release workflow: real filenames, cert-profile gate",
-        "url": "https://github.com/bnfy/blanc/pull/5"
-      },
-      {
-        "text": "Drop nonexistent .blockmap from the Linux AppImage asset list",
-        "url": "https://github.com/bnfy/blanc/pull/6"
-      },
-      {
-        "text": "Document tonight's Windows/Linux release gotchas in CLAUDE.md",
-        "url": "https://github.com/bnfy/blanc/pull/7"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.9.6...v0.9.7",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Add Windows and Linux release builds via CI workflow"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/3"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Fix Windows/Linux release workflow: real filenames, cert-profile gate"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/5"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Drop nonexistent .blockmap from the Linux AppImage asset list"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/6"
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Document tonight's Windows/Linux release gotchas in CLAUDE.md"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/7"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.9.6",
@@ -594,9 +1334,8 @@
     "machineDate": "2026-07-06",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.9.6",
     "anchor": "v0-9-6",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.9.5...v0.9.6",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.9.5",
@@ -607,14 +1346,28 @@
     "machineDate": "2026-07-05",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.9.5",
     "anchor": "v0-9-5",
-    "changes": [
-      {
-        "text": "Expand native Tabs/Favorites menus: pin, mute, duplicate tab",
-        "url": "https://github.com/bnfy/blanc/pull/4"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.9.4...v0.9.5",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Expand native Tabs/Favorites menus: pin, mute, duplicate tab"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/4"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.9.4",
@@ -625,9 +1378,8 @@
     "machineDate": "2026-07-05",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.9.4",
     "anchor": "v0-9-4",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.9.3...v0.9.4",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.9.3",
@@ -638,9 +1390,8 @@
     "machineDate": "2026-07-05",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.9.3",
     "anchor": "v0-9-3",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.9.2...v0.9.3",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.9.2",
@@ -651,14 +1402,28 @@
     "machineDate": "2026-07-05",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.9.2",
     "anchor": "v0-9-2",
-    "changes": [
-      {
-        "text": "Add opt-in launch ping telemetry",
-        "url": "https://github.com/bnfy/blanc/pull/2"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.9.1...v0.9.2",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Add opt-in launch ping telemetry"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/2"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.9.1",
@@ -669,9 +1434,8 @@
     "machineDate": "2026-07-05",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.9.1",
     "anchor": "v0-9-1",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.9.0...v0.9.1",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.9.0",
@@ -682,9 +1446,8 @@
     "machineDate": "2026-07-05",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.9.0",
     "anchor": "v0-9-0",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.8.0...v0.9.0",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.8.0",
@@ -695,9 +1458,8 @@
     "machineDate": "2026-07-05",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.8.0",
     "anchor": "v0-8-0",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.7.3...v0.8.0",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.7.3",
@@ -708,9 +1470,8 @@
     "machineDate": "2026-07-05",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.7.3",
     "anchor": "v0-7-3",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.7.2...v0.7.3",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.7.2",
@@ -721,9 +1482,8 @@
     "machineDate": "2026-07-05",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.7.2",
     "anchor": "v0-7-2",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.7.1...v0.7.2",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.7.1",
@@ -734,9 +1494,8 @@
     "machineDate": "2026-07-04",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.7.1",
     "anchor": "v0-7-1",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.7.0...v0.7.1",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.7.0",
@@ -747,18 +1506,42 @@
     "machineDate": "2026-07-04",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.7.0",
     "anchor": "v0-7-0",
-    "changes": [
-      {
-        "text": "Add blancbrowser.com marketing site",
-        "url": "https://github.com/bnfy/blanc/pull/1"
-      },
-      {
-        "text": "@bnfy made their first contribution",
-        "url": "https://github.com/bnfy/blanc/pull/1"
-      }
-    ],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.6.2...v0.7.0",
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Add blancbrowser.com marketing site"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/1"
+              }
+            ]
+          },
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "@bnfy made their first contribution"
+                  }
+                ],
+                "url": "https://github.com/bnfy/blanc/pull/1"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.6.2",
@@ -769,9 +1552,8 @@
     "machineDate": "2026-07-04",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.6.2",
     "anchor": "v0-6-2",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.6.1...v0.6.2",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.6.1",
@@ -782,9 +1564,8 @@
     "machineDate": "2026-07-04",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.6.1",
     "anchor": "v0-6-1",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.6.0...v0.6.1",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.6.0",
@@ -795,9 +1576,8 @@
     "machineDate": "2026-07-04",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.6.0",
     "anchor": "v0-6-0",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.5.1...v0.6.0",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.5.1",
@@ -808,9 +1588,8 @@
     "machineDate": "2026-07-04",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.5.1",
     "anchor": "v0-5-1",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.5.0...v0.5.1",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.5.0",
@@ -821,9 +1600,8 @@
     "machineDate": "2026-07-04",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.5.0",
     "anchor": "v0-5-0",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.4.1...v0.5.0",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.4.1",
@@ -834,9 +1612,8 @@
     "machineDate": "2026-07-04",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.4.1",
     "anchor": "v0-4-1",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.4.0...v0.4.1",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.4.0",
@@ -847,9 +1624,8 @@
     "machineDate": "2026-07-04",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.4.0",
     "anchor": "v0-4-0",
-    "changes": [],
     "compareUrl": "https://github.com/bnfy/blanc/compare/v0.3.0...v0.4.0",
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.3.0",
@@ -860,9 +1636,8 @@
     "machineDate": "2026-07-03",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.3.0",
     "anchor": "v0-3-0",
-    "changes": [],
     "compareUrl": null,
-    "extraParagraphs": []
+    "sections": []
   },
   {
     "tag": "v0.2.0",
@@ -873,10 +1648,22 @@
     "machineDate": "2026-07-03",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.2.0",
     "anchor": "v0-2-0",
-    "changes": [],
     "compareUrl": null,
-    "extraParagraphs": [
-      "Blanc rebrand release: identity rebrand, extensions popover, and new-tab focus-race fix."
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Blanc rebrand release: identity rebrand, extensions popover, and new-tab focus-race fix."
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -888,26 +1675,55 @@
     "machineDate": "2026-07-03",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.1.3",
     "anchor": "v0-1-3",
-    "changes": [
-      {
-        "text": "Consistent SVG toolbar icon set (replaces mismatched Unicode glyphs)",
-        "url": null
-      },
-      {
-        "text": "Fixed disconnected arrowhead on the reload icon",
-        "url": null
-      },
-      {
-        "text": "New blank tabs autofocus the address bar",
-        "url": null
-      },
-      {
-        "text": "Fixed the intermittent focus race so keystrokes reliably land in the address bar after opening a tab",
-        "url": null
-      }
-    ],
     "compareUrl": null,
-    "extraParagraphs": []
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Consistent SVG toolbar icon set (replaces mismatched Unicode glyphs)"
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Fixed disconnected arrowhead on the reload icon"
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "New blank tabs autofocus the address bar"
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Fixed the intermittent focus race so keystrokes reliably land in the address bar after opening a tab"
+                  }
+                ],
+                "url": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "tag": "v0.1.2",
@@ -918,10 +1734,22 @@
     "machineDate": "2026-07-03",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.1.2",
     "anchor": "v0-1-2",
-    "changes": [],
     "compareUrl": null,
-    "extraParagraphs": [
-      "Light mode: warm-stone light palette (now the default), with a System/Light/Dark appearance setting that themes the chrome, internal pages, and web content together."
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Light mode: warm-stone light palette (now the default), with a System/Light/Dark appearance setting that themes the chrome, internal pages, and web content together."
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -933,10 +1761,22 @@
     "machineDate": "2026-07-03",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.1.1",
     "anchor": "v0-1-1",
-    "changes": [],
     "compareUrl": null,
-    "extraParagraphs": [
-      "Auto-update test release: version label on the new tab page now reads v0.1.1."
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Auto-update test release: version label on the new tab page now reads v0.1.1."
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -948,8 +1788,7 @@
     "machineDate": "2026-07-03",
     "url": "https://github.com/bnfy/blanc/releases/tag/v0.1.0",
     "anchor": "v0-1-0",
-    "changes": [],
     "compareUrl": null,
-    "extraParagraphs": []
+    "sections": []
   }
 ]

--- a/site/src/lib/rss.mjs
+++ b/site/src/lib/rss.mjs
@@ -14,13 +14,29 @@ export function escapeXml(value) {
     .replaceAll("'", '&apos;');
 }
 
+// Feed readers get plain text, so the release's ordered sections flatten back
+// to one line per heading, bullet, and paragraph — inline spans concatenate to
+// the words they carry, dropping only the markup around them.
+export function summarize(release) {
+  const lines = [];
+  for (const section of release.sections || []) {
+    if (section.heading) lines.push(section.heading);
+    for (const block of section.blocks) {
+      if (block.type === 'list') for (const item of block.items) lines.push(spansToText(item.spans));
+      else lines.push(spansToText(block.spans));
+    }
+  }
+  return lines.join('\n');
+}
+
+function spansToText(spans = []) {
+  return spans.map((span) => span.value).join('');
+}
+
 export function renderRss(releases) {
   const newest = releases[0]?.publishedAt;
   const items = releases.slice(0, 20).map((release) => {
-    const summary = [
-      ...release.changes.map((change) => change.text),
-      ...release.extraParagraphs,
-    ].join('\n');
+    const summary = summarize(release);
     return `    <item>
       <title>${escapeXml(`Blanc ${release.version}`)}</title>
       <link>${escapeXml(release.url)}</link>

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import ReleaseText from '../components/ReleaseText.astro';
 import releases from '../data/releases.json';
 ---
 <BaseLayout
@@ -28,14 +29,22 @@ import releases from '../data/releases.json';
         <div class="release-meta"><time datetime={release.machineDate}>{release.humanDate}</time></div>
         <div class="release-body">
           <h2><a href={'#' + release.anchor}>Blanc {release.version}</a></h2>
-          {release.changes.length > 0 && (
-            <ul class="release-changes">
-              {release.changes.map((change) => (
-                <li>{change.url ? <a href={change.url} target="_blank" rel="noopener">{change.text}</a> : change.text}</li>
+          {release.sections.map((section) => (
+            <div class="release-section">
+              {section.heading && <h3 class="release-section-title">{section.heading}</h3>}
+              {section.blocks.map((block) => (
+                block.type === 'list' ? (
+                  <ul class="release-changes">
+                    {block.items.map((item) => (
+                      <li>{item.url
+                        ? <a href={item.url} target="_blank" rel="noopener"><ReleaseText spans={item.spans} /></a>
+                        : <ReleaseText spans={item.spans} />}</li>
+                    ))}
+                  </ul>
+                ) : <p class="release-para"><ReleaseText spans={block.spans} /></p>
               ))}
-            </ul>
-          )}
-          {release.extraParagraphs.map((paragraph) => <p>{paragraph}</p>)}
+            </div>
+          ))}
           <p class="release-links">{release.compareUrl && <><a href={release.compareUrl} target="_blank" rel="noopener">full changelog</a><span aria-hidden="true"> · </span></>}<a href={release.url} target="_blank" rel="noopener">GitHub release</a></p>
         </div>
       </article>

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -419,10 +419,22 @@ a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outlin
 .release-body h2 a:hover { border-color: var(--accent); }
 .release-changes { margin: 14px 0 0; padding: 0 0 0 18px; }
 .release-changes li { margin: 7px 0; color: var(--text-dim); font-size: 14.5px; line-height: 1.6; overflow-wrap: anywhere; }
-.release-body > p { margin: 12px 0 0; color: var(--text-dim); font-size: 14.5px; line-height: 1.6; overflow-wrap: anywhere; }
+.release-para, .release-body .release-links { margin: 12px 0 0; color: var(--text-dim); font-size: 14.5px; line-height: 1.6; overflow-wrap: anywhere; }
 .release-body .release-links { margin-top: 16px; font-family: var(--font-mono); font-size: 12px; }
-.release-changes a, .release-links a { color: inherit; text-decoration: none; border-bottom: 1px solid var(--border); padding-bottom: 1px; transition: color 0.15s, border-color 0.15s; }
-.release-changes a:hover, .release-links a:hover { color: var(--accent); border-color: var(--accent); }
+/* A hand-written release body is a run of sections — an optional label, then
+   the paragraphs and bullets written under it. The section owns the gap so the
+   blocks inside it keep their own rhythm. */
+.release-section { margin-top: 14px; }
+.release-section + .release-section { margin-top: 28px; }
+.release-section-title { margin: 0; font-family: var(--font-mono); font-size: 11px; font-weight: 400; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+.release-section-title + * { margin-top: 10px; }
+.release-section > :first-child { margin-top: 0; }
+/* Lead-in phrases lift out of the dim body copy so a long section stays
+   scannable; inline code matches the chip used on the feature pages. */
+.release-body strong { color: var(--text); font-weight: 500; }
+.release-body code { padding: 1px 5px; border: 1px solid var(--border); border-radius: 3px; background: var(--surface); color: var(--text); font-family: var(--font-mono); font-size: 0.88em; }
+.release-changes a, .release-para a, .release-links a { color: inherit; text-decoration: none; border-bottom: 1px solid var(--border); padding-bottom: 1px; transition: color 0.15s, border-color 0.15s; }
+.release-changes a:hover, .release-para a:hover, .release-links a:hover { color: var(--accent); border-color: var(--accent); }
 @media (max-width: 640px) {
   .changelog-page { padding: 78px 18px 68px; }
   .changelog-hero { margin-bottom: 52px; }

--- a/test/unit/site-changelog.test.js
+++ b/test/unit/site-changelog.test.js
@@ -17,6 +17,15 @@ test.before(async () => {
   fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8'));
 });
 
+// Release notes parse into ordered sections of blocks; most assertions here
+// care about one flavour of block, so pull them back out by kind.
+const text = (spans) => spans.map((span) => span.value).join('');
+const blocksOfType = (notes, type) =>
+  notes.sections.flatMap((section) => section.blocks.filter((block) => block.type === type));
+const listItems = (notes) => blocksOfType(notes, 'list').flatMap((block) => block.items);
+const changesOf = (notes) => listItems(notes).map((item) => ({ text: text(item.spans), url: item.url }));
+const paragraphsOf = (notes) => blocksOfType(notes, 'paragraph').map((block) => text(block.spans));
+
 test('normalization filters drafts and prereleases without inventing version gaps', () => {
   const releases = changelog.normalizeReleases([...fixture].reverse());
   assert.deepEqual(releases.map((release) => release.tag), ['v0.15.5', 'v0.15.4', 'v0.15.3']);
@@ -26,12 +35,14 @@ test('normalization filters drafts and prereleases without inventing version gap
 
 test('generated GitHub notes become clean labels and validated links', () => {
   const notes = changelog.parseGeneratedNotes(fixture[0].body);
-  assert.deepEqual(notes.changes, [{
+  assert.deepEqual(changesOf(notes), [{
     text: 'fix(webauthn): Touch ID passkeys — entitlement, provisioning profile, verified signing chain',
     url: 'https://github.com/bnfy/blanc/pull/32',
   }]);
   assert.equal(notes.compareUrl, 'https://github.com/bnfy/blanc/compare/v0.15.4...v0.15.5');
-  assert.deepEqual(notes.extraParagraphs, []);
+  assert.deepEqual(paragraphsOf(notes), []);
+  // "What's Changed" labels the boilerplate below it and carries nothing here.
+  assert.deepEqual(notes.sections.map((section) => section.heading), [null]);
 });
 
 test('non-Blanc links never become link URLs in the release data', () => {
@@ -40,7 +51,7 @@ test('non-Blanc links never become link URLs in the release data', () => {
     '* fix: <script>alert(1)</script> by @attacker in https://example.com/bnfy/blanc/pull/9',
     '**Full Changelog**: https://example.com/compare/a...b',
   ].join('\n'));
-  assert.equal(notes.changes[0].url, null);
+  assert.equal(listItems(notes)[0].url, null);
   assert.equal(notes.compareUrl, null);
 
   const release = changelog.normalizeReleases([{
@@ -54,8 +65,9 @@ test('non-Blanc links never become link URLs in the release data', () => {
   }]);
   const json = changelog.renderReleasesJson(release);
   const parsed = JSON.parse(json);
-  assert.equal(parsed[0].changes[0].url, null);
-  assert.equal(parsed[0].changes[0].text, 'fix: <script>alert(1)</script>');
+  const item = listItems(parsed[0])[0];
+  assert.equal(item.url, null);
+  assert.deepEqual(item.spans, [{ type: 'text', value: 'fix: <script>alert(1)</script>' }]);
   // HTML-escaping is Astro's job at render time; the data keeps raw text.
 });
 
@@ -65,9 +77,9 @@ test('pre-rename bnfy/bowser release links are rewritten to the current repo nam
     '* fix(updater): quit-and-install on Windows by @bnfy in https://github.com/bnfy/bowser/pull/7',
     '**Full Changelog**: https://github.com/bnfy/bowser/compare/v0.9.2...v0.9.3',
   ].join('\n'));
-  assert.equal(notes.changes[0].url, 'https://github.com/bnfy/blanc/pull/7');
+  assert.equal(listItems(notes)[0].url, 'https://github.com/bnfy/blanc/pull/7');
   assert.equal(notes.compareUrl, 'https://github.com/bnfy/blanc/compare/v0.9.2...v0.9.3');
-  assert.deepEqual(notes.extraParagraphs, []);
+  assert.deepEqual(paragraphsOf(notes), []);
 });
 
 test('the legacy Bowser name is scrubbed from visitor-facing release text', () => {
@@ -80,8 +92,8 @@ test('the legacy Bowser name is scrubbed from visitor-facing release text', () =
     '',
     'Bowser rebrand release: identity rebrand.',
   ].join('\n'));
-  assert.equal(notes.changes[0].text, 'Rename Blanc to Blanc');
-  assert.deepEqual(notes.extraParagraphs, ['Blanc rebrand release: identity rebrand.']);
+  assert.equal(changesOf(notes)[0].text, 'Rename Blanc to Blanc');
+  assert.deepEqual(paragraphsOf(notes), ['Blanc rebrand release: identity rebrand.']);
   assert.ok(!changelog.renderReleasesJson(changelog.normalizeReleases([{
     html_url: 'https://github.com/bnfy/bowser/releases/tag/v0.2.0',
     tag_name: 'v0.2.0', name: '0.2.0', draft: false, prerelease: false,
@@ -100,22 +112,114 @@ test('new-contributor notes become linked text instead of raw URLs', () => {
     '',
     '**Full Changelog**: https://github.com/bnfy/bowser/compare/v0.6.2...v0.7.0',
   ].join('\n'));
-  assert.deepEqual(notes.changes[0], {
+  assert.deepEqual(changesOf(notes)[0], {
     text: 'Add blancbrowser.com marketing site',
     url: 'https://github.com/bnfy/blanc/pull/1',
   });
-  assert.deepEqual(notes.changes[1], {
+  assert.deepEqual(changesOf(notes)[1], {
     text: '@bnfy made their first contribution',
     url: 'https://github.com/bnfy/blanc/pull/1',
   });
-  assert.deepEqual(notes.extraParagraphs, []);
+  assert.deepEqual(paragraphsOf(notes), []);
 });
 
 test('GitHub-looking URLs with embedded credentials are not trusted', () => {
   const notes = changelog.parseGeneratedNotes(
     '* fix: misleading host by @attacker in https://evil.example@github.com/bnfy/blanc/pull/9'
   );
-  assert.deepEqual(notes.changes, [{ text: 'fix: misleading host', url: null }]);
+  assert.deepEqual(changesOf(notes), [{ text: 'fix: misleading host', url: null }]);
+});
+
+test('inline markdown becomes typed spans instead of literal markup', () => {
+  assert.deepEqual(
+    changelog.parseInline('**Copy Clean Link** copies it, or type `/` — see [the docs](https://blancbrowser.com/x).'),
+    [
+      { type: 'strong', value: 'Copy Clean Link' },
+      { type: 'text', value: ' copies it, or type ' },
+      { type: 'code', value: '/' },
+      { type: 'text', value: ' — see ' },
+      { type: 'link', value: 'the docs', url: 'https://blancbrowser.com/x' },
+      { type: 'text', value: '.' },
+    ],
+  );
+  assert.equal(changelog.spansToText(changelog.parseInline('**bold** and `code`')), 'bold and code');
+});
+
+test('inline link targets are limited to https and mailto', () => {
+  const [mail] = changelog.parseInline('[support@blancbrowser.com](mailto:support@blancbrowser.com)');
+  assert.deepEqual(mail, {
+    type: 'link', value: 'support@blancbrowser.com', url: 'mailto:support@blancbrowser.com',
+  });
+  // A target we cannot vouch for keeps its words as prose rather than becoming
+  // an anchor — no javascript:/data: href can reach the page.
+  for (const href of ['javascript:alert%281%29', 'data:text/html,<script>x</script>', 'http://insecure.example']) {
+    assert.deepEqual(changelog.parseInline(`[click me](${href})`), [{ type: 'text', value: 'click me' }]);
+  }
+});
+
+test('a hand-written body keeps its headings, order, and lists', () => {
+  const notes = changelog.parseGeneratedNotes([
+    '# Blanc 1.0.0',
+    '',
+    'Blanc 1.0 puts the browser in one small Island.',
+    '',
+    '## What is new in 1.0',
+    '',
+    '- **Optional vertical tabs.** Turn on the left rail.',
+    '- **A first-class Island.** Type `/` to run a command.',
+    '',
+    '## Availability and boundaries',
+    '',
+    '- Blanc 1.0.0 is for **macOS on Apple Silicon**.',
+    '',
+    'Download the DMG and its `SHA256SUMS` manifest.',
+  ].join('\n'));
+
+  // The leading H1 restates the release title the entry already renders.
+  assert.deepEqual(notes.sections.map((section) => section.heading), [
+    null, 'What is new in 1.0', 'Availability and boundaries',
+  ]);
+  // The intro paragraph stays above the bullets it introduces.
+  assert.deepEqual(notes.sections[0].blocks.map((block) => block.type), ['paragraph']);
+  assert.equal(notes.sections[1].blocks.length, 1);
+  assert.equal(notes.sections[1].blocks[0].items.length, 2);
+  assert.deepEqual(notes.sections[2].blocks.map((block) => block.type), ['list', 'paragraph']);
+  assert.deepEqual(notes.sections[1].blocks[0].items[1].spans, [
+    { type: 'strong', value: 'A first-class Island.' },
+    { type: 'text', value: ' Type ' },
+    { type: 'code', value: '/' },
+    { type: 'text', value: ' to run a command.' },
+  ]);
+});
+
+test('a heading left empty by boilerplate stripping is not rendered', () => {
+  const notes = changelog.parseGeneratedNotes('## Notes\n\n## What\'s Changed\n* only bullet by @bnfy in https://github.com/bnfy/blanc/pull/1');
+  assert.deepEqual(notes.sections.map((section) => section.heading), ['Notes']);
+  assert.equal(listItems(notes).length, 1);
+});
+
+test('a bullet that links to its PR never nests an anchor inside itself', () => {
+  const notes = changelog.parseGeneratedNotes(
+    '* fix: see [the issue](https://blancbrowser.com/x) by @bnfy in https://github.com/bnfy/blanc/pull/9'
+  );
+  const [item] = listItems(notes);
+  assert.equal(item.url, 'https://github.com/bnfy/blanc/pull/9');
+  assert.ok(!item.spans.some((span) => span.type === 'link'));
+  assert.equal(text(item.spans), 'fix: see the issue');
+});
+
+test('RSS descriptions flatten sections back to plain text', async () => {
+  const { renderRss, summarize } = await import(pathToFileURL(path.join(ROOT, 'site/src/lib/rss.mjs')));
+  const [release] = changelog.normalizeReleases([{
+    html_url: 'https://github.com/bnfy/blanc/releases/tag/v1.0.0',
+    tag_name: 'v1.0.0', name: '1.0.0', draft: false, prerelease: false,
+    published_at: '2026-08-02T04:34:56Z',
+    body: 'Intro line.\n\n## What is new\n\n- **Bold lead.** Body text with `code`.',
+  }]);
+  assert.equal(summarize(release), 'Intro line.\nWhat is new\nBold lead. Body text with code.');
+  const rss = renderRss([release]);
+  assert.ok(!rss.includes('**'), 'markdown markup must not reach the feed');
+  assert.match(rss, /Bold lead\. Body text with code\./);
 });
 
 test('release data is deterministic and RSS is capped at twenty newest releases', async () => {


### PR DESCRIPTION
The 1.0.0 entry was the first hand-written release body; every release
before it used GitHub's auto-generated "What's Changed" notes, which is
all the changelog parser understood. So the entry rendered its markdown
as literal text — `**Optional vertical tabs.**`, a bare `/`, and a raw
`[support@blancbrowser.com](mailto:...)` — and its four headings were
flattened into plain paragraphs that the template emitted *after* the
bullet list, orphaning the intro and merging three sections into one
undifferentiated run of 17 bullets.

Parse bodies into ordered sections of blocks (paragraphs and lists) so a
release renders in the order it was written, and turn inline `**bold**`,
`code`, and `[text](url)` into typed spans. Spans, not an HTML string:
bullet text comes from contributor-supplied PR titles, so the renderer
maps each span onto a real element and Astro's auto-escaping stays in
the path. Inline hrefs are pinned to https/mailto.

This also fixes ordering for the eight older releases whose prose
introduction rendered below the bullets it introduces, and drops the
"What's Changed"/"New Contributors" boilerplate headings along with a
leading H1 that just restates the release title.

Style: section labels reuse the site's mono kicker idiom, bold lead-ins
lift out of the dim body copy so a long section stays scannable, and
inline code matches the chip used on the feature pages.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TSsZeYArc8cEcpW9PCvTkP