### PR TITLE
Point the press page at Blanc 1.0.3

### DIFF
--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -4,7 +4,7 @@ import BrandMark from '../components/BrandMark.astro';
 import PressIslandDemo from '../components/PressIslandDemo.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 
-const VERSION = '1.0.2';
+const VERSION = '1.0.3';
 const TAG = `v${VERSION}`;
 const RELEASE_BASE = 'https://github.com/bnfy/blanc/releases';
 const RELEASE_URL = `${RELEASE_BASE}/tag/${TAG}`;

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.0.2');
+  assert.equal(packageVersion, '1.0.3');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
Follow-up to #62: updates the press page VERSION constant and the press-kit guard pin to 1.0.3. The release pipeline's verify gate caught the mismatch and aborted before tagging, as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)