### PR TITLE
Move Windows and Linux main menu to upper-left

### DIFF
--- a/src/main/about-panel.js
+++ b/src/main/about-panel.js
@@ -1,0 +1,30 @@
+const path = require('node:path');
+
+const ABOUT_APPLICATION_NAME = 'Blanc';
+const ABOUT_WEBSITE = 'https://blancbrowser.com';
+const ABOUT_COPYRIGHT = '© 2026 Bananify';
+
+function aboutPanelOptions({ app, iconPath } = {}) {
+  return {
+    applicationName: ABOUT_APPLICATION_NAME,
+    applicationVersion: app.getVersion(),
+    copyright: ABOUT_COPYRIGHT,
+    credits: 'Independent browser by Bananify.',
+    authors: ['Bananify'],
+    website: ABOUT_WEBSITE,
+    iconPath: iconPath ?? path.join(__dirname, '../renderer/pages/icon-paper.png'),
+  };
+}
+
+function showAboutPanel({ app, iconPath } = {}) {
+  app.setAboutPanelOptions(aboutPanelOptions({ app, iconPath }));
+  app.showAboutPanel();
+}
+
+module.exports = {
+  ABOUT_APPLICATION_NAME,
+  ABOUT_COPYRIGHT,
+  ABOUT_WEBSITE,
+  aboutPanelOptions,
+  showAboutPanel,
+};

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -53,6 +53,7 @@ const {
   installPlatformMainMenuShortcut,
   popupPlatformMainMenu,
 } = require('./platform-main-menu');
+const { showAboutPanel } = require('./about-panel');
 
 const NEW_TAB_URL = 'blanc://newtab/';
 const newTabUrl = () => settings.getSettings().homePage || NEW_TAB_URL;
@@ -2677,6 +2678,10 @@ function buildMenu() {
             { label: 'Show All Shortcuts…', accelerator: 'CmdOrCtrl+/', click: () => openInternalPage('blanc://shortcuts/') },
           ],
         },
+        ...(isMac ? [] : [
+          { type: 'separator' },
+          { label: 'About Blanc', click: () => showAboutPanel({ app }) },
+        ]),
       ],
     },
   ];

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -49,7 +49,10 @@ const {
   calculateChromeLayout,
 } = require('./chrome-layout');
 const { reorderWithinBucket } = require('./tab-order');
-const { popupPlatformMainMenu } = require('./platform-main-menu');
+const {
+  installPlatformMainMenuShortcut,
+  popupPlatformMainMenu,
+} = require('./platform-main-menu');
 
 const NEW_TAB_URL = 'blanc://newtab/';
 const newTabUrl = () => settings.getSettings().homePage || NEW_TAB_URL;
@@ -668,7 +671,7 @@ function createOverlay() {
   });
   overlayView.setBackgroundColor('#00000000'); // page shows through around the panel
   lockPrivilegedNavigation(overlayView.webContents, CHROME_OVERLAY_URL);
-  installVerticalTabsShortcut(overlayView.webContents);
+  installChromeShortcuts(overlayView.webContents);
   overlayView.webContents.loadFile(CHROME_OVERLAY_FILE);
 
   // A show requested before the overlay document finished its first load
@@ -793,7 +796,7 @@ function createUtilitySheet() {
   utilitySheetView = new WebContentsView({ webPreferences: TAB_WEB_PREFERENCES });
   utilitySheetView.setBackgroundColor('#00000000');
   const wc = utilitySheetView.webContents;
-  installVerticalTabsShortcut(wc);
+  installChromeShortcuts(wc);
   // Esc dismisses no matter what inside the page holds focus (mirrors the
   // island overlay's handler).
   wc.on('before-input-event', (event, input) => {
@@ -1110,6 +1113,15 @@ function installVerticalTabsShortcut(webContents) {
     // duplicate native-menu accelerator dispatch for this same key event.
     event.preventDefault();
     toggleTabLayout();
+  });
+}
+
+function installChromeShortcuts(webContents) {
+  installVerticalTabsShortcut(webContents);
+  installPlatformMainMenuShortcut({
+    webContents,
+    Menu,
+    getWindow: () => win,
   });
 }
 
@@ -1440,7 +1452,7 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
   tabOrder.push(id);
 
   const wc = view.webContents;
-  installVerticalTabsShortcut(wc);
+  installChromeShortcuts(wc);
   // WebRTC IP-handling policy applies per-webContents; this is the single choke
   // point every tab (fresh or adopted window.open child) passes through.
   wc.setWebRTCIPHandlingPolicy(webrtcPolicyFor(settings.getSettings().webrtcPolicy));
@@ -2689,7 +2701,7 @@ function createMainWindow() {
   });
 
   lockPrivilegedNavigation(win.webContents, CHROME_INDEX_URL);
