### PR TITLE
Record 1.0.1 release and fix native tag handoff

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -227,6 +227,13 @@ BLANC_STABLE_EXECUTABLE="$MIGRATION_DIR/stable/Blanc.app/Contents/MacOS/Blanc" \
 rm -rf "$MIGRATION_DIR"
 trap - EXIT
 
+# A draft release's requested tag is not exposed as a Git ref. Publish the
+# immutable source tag first so native workflow runners can check out the
+# exact commit while every release asset remains private in the draft.
+echo "==> Publishing immutable source tag for native builders"
+git tag "$TAG" "$LOCAL_HEAD"
+git push origin "refs/tags/$TAG"
+
 CREATE_ARGS=(
   release create "$TAG"
   "${MAC_ASSETS[@]}"

--- a/site/src/data/releases.json
+++ b/site/src/data/releases.json
@@ -1,5 +1,180 @@
 [
   {
+    "tag": "v1.0.1",
+    "version": "1.0.1",
+    "name": "1.0.1",
+    "publishedAt": "2026-08-03T00:12:29.000Z",
+    "humanDate": "August 2, 2026",
+    "machineDate": "2026-08-02",
+    "url": "https://github.com/bnfy/blanc/releases/tag/v1.0.1",
+    "anchor": "v1-0-1",
+    "compareUrl": null,
+    "sections": [
+      {
+        "heading": null,
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "Blanc 1.0.1 is a maintenance release for macOS, Windows, and Linux. It fixes"
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "the Windows restart handoff that could leave an old Blanc process running while"
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "the installer tried to replace it."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Fixed",
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "The Windows installer now closes the old Blanc process and retries for a"
+                  }
+                ],
+                "url": null
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "bounded period before asking for manual intervention. This replaces the"
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "failure mode where the first install attempt said Blanc could not be closed"
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "and clicking "
+              },
+              {
+                "type": "strong",
+                "value": "Retry"
+              },
+              {
+                "type": "text",
+                "value": " later succeeded."
+              }
+            ]
+          },
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "strong",
+                    "value": "Restart Now"
+                  },
+                  {
+                    "type": "text",
+                    "value": " on Windows now tears down every Blanc browser surface after"
+                  }
+                ],
+                "url": null
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "session data has been preserved, with a forced-exit backstop if Chromium does"
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "not finish shutting down promptly. This also prevents an old instance from"
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "reclaiming the relaunch and offering the same update again."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Other platforms",
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "The macOS and Linux application behavior is unchanged. All three platforms are"
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "built from the same "
+              },
+              {
+                "type": "code",
+                "value": "v1.0.1"
+              },
+              {
+                "type": "text",
+                "value": " source tag and published with one SHA-256 manifest."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     "tag": "v1.0.0",
     "version": "1.0.0",
     "name": "1.0.0",

--- a/test/unit/release-manifest.test.js
+++ b/test/unit/release-manifest.test.js
@@ -110,6 +110,12 @@ test('release policy stages a draft, warns on unsigned Windows builds, and verif
     .join('\n');
 
   assert.ok(releaseScript.indexOf('--draft') < releaseScript.indexOf('--draft=false'));
+  const sourceTagPush = releaseScript.indexOf('git push origin "refs/tags/$TAG"');
+  const draftCreate = releaseScript.indexOf('gh "${CREATE_ARGS[@]}"');
+  const nativeDispatch = releaseScript.indexOf('gh workflow run release-windows-linux.yml');
+  assert.ok(sourceTagPush >= 0, 'release must publish the immutable source tag');
+  assert.ok(sourceTagPush < draftCreate, 'source tag must exist before the draft is created');
+  assert.ok(sourceTagPush < nativeDispatch, 'native builders must be able to fetch the tag');
   assert.match(releaseScript, /verify-release-manifest\.mjs/);
   assert.match(releaseScript, /SHA256SUMS/);
   // Windows signing is opportunistic until Azure Trusted Signing is live:


### PR DESCRIPTION
## What

- record the public v1.0.1 release in the generated site changelog
- publish the immutable source tag before creating the private draft and dispatching native builders
- test that tag publication stays ahead of draft creation and native CI dispatch

## Why

During v1.0.1, GitHub kept the draft release’s requested tag internal, so Windows and Linux could not fetch `v1.0.1` until the exact source tag was pushed separately. This preserves the draft-first asset policy while making the source commit available to native runners.

## Verification

- `node --test test/unit/release-manifest.test.js test/unit/site-changelog.test.js`
- `npm run site:build`
- `git diff --check`
