### PR TITLE
Add Windows and Linux main menu button

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -49,6 +49,7 @@ const {
   calculateChromeLayout,
 } = require('./chrome-layout');
 const { reorderWithinBucket } = require('./tab-order');
+const { popupPlatformMainMenu } = require('./platform-main-menu');
 
 const NEW_TAB_URL = 'blanc://newtab/';
 const newTabUrl = () => settings.getSettings().homePage || NEW_TAB_URL;
@@ -2188,6 +2189,13 @@ function registerIpcHandlers() {
 
   chromeOn('chrome:open-island', () => showOverlay('panel'));
   chromeOn('chrome:open-find', () => showOverlay('find'));
+  chromeHandle('chrome:open-main-menu', (event, point) => {
+    // The rich preload is shared with the overlay, but the visible platform
+    // menu button exists only in the strip document. Keep this entry point as
+    // narrow as the UI that owns it.
+    if (event.sender !== win?.webContents) return false;
+    return popupPlatformMainMenu({ Menu, window: win, point });
+  });
   chromeHandle('chrome:set-tab-layout', (_e, layout) => setTabLayout(layout));
   chromeOn('chrome:preview-vertical-tabs-width', (_e, width) =>
     previewVerticalTabsWidth(width));

--- a/src/main/platform-main-menu.js
+++ b/src/main/platform-main-menu.js
@@ -1,0 +1,49 @@
+function supportsPlatformMainMenu(platform = process.platform) {
+  return platform === 'win32' || platform === 'linux';
+}
+
+function clampCoordinate(value, maximum) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.round(value), 0), Math.max(0, maximum - 1));
+}
+
+function popupPoint(point, contentBounds) {
+  return {
+    x: clampCoordinate(point?.x, contentBounds?.width ?? 0),
+    y: clampCoordinate(point?.y, contentBounds?.height ?? 0),
+  };
+}
+
+/**
+ * Open the live application Menu as a context menu beside the custom chrome.
+ * This deliberately reuses Menu.getApplicationMenu(): File/Edit/View/Tabs/
+ * Favorites/Help and their dynamic state must have exactly one definition.
+ */
+function popupPlatformMainMenu({ Menu, window, point, platform = process.platform }) {
+  if (!supportsPlatformMainMenu(platform) || !window || window.isDestroyed()) {
+    return Promise.resolve(false);
+  }
+
+  const menu = Menu.getApplicationMenu();
+  if (!menu?.items?.length) return Promise.resolve(false);
+
+  const { x, y } = popupPoint(point, window.getContentBounds());
+  return new Promise((resolve, reject) => {
+    try {
+      menu.popup({
+        window,
+        x,
+        y,
+        callback: () => resolve(true),
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+module.exports = {
+  popupPlatformMainMenu,
+  popupPoint,
+  supportsPlatformMainMenu,
+};

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -52,6 +52,7 @@ contextBridge.exposeInMainWorld('browserAPI', {
 
   openIsland: () => ipcRenderer.send('chrome:open-island'),
   openFindBar: () => ipcRenderer.send('chrome:open-find'),
+  openMainMenu: (point) => ipcRenderer.invoke('chrome:open-main-menu', point),
   closeOverlay: () => ipcRenderer.send('overlay:close'),
 
   listHistory: (opts) => ipcRenderer.invoke('chrome:history-list', opts),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -33,7 +33,19 @@
         <button id="permAllowBtn">Allow</button>
         <button id="permBlockBtn">Block</button>
       </div>
-      <div id="windowControls" class="no-drag"></div>
+      <div id="windowControls" class="no-drag">
+        <button
+          id="mainMenuButton"
+          type="button"
+          title="Main menu"
+          aria-label="Main menu"
+          aria-haspopup="menu"
+          aria-expanded="false"
+          hidden
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 3.25h.01M8 8h.01M8 12.75h.01"/></svg>
+        </button>
+      </div>
     </div>
   </div>
   <aside id="verticalTabsRail" class="vertical-tabs-rail no-drag" aria-label="Vertical tabs" hidden>

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -22,6 +22,7 @@
   const pillPrivateChip = document.getElementById('pillPrivateChip');
   const pillSourceChip = document.getElementById('pillSourceChip');
   const windowControls = document.getElementById('windowControls');
+  const mainMenuButton = document.getElementById('mainMenuButton');
   const permissionBar = document.getElementById('permissionBar');
   const permissionText = document.getElementById('permissionText');
   const permAllowBtn = document.getElementById('permAllowBtn');
@@ -110,6 +111,21 @@
 
   // --- Window controls (non-mac only; macOS gets native traffic lights) ---
   if (!isMac) {
+    let mainMenuOpen = false;
+    mainMenuButton.hidden = false;
+    mainMenuButton.addEventListener('click', async () => {
+      if (mainMenuOpen) return;
+      const rect = mainMenuButton.getBoundingClientRect();
+      mainMenuOpen = true;
+      mainMenuButton.setAttribute('aria-expanded', 'true');
+      try {
+        await window.browserAPI.openMainMenu({ x: rect.left, y: rect.bottom });
+      } finally {
+        mainMenuOpen = false;
+        mainMenuButton.setAttribute('aria-expanded', 'false');
+      }
+    });
+
     const mk = (icon, title, onClick, extraClass) => {
       const b = document.createElement('button');
       b.innerHTML = icon;

--- a/test/unit/platform-main-menu.test.js
+++ b/test/unit/platform-main-menu.test.js
@@ -1,0 +1,104 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  popupPlatformMainMenu,
+  popupPoint,
+  supportsPlatformMainMenu,
+} = require('../../src/main/platform-main-menu');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+test('the custom main-menu affordance is limited to Windows and Linux', () => {
+  assert.equal(supportsPlatformMainMenu('win32'), true);
+  assert.equal(supportsPlatformMainMenu('linux'), true);
+  assert.equal(supportsPlatformMainMenu('darwin'), false);
+});
+
+test('popup coordinates are integer content coordinates clamped to the window', () => {
+  assert.deepEqual(
+    popupPoint({ x: 1250.6, y: 38.2 }, { width: 1280, height: 800 }),
+    { x: 1251, y: 38 }
+  );
+  assert.deepEqual(
+    popupPoint({ x: -20, y: Number.NaN }, { width: 1280, height: 800 }),
+    { x: 0, y: 0 }
+  );
+  assert.deepEqual(
+    popupPoint({ x: 9000, y: 9000 }, { width: 1280, height: 800 }),
+    { x: 1279, y: 799 }
+  );
+});
+
+test('the platform button pops up the existing live application menu', async () => {
+  let popupOptions = null;
+  const applicationMenu = {
+    items: [{ label: 'File' }],
+    popup(options) {
+      popupOptions = options;
+      options.callback();
+    },
+  };
+  const Menu = { getApplicationMenu: () => applicationMenu };
+  const window = {
+    isDestroyed: () => false,
+    getContentBounds: () => ({ width: 640, height: 480 }),
+  };
+
+  assert.equal(
+    await popupPlatformMainMenu({
+      Menu,
+      window,
+      point: { x: 610, y: 38 },
+      platform: 'win32',
+    }),
+    true
+  );
+  assert.equal(popupOptions.window, window);
+  assert.equal(popupOptions.x, 610);
+  assert.equal(popupOptions.y, 38);
+  assert.equal(typeof popupOptions.callback, 'function');
+});
+
+test('macOS and missing window/menu state never open a popup', async () => {
+  let popupCalls = 0;
+  const menu = { items: [{ label: 'File' }], popup: () => { popupCalls += 1; } };
+  const Menu = { getApplicationMenu: () => menu };
+  const window = {
+    isDestroyed: () => false,
+    getContentBounds: () => ({ width: 640, height: 480 }),
+  };
+
+  assert.equal(await popupPlatformMainMenu({ Menu, window, platform: 'darwin' }), false);
+  assert.equal(await popupPlatformMainMenu({ Menu, window: null, platform: 'linux' }), false);
+  assert.equal(
+    await popupPlatformMainMenu({
+      Menu: { getApplicationMenu: () => null },
+      window,
+      platform: 'linux',
+    }),
+    false
+  );
+  assert.equal(popupCalls, 0);
+});
+
+test('chrome markup and IPC keep one native menu definition', () => {
+  const html = fs.readFileSync(path.join(ROOT, 'src/renderer/index.html'), 'utf8');
+  const renderer = fs.readFileSync(path.join(ROOT, 'src/renderer/renderer.js'), 'utf8');
+  const preload = fs.readFileSync(path.join(ROOT, 'src/main/preload.js'), 'utf8');
+  const main = fs.readFileSync(path.join(ROOT, 'src/main/main.js'), 'utf8');
+
+  assert.match(html, /id="mainMenuButton"[\s\S]*aria-haspopup="menu"[\s\S]*hidden/);
+  assert.match(renderer, /if \(!isMac\) \{[\s\S]*mainMenuButton\.hidden = false/);
+  assert.match(renderer, /getBoundingClientRect\(\)/);
+  assert.match(renderer, /window\.browserAPI\.openMainMenu/);
+  assert.match(preload, /ipcRenderer\.invoke\('chrome:open-main-menu', point\)/);
+  assert.match(main, /event\.sender !== win\?\.webContents/);
+  assert.match(main, /popupPlatformMainMenu\(\{ Menu, window: win, point \}\)/);
+  assert.match(
+    fs.readFileSync(path.join(ROOT, 'src/main/platform-main-menu.js'), 'utf8'),
+    /Menu\.getApplicationMenu\(\)/
+  );
+});


### PR DESCRIPTION
## What changed

- adds a visible three-dot main-menu button immediately before the custom window controls on Windows and Linux
- opens the existing live Electron application menu instead of duplicating File, Edit, View, Tabs, Favorites, and Help actions
- keeps macOS unchanged, where the system menu bar remains available
- guards the IPC entry point so only the trusted strip renderer can open the menu
- adds unit coverage for supported platforms, popup positioning, live-menu reuse, and end-to-end wiring

## Why

Blanc uses a frameless window on Windows and Linux, so its native application menu existed but had no visible entry point. This made manual update checks, Duplicate Tab, and Add All Open Tabs to Favorites inaccessible or undiscoverable.

## Validation

- `npm run test:unit` — 295 passed
- `npm run test:acceptance:desktop` — 55 scenarios / 364 steps passed
- `git diff --check`