-  installVerticalTabsShortcut(win.webContents);
+  installChromeShortcuts(win.webContents);
   win.loadFile(CHROME_INDEX_FILE);
   createOverlay();
   win.on('resize', resizeActiveView);

--- a/src/main/platform-main-menu.js
+++ b/src/main/platform-main-menu.js
@@ -14,6 +14,17 @@ function popupPoint(point, contentBounds) {
   };
 }
 
+function isPlatformMainMenuShortcut(input, platform = process.platform) {
+  return supportsPlatformMainMenu(platform) &&
+    input?.type === 'keyDown' &&
+    !input.isAutoRepeat &&
+    String(input.key).toLowerCase() === 'f' &&
+    input.alt &&
+    !input.control &&
+    !input.meta &&
+    !input.shift;
+}
+
 /**
  * Open the live application Menu as a context menu beside the custom chrome.
  * This deliberately reuses Menu.getApplicationMenu(): File/Edit/View/Tabs/
@@ -42,7 +53,24 @@ function popupPlatformMainMenu({ Menu, window, point, platform = process.platfor
   });
 }
 
+function installPlatformMainMenuShortcut({
+  webContents,
+  Menu,
+  getWindow,
+  point = { x: 8, y: 38 },
+  platform = process.platform,
+}) {
+  if (!supportsPlatformMainMenu(platform)) return;
+  webContents.on('before-input-event', (event, input) => {
+    if (!isPlatformMainMenuShortcut(input, platform)) return;
+    event.preventDefault();
+    popupPlatformMainMenu({ Menu, window: getWindow(), point, platform }).catch(() => {});
+  });
+}
+
 module.exports = {
+  installPlatformMainMenuShortcut,
+  isPlatformMainMenuShortcut,
   popupPlatformMainMenu,
   popupPoint,
   supportsPlatformMainMenu,

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -9,6 +9,20 @@
 <body>
   <div id="chrome">
     <div id="strip">
+      <button
+        id="mainMenuButton"
+        class="no-drag"
+        type="button"
+        title="Main menu (Alt+F)"
+        aria-label="Main menu"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        hidden
+      >
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M3 4.5h10M3 8h10M3 11.5h10"/>
+        </svg>
+      </button>
       <div id="islandPill" class="no-drag" role="button" tabindex="0" title="Search, tabs & commands (Ctrl/Cmd+L)">
         <div id="pillNav" class="pill-btns"></div>
         <div id="pillDots"></div>
@@ -33,19 +47,7 @@
         <button id="permAllowBtn">Allow</button>
         <button id="permBlockBtn">Block</button>
       </div>
-      <div id="windowControls" class="no-drag">
-        <button
-          id="mainMenuButton"
-          type="button"
-          title="Main menu"
-          aria-label="Main menu"
-          aria-haspopup="menu"
-          aria-expanded="false"
-          hidden
-        >
-          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 3.25h.01M8 8h.01M8 12.75h.01"/></svg>
-        </button>
-      </div>
+      <div id="windowControls" class="no-drag"></div>
     </div>
   </div>
   <aside id="verticalTabsRail" class="vertical-tabs-rail no-drag" aria-label="Vertical tabs" hidden>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -157,6 +157,12 @@ button svg {
   background: rgba(255, 255, 255, 0.14);
   color: #f5f5f5;
 }
+#strip.tint-dark #mainMenuButton { color: rgba(245, 245, 245, 0.75); }
+#strip.tint-dark #mainMenuButton:hover,
+#strip.tint-dark #mainMenuButton[aria-expanded="true"] {
+  background: rgba(255, 255, 255, 0.14);
+  color: #f5f5f5;
+}
 
 /* ---------- Vertical tabs: optional trusted-chrome rail ----------
    The rail starts below the strip and reserves space only from page-scoped
@@ -1455,7 +1461,27 @@ body[data-mode="palette"] #panelAnchor { top: 120px; }
   padding: 8px 10px 2px;
 }
 
-/* ---------- Window controls (non-mac; macOS gets native traffic lights) ---------- */
+/* ---------- Platform menu + window controls (non-mac) ---------- */
+
+#mainMenuButton {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 34px;
+  height: 30px;
+  border-radius: var(--radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-dim);
+}
+#mainMenuButton[hidden] { display: none; }
+#mainMenuButton svg { width: 16px; height: 16px; }
+#mainMenuButton:hover,
+#mainMenuButton[aria-expanded="true"] {
+  background: var(--accent-dim);
+  color: var(--text);
+}
 
 #windowControls {
   position: absolute;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -159,6 +159,7 @@ button svg {
 }
 #strip.tint-dark #mainMenuButton { color: rgba(245, 245, 245, 0.75); }
 #strip.tint-dark #mainMenuButton:hover,
