### PR TITLE
Fix Windows update shutdown for 1.0.1

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,51 @@
+# Blanc's one-window/many-WebContentsView architecture can leave an old
+# renderer or GPU process alive a little longer than electron-builder's
+# default NSIS close loop allows. Retry used to work because it simply gave
+# that process another loop. Keep the exact-path process checks and kill
+# implementation supplied by electron-builder, but make the bounded retry
+# automatic so an update does not strand users at a misleading dialog.
+!include "getProcessInfo.nsh"
+Var pid
+
+!macro customCheckAppRunning
+  ${GetProcessInfo} 0 $pid $1 $2 $3 $4
+  !insertmacro IS_POWERSHELL_AVAILABLE
+  ${if} $3 != "${APP_EXECUTABLE_FILENAME}"
+    ${ifNot} ${isUpdated}
+      !insertmacro FIND_PROCESS "${APP_EXECUTABLE_FILENAME}" $R0
+      ${if} $R0 == 0
+        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "$(appRunning)" /SD IDOK IDOK blancStopProcess
+        Quit
+      ${else}
+        Goto blancProcessClosed
+      ${endIf}
+    ${endIf}
+
+    blancStopProcess:
+      DetailPrint "$(appClosing)"
+      !insertmacro KILL_PROCESS "${APP_EXECUTABLE_FILENAME}" 0
+      Sleep 500
+      StrCpy $R1 0
+
+    blancCloseLoop:
+      !insertmacro FIND_PROCESS "${APP_EXECUTABLE_FILENAME}" $R0
+      ${if} $R0 != 0
+        Goto blancProcessClosed
+      ${endIf}
+
+      IntOp $R1 $R1 + 1
+      !insertmacro KILL_PROCESS "${APP_EXECUTABLE_FILENAME}" 1
+      Sleep 1000
+
+      # Fifteen automatic retries cover slow Chromium teardown and the
+      # observed case where the stock installer's first manual Retry worked.
+      ${if} $R1 < 15
+        Goto blancCloseLoop
+      ${endIf}
+
+      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY blancStopProcess
+      Quit
+
+    blancProcessClosed:
+  ${endIf}
+!macroend

--- a/docs/press/fact-sheet.md
+++ b/docs/press/fact-sheet.md
@@ -19,7 +19,7 @@ extension runtime.
 | Item | Fact |
 |---|---|
 | Product | Blanc Browser |
