### PR TITLE
Release Blanc 1.0.3

### DIFF
--- a/docs/press/release-notes/v1.0.3.md
+++ b/docs/press/release-notes/v1.0.3.md
@@ -1,0 +1,19 @@
+# Blanc 1.0.3
+
+Blanc 1.0.3 ships digitally signed Windows builds. There are no application
+changes in this release.
+
+## Signed Windows installer
+
+- The Windows installer and application binaries are now code signed by
+  Bananify Creative through Azure Trusted Signing.
+- New installs no longer trigger the Windows SmartScreen "unknown publisher"
+  warning, and Microsoft Defender false positives on the unsigned installer
+  are resolved.
+- Windows auto-update continues to work from earlier versions; updating from
+  an unsigned install to 1.0.3 is seamless.
+
+## Release integrity
+
+The macOS, Windows, and Linux applications are built from the same `v1.0.3`
+source tag and published with one SHA-256 manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",


### PR DESCRIPTION
Bumps the version to 1.0.3 and adds the release notes. First Windows release signed via Azure Trusted Signing (publisher: Bananify Creative) — the Azure certificate profile `blanc-profile` went Active today and all four repo variables are set, so the windows job takes the Azure signing branch. No application changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)