+#strip.tint-dark #mainMenuButton:focus-visible,
 #strip.tint-dark #mainMenuButton[aria-expanded="true"] {
   background: rgba(255, 255, 255, 0.14);
   color: #f5f5f5;
@@ -1478,10 +1479,12 @@ body[data-mode="palette"] #panelAnchor { top: 120px; }
 #mainMenuButton[hidden] { display: none; }
 #mainMenuButton svg { width: 16px; height: 16px; }
 #mainMenuButton:hover,
+#mainMenuButton:focus-visible,
 #mainMenuButton[aria-expanded="true"] {
   background: var(--accent-dim);
   color: var(--text);
 }
+#mainMenuButton:focus-visible { outline: none; }
 
 #windowControls {
   position: absolute;

--- a/test/unit/about-panel.test.js
+++ b/test/unit/about-panel.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  ABOUT_APPLICATION_NAME,
+  ABOUT_COPYRIGHT,
+  ABOUT_WEBSITE,
+  aboutPanelOptions,
+  showAboutPanel,
+} = require('../../src/main/about-panel');
+
+test('about panel metadata comes from the running Blanc build', () => {
+  const options = aboutPanelOptions({ app: { getVersion: () => '1.0.2-dev.3' } });
+
+  assert.deepEqual(options, {
+    applicationName: ABOUT_APPLICATION_NAME,
+    applicationVersion: '1.0.2-dev.3',
+    copyright: ABOUT_COPYRIGHT,
+    credits: 'Independent browser by Bananify.',
+    authors: ['Bananify'],
+    website: ABOUT_WEBSITE,
+    iconPath: path.join(__dirname, '../../src/renderer/pages/icon-paper.png'),
+  });
+});
+
+test('showAboutPanel configures metadata before opening the native dialog', () => {
+  const calls = [];
+  const app = {
+    getVersion: () => '1.0.2',
+    setAboutPanelOptions: (options) => calls.push(['options', options]),
+    showAboutPanel: () => calls.push(['show']),
+  };
+
+  showAboutPanel({ app, iconPath: '/tmp/blanc-about.png' });
+
+  assert.equal(calls[0][0], 'options');
+  assert.equal(calls[0][1].applicationVersion, '1.0.2');
+  assert.equal(calls[0][1].iconPath, '/tmp/blanc-about.png');
+  assert.deepEqual(calls[1], ['show']);
+});