-| Version | [1.0.0](https://github.com/bnfy/blanc/releases/tag/v1.0.0) |
+| Version | [1.0.1](https://github.com/bnfy/blanc/releases/tag/v1.0.1) |
 | Press-build platform | macOS on Apple Silicon |
 | Price | Free |
 | Optional purchase | Blanc Supporter, US$19 one time, plus applicable taxes; unlocks three cosmetic app-icon colorways |

--- a/docs/press/release-notes/v1.0.1.md
+++ b/docs/press/release-notes/v1.0.1.md
@@ -1,0 +1,21 @@
+# Blanc 1.0.1
+
+Blanc 1.0.1 is a maintenance release for macOS, Windows, and Linux. It fixes
+the Windows restart handoff that could leave an old Blanc process running while
+the installer tried to replace it.
+
+## Fixed
+
+- The Windows installer now closes the old Blanc process and retries for a
+  bounded period before asking for manual intervention. This replaces the
+  failure mode where the first install attempt said Blanc could not be closed
+  and clicking **Retry** later succeeded.
+- **Restart Now** on Windows now tears down every Blanc browser surface after
+  session data has been preserved, with a forced-exit backstop if Chromium does
+  not finish shutting down promptly. This also prevents an old instance from
+  reclaiming the relaunch and offering the same update again.
+
+## Other platforms
+
+The macOS and Linux application behavior is unchanged. All three platforms are
+built from the same `v1.0.1` source tag and published with one SHA-256 manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -4,7 +4,7 @@ import BrandMark from '../components/BrandMark.astro';
 import PressIslandDemo from '../components/PressIslandDemo.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 
-const VERSION = '1.0.0';
+const VERSION = '1.0.1';
 const TAG = `v${VERSION}`;
 const RELEASE_BASE = 'https://github.com/bnfy/blanc/releases';
 const RELEASE_URL = `${RELEASE_BASE}/tag/${TAG}`;
@@ -230,7 +230,7 @@ const slashCommands = slashCommandCopy.commands.map((entry) => entry.doc ?? entr
       <section class="press-fact-group" aria-labelledby="press-facts-launch">
         <h3 id="press-facts-launch">launch</h3>
         <dl class="press-fact-grid">
-          <div><dt>version</dt><dd>Blanc 1.0.0</dd></div>
+          <div><dt>version</dt><dd>Blanc {VERSION}</dd></div>
           <div><dt>released</dt><dd>August 2, 2026</dd></div>
           <div><dt>platforms</dt><dd>macOS · Windows · Linux</dd></div>
           <div><dt>release files</dt><dd>DMG + ZIP · EXE · AppImage</dd></div>

--- a/src/main/update-restart.js
+++ b/src/main/update-restart.js
@@ -1,0 +1,80 @@
+const WINDOWS_FORCE_EXIT_DELAY_MS = 1000;
+
+/** Force-close every Electron surface after app.quit has begun.
+ *
+ * Blanc intentionally keeps tab WebContentsViews alive when its one
+ * BrowserWindow closes so macOS can recreate the window from the Dock. During
+ * a Windows update that same lifetime is harmful: NSIS cannot replace the
+ * executable while even one old Blanc process survives. This runs from the
+ * app's `before-quit` event, after main's session-persistence guard and store
+ * flush listeners have observed the quit, and bypasses page beforeunload
+ * handlers because the installer must win this shutdown.
+ */
+function closeAllSurfaces({ BrowserWindow, webContents }) {
+  for (const contents of webContents.getAllWebContents()) {
+    if (contents.isDestroyed() || BrowserWindow.fromWebContents(contents)) continue;
+    try {
+      contents.close({ waitForBeforeUnload: false });
+    } catch {
+      // The owning window may have destroyed it between the snapshot and close.
+    }
+  }
+
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (window.isDestroyed()) continue;
+    try {
+      window.destroy();
+    } catch {
+      // Shutdown continues to the forced-exit backstop below.
+    }
+  }
+}
+
+/**
+ * Build the single restart action used by the downloaded-update prompt.
+ * Dependencies are explicit so the Windows-only shutdown contract stays
+ * unit-testable on the macOS release host.
+ */
+function createUpdateRestarter({
+  app,
+  autoUpdater,
+  BrowserWindow,
+  webContents,
+  platform = process.platform,
+  schedule = setTimeout,
+}) {
+  let restartRequested = false;
+
+  return function restartToInstallUpdate() {
+    if (restartRequested) return;
+    restartRequested = true;
+
+    const isWindows = platform === 'win32';
+    const closeForUpdate = () => closeAllSurfaces({ BrowserWindow, webContents });
+    if (isWindows) app.once('before-quit', closeForUpdate);
+
+    try {
+      // electron-updater spawns NSIS before it schedules app.quit(). Arm the
+      // before-quit cleanup first so there is no event-ordering race.
+      autoUpdater.quitAndInstall();
+    } catch (err) {
+      restartRequested = false;
+      if (isWindows) app.removeListener('before-quit', closeForUpdate);
+      throw err;
+    }
+
+    if (!isWindows) return;
+
+    // Browser/GPU processes should disappear through the normal quit path.
+    // If Chromium or a page wedges teardown, exit before NSIS gives up and
+    // shows its "Blanc cannot be closed" retry loop. The installer is a
+    // detached process, so app.exit() does not terminate it.
+    schedule(() => app.exit(0), WINDOWS_FORCE_EXIT_DELAY_MS);
+  };
+}
+
+module.exports = {
+  WINDOWS_FORCE_EXIT_DELAY_MS,
+  closeAllSurfaces,
+  createUpdateRestarter,
+};

--- a/src/main/updater.js
+++ b/src/main/updater.js
@@ -1,5 +1,6 @@
-const { app, dialog, BrowserWindow } = require('electron');
+const { app, dialog, BrowserWindow, webContents } = require('electron');
 const { autoUpdater } = require('electron-updater');
+const { createUpdateRestarter } = require('./update-restart');
 
 // Attach update dialogs to the browser window so they can't appear behind
 // it; fall back to an unparented dialog if no window exists.
@@ -15,6 +16,12 @@ function showDialog(options) {
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
 
 let updateDownloaded = false;
+const restartToInstallUpdate = createUpdateRestarter({
+  app,
+  autoUpdater,
+  BrowserWindow,
+  webContents,
+});
 
 function promptRestart(info) {
   showDialog({
@@ -24,7 +31,7 @@ function promptRestart(info) {
     message: `Update ${info.version} downloaded`,
     detail: 'Restart to apply it. The update includes the latest Chromium engine.',
   }).then(({ response }) => {
-    if (response === 0) autoUpdater.quitAndInstall();
+    if (response === 0) restartToInstallUpdate();
   });
 }
 

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.0.0');
+  assert.equal(packageVersion, '1.0.1');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),

--- a/test/unit/update-restart.test.js
+++ b/test/unit/update-restart.test.js
@@ -1,0 +1,111 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+
+const {
+  WINDOWS_FORCE_EXIT_DELAY_MS,
+  createUpdateRestarter,
+} = require('../../src/main/update-restart');
+
+function harness(platform = 'win32') {
+  const app = new EventEmitter();
+  const calls = [];
+  app.exit = (code) => calls.push(['exit', code]);
+
+  const ownedContents = { isDestroyed: () => false };
+  const closedContents = {
+    isDestroyed: () => false,
+    close: (options) => calls.push(['close-contents', options]),
+  };
+  const alreadyDestroyedContents = {
+    isDestroyed: () => true,
+    close: () => calls.push(['close-destroyed-contents']),
+  };
+  const window = {
+    isDestroyed: () => false,
+    destroy: () => calls.push(['destroy-window']),
+  };
+  const alreadyDestroyedWindow = {
+    isDestroyed: () => true,
+    destroy: () => calls.push(['destroy-destroyed-window']),
+  };
+
+  const BrowserWindow = {
+    fromWebContents: (contents) => contents === ownedContents ? window : null,
+    getAllWindows: () => [window, alreadyDestroyedWindow],
+  };
+  const webContents = {
+    getAllWebContents: () => [ownedContents, closedContents, alreadyDestroyedContents],
+  };
+  const autoUpdater = {
+    quitAndInstall: () => calls.push(['quit-and-install']),
+  };
+  const scheduled = [];
+  const schedule = (callback, delay) => {
+    scheduled.push({ callback, delay });
+  };
+
+  const restart = createUpdateRestarter({
+    app,
+    autoUpdater,
+    BrowserWindow,
+    webContents,
+    platform,
+    schedule,
+  });
+
+  return { app, autoUpdater, calls, restart, scheduled };
+}
+
+test('Windows update closes every old surface after quit begins and forces a bounded exit', () => {
+  const { app, calls, restart, scheduled } = harness();
+  app.on('before-quit', () => calls.push(['existing-before-quit-listener']));
+
+  restart();
+  assert.deepEqual(calls, [['quit-and-install']]);
+  assert.equal(scheduled.length, 1);
+  assert.equal(scheduled[0].delay, WINDOWS_FORCE_EXIT_DELAY_MS);
+
+  app.emit('before-quit');
+  assert.deepEqual(calls, [
+    ['quit-and-install'],
+    ['existing-before-quit-listener'],
+    ['close-contents', { waitForBeforeUnload: false }],
+    ['destroy-window'],
+  ]);
+
+  scheduled[0].callback();
+  assert.deepEqual(calls.at(-1), ['exit', 0]);
+
+  restart();
+  assert.equal(calls.filter(([name]) => name === 'quit-and-install').length, 1);
+});
+
+test('non-Windows updates retain electron-updater native restart behavior', () => {
+  const { app, calls, restart, scheduled } = harness('darwin');
+
+  restart();
+  app.emit('before-quit');
+
+  assert.deepEqual(calls, [['quit-and-install']]);
+  assert.deepEqual(scheduled, []);
+});
+
+test('a synchronous updater failure disarms cleanup and permits retry', () => {
+  const { app, autoUpdater, calls, restart, scheduled } = harness();
+  let attempts = 0;
+  autoUpdater.quitAndInstall = () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error('installer spawn failed');
+    calls.push(['quit-and-install']);
+  };
+
+  assert.throws(restart, /installer spawn failed/);
+  assert.equal(app.listenerCount('before-quit'), 0);
+  assert.deepEqual(scheduled, []);
+
+  restart();
+  assert.equal(attempts, 2);
+  assert.equal(app.listenerCount('before-quit'), 1);
+  assert.equal(scheduled.length, 1);
+});

--- a/test/unit/windows-updater-packaging.test.js
+++ b/test/unit/windows-updater-packaging.test.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+test('the Windows installer carries Blanc\'s bounded old-process close loop', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  const include = fs.readFileSync(path.join(ROOT, 'build/installer.nsh'), 'utf8');
+
+  assert.deepEqual(pkg.build.win.target, ['nsis']);
+  assert.match(include, /!include "getProcessInfo\.nsh"/);
+  assert.match(include, /Var pid/);
+  assert.match(include, /!macro customCheckAppRunning/);
+  assert.match(include, /!insertmacro IS_POWERSHELL_AVAILABLE/);
+  assert.match(include, /!insertmacro FIND_PROCESS "\$\{APP_EXECUTABLE_FILENAME\}"/);
+  assert.match(include, /!insertmacro KILL_PROCESS "\$\{APP_EXECUTABLE_FILENAME\}" 1/);
+  assert.match(include, /\$R1 < 15/);
+  assert.match(include, /MB_RETRYCANCEL/);
+  assert.match(include, /IDRETRY blancStopProcess/);
+});


### PR DESCRIPTION
## What

- make Windows update restarts close every remaining Blanc surface after state is flushed
- add a forced-exit backstop for Chromium processes that do not finish promptly
- extend the NSIS close loop so slow old processes are retried automatically before showing Retry/Cancel
- bump Blanc to 1.0.1 and add maintenance release metadata

## Why

A Windows user saw the installer stop with “Blanc cannot be closed.” Clicking Retry later worked, but the old instance then reopened and offered 1.0.0 again. The app and installer now cooperate to complete that handoff reliably.

## Verification

- `npm run release:verify:press`
- `npm run test:unit` (290 passing)
- unpublished x64 NSIS build produced `Blanc-Setup-1.0.1.exe` and its blockmap
- `git diff --check`
