### PR TITLE
Switch site analytics to GA4 Consent Mode

### DIFF
--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -16,7 +16,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <p class="legal-updated">Last updated: July 23, 2026</p>
 
   <div class="legal-tldr">
-    <p><strong>The short version.</strong> Blanc keeps your browsing history, downloads, favorites, and settings on your device unless you enable end-to-end-encrypted Profile Sync for eligible data. A fresh install asks before search suggestions or the pseudonymous launch ping can send anything. Like any browser, Blanc still connects to sites you visit and makes clearly described service requests for blocking lists, updates, enabled suggestions, optional sync, and supporter activation. This website uses analytics only if you allow it.</p>
+    <p><strong>The short version.</strong> Blanc keeps your browsing history, downloads, favorites, and settings on your device unless you enable end-to-end-encrypted Profile Sync for eligible data. A fresh install asks before search suggestions or the pseudonymous launch ping can send anything. Like any browser, Blanc still connects to sites you visit and makes clearly described service requests for blocking lists, updates, enabled suggestions, optional sync, and supporter activation. This website runs analytics in a restricted, cookieless mode by default; full measurement activates only if you allow it.</p>
   </div>
 
   <h2>Who this covers</h2>
@@ -85,7 +85,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <h2>This website (blancbrowser.com)</h2>
   <p>The marketing site is intentionally light:</p>
   <ul>
-    <li><strong>Analytics is opt-in.</strong> Nothing analytics-related loads until you click "Allow" on the banner. If you allow it, we use Google Analytics to gauge interest, and your choice is remembered in your browser so we don't ask again. If you decline, no analytics runs.</li>
+    <li><strong>Analytics consent.</strong> Non-legal pages load a Google Analytics script in a restricted mode — no cookies are set and no persistent identifiers are stored. If you click "Allow" on the banner, GA switches to full measurement with a cookie, and your choice is remembered in your browser so we don't ask again. If you decline or ignore the banner, GA stays restricted — cookieless pings let Google estimate overall traffic, but nothing identifies you across visits.</li>
     <li><strong>Fonts</strong> are bundled with the site and served from our own host — no third-party font service is contacted.</li>
     <li><strong>Download buttons</strong> ask GitHub's API for the latest release so they point to the right installer; the installers themselves are hosted and served by GitHub.</li>
     <li><strong>Hosting</strong> is on Cloudflare Pages, which keeps standard server logs (such as IP addresses) to serve and protect the site.</li>

--- a/site/src/scripts/site.js
+++ b/site/src/scripts/site.js
@@ -70,28 +70,24 @@
     .catch(() => { /* Releases page remains the deliberate fallback. */ });
 })();
 
-// Nothing Google-related loads until the visitor opts in. Tracking hooks are
-// harmless before consent because no gtag function exists until GA is loaded.
+// GA4 Consent Mode: gtag loads with analytics_storage denied by default.
+// Cookieless pings give GA4 modelling signal; full measurement requires opt-in.
 try {
   const GA_ID = 'G-MN8BLY6GE9';
-  let loaded = false;
-  const loadGA = () => {
-    if (loaded) return;
-    loaded = true;
-    const script = document.createElement('script');
-    script.async = true;
-    script.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_ID;
-    document.head.appendChild(script);
-    window.dataLayer = window.dataLayer || [];
-    window.gtag = function () { window.dataLayer.push(arguments); };
-    window.gtag('js', new Date());
-    window.gtag('config', GA_ID);
-  };
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = function () { window.dataLayer.push(arguments); };
+  window.gtag('consent', 'default', { analytics_storage: 'denied' });
+  window.gtag('js', new Date());
+  window.gtag('config', GA_ID);
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_ID;
+  document.head.appendChild(script);
 
   const banner = document.getElementById('consent');
   const consent = localStorage.getItem('ga-consent');
   if (consent === 'granted') {
-    loadGA();
+    window.gtag('consent', 'update', { analytics_storage: 'granted' });
   } else if (consent !== 'denied' && banner) {
     banner.hidden = false;
     document.body.classList.add('has-consent');
@@ -102,7 +98,7 @@ try {
     };
     document.getElementById('consentAllow').addEventListener('click', () => {
       dismiss('granted');
-      loadGA();
+      window.gtag('consent', 'update', { analytics_storage: 'granted' });
     });
     document.getElementById('consentDeny').addEventListener('click', () => dismiss('denied'));
   }


### PR DESCRIPTION
Load gtag with analytics_storage denied by default so GA4 receives
cookieless pings for traffic modelling without setting any cookies or
persistent identifiers. Full measurement activates only after the
visitor clicks Allow. Update privacy page to describe the new behaviour.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LqB2QVVmj7b3xWWDcUYr6J