--- a/test/unit/platform-main-menu.test.js
+++ b/test/unit/platform-main-menu.test.js
@@ -4,6 +4,8 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const {
+  installPlatformMainMenuShortcut,
+  isPlatformMainMenuShortcut,
   popupPlatformMainMenu,
   popupPoint,
   supportsPlatformMainMenu,
@@ -15,6 +17,90 @@ test('the custom main-menu affordance is limited to Windows and Linux', () => {
   assert.equal(supportsPlatformMainMenu('win32'), true);
   assert.equal(supportsPlatformMainMenu('linux'), true);
   assert.equal(supportsPlatformMainMenu('darwin'), false);
+});
+
+test('Alt+F is the platform main-menu shortcut on Windows and Linux', () => {
+  const input = {
+    type: 'keyDown',
+    key: 'f',
+    alt: true,
+    control: false,
+    meta: false,
+    shift: false,
+    isAutoRepeat: false,
+  };
+
+  assert.equal(isPlatformMainMenuShortcut(input, 'win32'), true);
+  assert.equal(isPlatformMainMenuShortcut({ ...input, key: 'F' }, 'linux'), true);
+  assert.equal(isPlatformMainMenuShortcut(input, 'darwin'), false);
+  assert.equal(isPlatformMainMenuShortcut({ ...input, type: 'keyUp' }, 'win32'), false);
+  assert.equal(isPlatformMainMenuShortcut({ ...input, isAutoRepeat: true }, 'win32'), false);
+  assert.equal(isPlatformMainMenuShortcut({ ...input, alt: false }, 'win32'), false);
+  assert.equal(isPlatformMainMenuShortcut({ ...input, control: true }, 'win32'), false);
+  assert.equal(isPlatformMainMenuShortcut({ ...input, meta: true }, 'win32'), false);
+  assert.equal(isPlatformMainMenuShortcut({ ...input, shift: true }, 'win32'), false);
+  assert.equal(isPlatformMainMenuShortcut({ ...input, key: 'm' }, 'win32'), false);
+});
+
+test('the shortcut opens the menu below the upper-left button', async () => {
+  let beforeInput = null;
+  let popupOptions = null;
+  let prevented = false;
+  const webContents = {
+    on(eventName, listener) {
+      assert.equal(eventName, 'before-input-event');
+      beforeInput = listener;
+    },
+  };
+  const window = {
+    isDestroyed: () => false,
+    getContentBounds: () => ({ width: 640, height: 480 }),
+  };
+  const Menu = {
+    getApplicationMenu: () => ({
+      items: [{ label: 'File' }],
+      popup(options) {
+        popupOptions = options;
+        options.callback();
+      },
+    }),
+  };
+
+  installPlatformMainMenuShortcut({
+    webContents,
+    Menu,
+    getWindow: () => window,
+    platform: 'win32',
+  });
+  assert.equal(typeof beforeInput, 'function');
+
+  beforeInput(
+    { preventDefault: () => { prevented = true; } },
+    {
+      type: 'keyDown',
+      key: 'f',
+      alt: true,
+      control: false,
+      meta: false,
+      shift: false,
+      isAutoRepeat: false,
+    }
+  );
+  await Promise.resolve();
+
+  assert.equal(prevented, true);
+  assert.equal(popupOptions.window, window);
+  assert.equal(popupOptions.x, 8);
+  assert.equal(popupOptions.y, 38);
+
+  let registeredOnMac = false;
+  installPlatformMainMenuShortcut({
+    webContents: { on: () => { registeredOnMac = true; } },
+    Menu,
+    getWindow: () => window,
+    platform: 'darwin',
+  });
+  assert.equal(registeredOnMac, false);
 });
 
 test('popup coordinates are integer content coordinates clamped to the window', () => {
@@ -89,14 +175,22 @@ test('chrome markup and IPC keep one native menu definition', () => {
   const renderer = fs.readFileSync(path.join(ROOT, 'src/renderer/renderer.js'), 'utf8');
   const preload = fs.readFileSync(path.join(ROOT, 'src/main/preload.js'), 'utf8');
   const main = fs.readFileSync(path.join(ROOT, 'src/main/main.js'), 'utf8');
+  const styles = fs.readFileSync(path.join(ROOT, 'src/renderer/styles.css'), 'utf8');
 
-  assert.match(html, /id="mainMenuButton"[\s\S]*aria-haspopup="menu"[\s\S]*hidden/);
+  assert.match(html, /<div id="strip">\s*<button\s+id="mainMenuButton"[\s\S]*aria-haspopup="menu"[\s\S]*hidden/);
+  assert.match(html, /<path d="M3 4\.5h10M3 8h10M3 11\.5h10"\/?>/);
+  assert.doesNotMatch(html, /<circle cx="8"/);
+  assert.match(html, /<div id="windowControls" class="no-drag"><\/div>/);
+  assert.match(styles, /#mainMenuButton \{[\s\S]*position: absolute;[\s\S]*top: 8px;[\s\S]*left: 8px;[\s\S]*width: 34px;[\s\S]*height: 30px/);
+  assert.match(styles, /#mainMenuButton:hover,[\s\S]*background: var\(--accent-dim\)/);
   assert.match(renderer, /if \(!isMac\) \{[\s\S]*mainMenuButton\.hidden = false/);
   assert.match(renderer, /getBoundingClientRect\(\)/);
   assert.match(renderer, /window\.browserAPI\.openMainMenu/);
   assert.match(preload, /ipcRenderer\.invoke\('chrome:open-main-menu', point\)/);
   assert.match(main, /event\.sender !== win\?\.webContents/);
   assert.match(main, /popupPlatformMainMenu\(\{ Menu, window: win, point \}\)/);
+  assert.match(main, /function installChromeShortcuts\(webContents\) \{[\s\S]*installVerticalTabsShortcut\(webContents\);[\s\S]*installPlatformMainMenuShortcut/);
+  assert.equal((main.match(/installChromeShortcuts\([^)]*webContents\)/g) ?? []).length >= 2, true);
   assert.match(
     fs.readFileSync(path.join(ROOT, 'src/main/platform-main-menu.js'), 'utf8'),
     /Menu\.getApplicationMenu\(\)/

--- a/test/unit/platform-main-menu.test.js
+++ b/test/unit/platform-main-menu.test.js
@@ -182,7 +182,8 @@ test('chrome markup and IPC keep one native menu definition', () => {
   assert.doesNotMatch(html, /<circle cx="8"/);
   assert.match(html, /<div id="windowControls" class="no-drag"><\/div>/);
   assert.match(styles, /#mainMenuButton \{[\s\S]*position: absolute;[\s\S]*top: 8px;[\s\S]*left: 8px;[\s\S]*width: 34px;[\s\S]*height: 30px/);
-  assert.match(styles, /#mainMenuButton:hover,[\s\S]*background: var\(--accent-dim\)/);
+  assert.match(styles, /#mainMenuButton:hover,[\s\S]*#mainMenuButton:focus-visible,[\s\S]*background: var\(--accent-dim\)/);
+  assert.match(styles, /#mainMenuButton:focus-visible \{ outline: none; \}/);
   assert.match(renderer, /if \(!isMac\) \{[\s\S]*mainMenuButton\.hidden = false/);
   assert.match(renderer, /getBoundingClientRect\(\)/);
   assert.match(renderer, /window\.browserAPI\.openMainMenu/);

--- a/test/unit/platform-main-menu.test.js
+++ b/test/unit/platform-main-menu.test.js
@@ -189,6 +189,7 @@ test('chrome markup and IPC keep one native menu definition', () => {
   assert.match(preload, /ipcRenderer\.invoke\('chrome:open-main-menu', point\)/);
   assert.match(main, /event\.sender !== win\?\.webContents/);
   assert.match(main, /popupPlatformMainMenu\(\{ Menu, window: win, point \}\)/);
+  assert.match(main, /label: 'Help'[\s\S]*isMac \? \[\] : \[[\s\S]*label: 'About Blanc'[\s\S]*showAboutPanel\(\{ app \}\)/);
   assert.match(main, /function installChromeShortcuts\(webContents\) \{[\s\S]*installVerticalTabsShortcut\(webContents\);[\s\S]*installPlatformMainMenuShortcut/);
   assert.equal((main.match(/installChromeShortcuts\([^)]*webContents\)/g) ?? []).length >= 2, true);
   assert.match(


### PR DESCRIPTION
## Summary
- move the non-macOS main-menu affordance from the Windows caption controls to a quiet upper-left hamburger
- retain the existing live Electron application menu as the single action definition
- add `Alt+F` access across chrome, overlay, utility sheets, and tab surfaces
- add **Help → About Blanc** on Windows/Linux, backed by the native About panel and the running app version
- replace the heavy focus outline with the same subtle rounded backplate used for hover/open

## Validation
- `npm run test:unit` — 299 tests passed
- `npm run test:acceptance:desktop` — 55 scenarios / 364 steps passed
- `npm run substrate:check` — passed
- Windows `1.0.2-dev.3` build and focused Windows regression checks — passed

The placement and visual treatment match the user-approved mockup. The unsigned `1.0.2-dev.3` Windows installer is available for final Parallels testing before release.