### PR TITLE
Bump undici to 7.29.0 to clear audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5077,9 +5077,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "optional": true,
       "engines": {


### PR DESCRIPTION
Second follow-up for the 1.0.3 release: the pipeline's release:security gate (npm audit, fail-closed on high) flagged undici 7.28.0. Lockfile-only bump to 7.29.0; npm audit --omit=dev --audit-level=high is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)