### PR TITLE
Built-in 1Password credential fill (SPIKE, dev-gated)

### DIFF
--- a/docs/1password-dev-usage.md
+++ b/docs/1password-dev-usage.md
@@ -1,0 +1,68 @@
+# Using 1Password fill in the local dev build
+
+How to run Blanc's built-in 1Password fill on this branch (`feature/1password-fill`). This is the spike implementation — dev/personal use only; see [`1password-legal-inquiry.md`](1password-legal-inquiry.md) before anything ships.
+
+In a dev build the fill is **on by default** (`ONE_PASSWORD_SPIKE_ENABLED = !app.isPackaged || BLANC_1P_SPIKE === '1'`), so no flag is needed — the one required input is your 1Password **account identifier** via `BLANC_1P_ACCOUNT`.
+
+## 1. Be on this branch
+
+```bash
+git checkout feature/1password-fill
+npm install          # only if `npm start` later reports a missing @1password/sdk
+```
+(The code isn't on `main` — it was torn down there; it lives here.)
+
+## 2. One-time 1Password app setup
+
+- 1Password 8 desktop app installed in `/Applications`, signed in, and **unlocked**.
+- **Settings → Developer** → enable the SDK / "Integrate with other apps" toggle (label varies by app version — it's the Developer setting that lets external apps connect through the SDK). `DesktopAuth` can't connect without it.
+- **Settings → Security → Touch ID** enabled (for the approval prompt).
+
+## 3. Find your account identifier
+
+`DesktopAuth` accepts your account name (top-left of the 1Password app), your sign-in email/address, or your account UUID. To list them:
+
+```bash
+op account list        # shows URL / EMAIL / USER ID for each configured account
+```
+
+Use whichever value worked previously, or start with the email.
+
+## 4. Run
+
+```bash
+BLANC_1P_ACCOUNT="you@example.com" npm start
+```
+
+Optional — export it so plain `npm start` works (it's an identifier, not a secret, but keep it out of git):
+
+```bash
+echo 'export BLANC_1P_ACCOUNT="you@example.com"' >> ~/.zshrc
+```
+
+## 5. Use it
+
+1. Open a **login page** (http/https) that has a matching Login item in your vault.
+2. Press **⌥⌘P** (Option-Command-P).
+3. First trigger per ~10-minute SDK session: approve the 1Password prompt (Touch ID or password).
+   **In dev the prompt names "Electron," not "Blanc"** — expected, because the dev binary is unsigned. A signed build names Blanc.
+4. Username + password fill; the terminal logs `[1p-spike] filled user+pass`.
+
+## Troubleshooting — read the `[1p-spike]` line in the terminal
+
+| Log line | Meaning / fix |
+|---|---|
+| *(nothing at all after ⌥⌘P)* | You're on a blank new tab — focus is in the address bar, which has no chord listener. Navigate to a real page first. |
+| `no-match <host>` | No Login item whose website host matches. Add/fix the item's website in 1Password (exact host; leading `www.` is fine). |
+| `non-http-noop` | Active tab isn't http/https (internal page, `file://`, blank tab). Go to the login page. |
+| `chooser-cancel` | You dismissed the multi-match chooser. |
+| `setup-error BLANC_1P_ACCOUNT is not set` | Env var missing — pass it or export it. |
+| `fill-error` / an SDK or auth error | 1Password app not running/unlocked, or the Developer "integrate" toggle is off. |
+| `abort-navigated` / `abort-url-changed` / `abort-tab-changed` / `abort-window-changed` | The page navigated, or you switched tab/window, during approval — the fill aborts for safety. Retry. |
+| `origin-or-focus-mismatch` | The page changed or lost focus between trigger and injection. Retry. |
+
+## Notes & limits (this is the spike, not the shippable engine)
+
+- **Chrome/overlay changes need a relaunch, not ⌘R** — but the fill logic is main-process, so a normal `npm start` picks up any code change.
+- Matching is **exact-host only** (no subdomains/redirects/1Password per-item rules), field detection is **first visible password field**, injection is **main-world**, and there's **no save/TOTP/iframe** support. These are the known shortcuts (spec Non-goals) that the real engine addresses.
+- Credentials are handled **main-process only** — never persisted, logged, synced, or transmitted; only the selected item is decrypted.

--- a/docs/1password-legal-inquiry.md
+++ b/docs/1password-legal-inquiry.md
@@ -1,0 +1,120 @@
+# 1Password SDK — terms/compliance inquiry
+
+**Purpose:** Blanc's built-in 1Password fill (branch `feature/1password-fill`) is technically proven feasible (see `docs/superpowers/specs/2026-07-12-1password-autofill-spike-design.md` → Findings). Before building the *shippable* engine, one clause in 1Password's [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service) — **§4.1(e)**, the competitive/replication restriction — needs written confirmation from 1Password. This file holds the inquiry and (later) their reply, so the answer lives beside the code that depends on it.
+
+**Status:** ☑ drafted · ☑ sent (2026-07-12) · ☑ reply received (2026-07-17) · ☑ **resolved — but not answered**
+
+> **Outcome: 1Password does not pre-approve compliance, as a matter of policy** (reply below). They did **not** say the use is prohibited, and did not assert §4.1(e) applies — they declined to rule either way and pointed to our own counsel. **The original gate ("get written confirmation before building the shippable engine") is therefore unachievable and is retired.** See *Revised gate* below.
+>
+> **Personal/dev use is unaffected and was never in question** — a user running a local integration against their own vault is the documented intended use of desktop-app integrations. The current dev build on this branch is fine to keep using. The open question was only ever **distribution to end users**.
+
+---
+
+## Research summary (2026-07-12, two independent passes converged)
+
+Apparently **permitted by the published terms; no partner program or vendor allowlist required** — `DesktopAuth` is user-authorized with no code-signature gate (the barrier that blocked the old native-messaging path). Supporting points:
+
+- **Code license is MIT** (`@1password/sdk` + native `@1password/sdk-core`).
+- The **API/SDK Terms grant** "incorporate and distribute the SDK… as part of an Application, on an integrated (not standalone) basis."
+- The [desktop-integration security model](https://developer.1password.com/docs/sdks/desktop-app-integrations/) explicitly anticipates third-party binaries it can't code-verify, leaving the trust decision to the user.
+- Autofill is a **documented SDK use case** ([SDK concepts](https://www.1password.dev/sdks/concepts/) defines website-matching rules + credential field IDs) — *supporting evidence, not explicit permission for a third-party browser implementation*.
+
+**Open clause — §4.1(e):** no product that "competes directly or indirectly with 1Password… or replicates a substantial portion of the functionality of the Services." Blanc reads as complementary (requires 1Password installed + subscribed; no vault/sync of its own), but "indirectly" is broad enough to warrant written confirmation.
+
+**Caveat:** the above is an AI-assisted reading of a legal document, not legal advice. A human (ideally counsel) should read the actual §4.1(e) text before a shipping commitment.
+
+**Accurate note on the auth model:** `DesktopAuth` grants the approved process temporary access to the *whole authorized account* (expiring per 1Password's session rules; approval via Touch ID, account password, or another configured method). Blanc's v1 read-only behavior is a function of it calling only list/read operations — **not** a scope limit imposed by the SDK. Don't describe it as "per-use" or "read-only authorization."
+
+---
+
+## Draft inquiry email
+
+**To:** 1Password developer / partner relations *(if no direct contact: developer-portal support or `support@1password.com`, asking to be routed to developer relations)*
+**Subject:** API/SDK Terms question — independent browser using `DesktopAuth` for opt-in autofill (§4.1(e))
+
+Hello,
+
+I'm building **Blanc**, an independent Electron-based web browser (not affiliated with, endorsed by, or certified by 1Password). Blanc has no browser-extension runtime, so rather than an extension I'd like to integrate 1Password directly via the JavaScript SDK's desktop app integration (`DesktopAuth`). Before investing in a shippable implementation, I want to confirm this is permitted under the API and SDK Terms of Service.
+
+**Intended behavior (v1):**
+
+In v1, Blanc will invoke only list and read operations. Users must explicitly enable SDK integration and authorize the Blanc process through the 1Password desktop app. Authorization is scoped per account and process and expires according to 1Password's documented session rules. Blanc will decrypt only the user-selected item and will not persist, log, sync, or transmit retrieved credentials. Blanc does not provide its own vault, sync, or password-management service — it retrieves a user-selected item from the user's existing 1Password account and fills it into the matching page.
+
+To be precise about the security model: I understand `DesktopAuth` grants the approved process temporary access to the authorized account (via Touch ID, account password, or another configured method), not a per-item or read-only grant. Blanc's read-only behavior is a property of the operations it calls, not a limit on the authorization your SDK issues.
+
+Your SDK documentation describes website-matching behavior for autofill, which I read as supporting evidence that autofill is an intended SDK use. I recognize, though, that it doesn't specifically address a third-party browser distributing this to end users — which is exactly why I'm asking directly rather than assuming.
+
+**My questions:**
+
+1. Does this integration comply with **§4.1(e)** of the API and SDK Terms (the restriction on products that compete directly or indirectly with 1Password, or replicate a substantial portion of the Services' functionality)? Blanc is intended to be complementary — it requires an active 1Password installation and subscription and adds no vault or sync of its own — but I'd appreciate your confirmation given the breadth of "indirectly."
+
+2. Is any **security review, registration, or written approval** required before public distribution of an application that bundles the SDK and uses `DesktopAuth`?
+
+3. Are there specific **end-user terms, disclaimers, or brand-usage requirements** you'd want included beyond what's in the API/SDK Terms and Brand Guidelines?
+
+I'm glad to share more detail on the implementation or credential-handling design. Thank you for your time.
+
+Best regards,
+[Your name] — Bananify (the studio behind Blanc)
+[contact email] · [blancbrowser.com]
+
+---
+
+## Shipping obligations to fold into the real-engine spec (once §4.1(e) is cleared)
+
+Paperwork/policy layer — *not code blockers*, and the spike already satisfies the data-handling ones:
+
+- End-user terms: 1Password warranty/support disclaimer, no 1Password participation in the agreement, protection against reverse-engineering bundled components, appropriate liability limits.
+- Privacy-policy disclosure of the integration and credential handling.
+- Use of the 1Password name/logo strictly per their Brand Guidelines; no implied endorsement/certification.
+- Reasonable credential-grade security; notify 1Password of relevant incidents within 24 hours.
+- Track SDK versions — v0 releases have short support windows and the terms require compatibility with current versions.
+
+**Already satisfied by the spike's design:** reveal-one-item (no bulk decrypt), no persist/log/sync/transmit of credentials, main-process-only handling, data minimized to the selected item's built-in fields.
+
+---
+
+## 1Password's reply
+
+**Received:** 2026-07-17, 7:19 AM · **From:** `support@1password.com` ·
+**Contact:** Brendan Rodgers, Sr Technical Representative — 1Password Support ·
+**Re:** "API/SDK Terms question — independent browser using DesktopAuth for opt-in autofill (§4.1(e))"
+
+> Hello Anthony,
+>
+> Thank you for reaching out. We appreciate you taking the time to share the details of your project.
+>
+> We aren't able to pre-approve compliance under our API and SDK Terms of Service. If you have questions about whether your intended use is permitted, we'd recommend having your own legal counsel review the terms directly.
+>
+> Thanks again for your interest in 1Password.
+
+### What this does and doesn't say
+
+- **Does not** state the use is prohibited, and **does not** assert §4.1(e) applies. No compliance determination was made either way.
+- **Does** establish that pre-approval is unavailable as a matter of policy — support is not authorized to issue legal rulings on their own terms. This is the standing answer to this class of question, not a signal about the merits.
+- **Consequence:** waiting for 1Password's written confirmation is not a viable plan. The question routes to our own counsel or to an explicit risk decision.
+
+## Revised gate (replaces "wait for 1Password")
+
+**Distribution to end users** is now a judgment call, not a blocked-on-vendor item. Options:
+
+| Option | Cost | Risk |
+|---|---|---|
+| **Counsel review** — what 1Password recommended | A few hours of a software-licensing attorney on one focused question (§4.1(e) vs. the behavior described above) | Resolves it properly; the actual answer to the question asked |
+| **Risk-accept and ship** | None upfront | Realistic worst case is a request to stop → run the spike-teardown procedure (plan Task 6). Not existential, but real |
+| **Personal-only** *(current state)* | None | Zero terms risk; feature stays local to the developer |
+| **Shelve distribution, keep the work** | None | Branch + specs stay intact if the picture changes (clearer guidance, a partner program, or counsel later) |
+
+**Current decision (2026-07-17): personal-only / distribution shelved.** The dev
+build stays in use; the shippable engine is not being built. Revisit if/when
+counsel review is worth the cost or 1Password's published guidance changes.
+
+**Standing arguments for the record** (if this is revisited — *product/legal
+reasoning, not legal advice*): the API/SDK Terms grant "incorporate and distribute
+the SDK… as part of an Application, on an integrated (not standalone) basis";
+autofill is a **documented** SDK use case (the concepts page defines website-matching
+rules + credential field IDs); the desktop-integration security model explicitly
+anticipates third-party binaries it cannot code-verify and leaves the trust decision
+to the user; and Blanc requires an active 1Password installation + subscription and
+adds no vault, sync, or password management of its own — complementary rather than
+competitive. The open ambiguity is the breadth of "indirectly" in §4.1(e).

--- a/docs/superpowers/plans/2026-07-12-1password-autofill-spike.md
+++ b/docs/superpowers/plans/2026-07-12-1password-autofill-spike.md
@@ -1,0 +1,896 @@
+# 1Password Fill — Feasibility Spike Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove — with throwaway, env-gated spike code — whether Blanc can fill a web login form's username + password from the user's 1Password vault behind Touch ID, with **no browser extension**, by injecting from the inside of the tab's `WebContentsView`.
+
+**Architecture:** One new self-contained main-process module (`src/main/onepassword.js`) owns the 1Password JS SDK client and *all* credential handling; it exposes two pure, unit-tested helpers (`matchesHost`, `buildFillScript`), three SDK-backed async functions (`getClient`, `findLogins`, `revealCredential`), and a `probePackageLoad()` require-probe. `src/main/main.js` gains clearly-commented spike hooks — a fill orchestrator, a per-tab `⌥⌘P` chord listener, and a startup packaging check (a headless `BLANC_1P_PACKAGE_PROBE` probe that exits with a code, plus the `BLANC_1P_SPIKE` GUI hook) — plus a small per-tab navigation-epoch counter folded into the existing navigation handlers. `main.js` never requires the SDK directly. No IPC namespace, store, setting, preload, or renderer change. The SDK is `require`d lazily so a normal packaged startup never loads it, and every entry point is env-gated.
+
+**Tech Stack:** Electron main process (`WebContentsView.executeJavaScript`, `dialog.showMessageBox`, `before-input-event`), `@1password/sdk@0.4.0` (`createClient` + `DesktopAuth`, native `SharedLibCore` bridge), Node's built-in `node --test` for the pure helpers.
+
+## Global Constraints
+
+*Every task's requirements implicitly include this section. Values are copied verbatim from the spec.*
+
+- **This is a spike, not a feature.** Its only output is a yes/no + learnings. Every spike hook in `main.js` carries a `// SPIKE (1Password fill feasibility)` comment. **Env-gating is not release-safety** (the source + SDK dependency still ship, and a user could set `BLANC_1P_SPIKE=1`): **Task 6 removes the spike entirely, and this branch must not merge to `main` with the spike code present.**
+- **Dependency, pinned exactly:** `npm i -E @1password/sdk@0.4.0` (pulls transitive `@1password/sdk-core`). Never a caret/tilde range. Re-verify the SDK surface (`createClient`, `DesktopAuth`, `SharedLibCore`, `vaults.list`, `items.list`, `items.get`, `ItemOverview.websites`) on any bump.
+- **Lazy require only.** `require('@1password/sdk')` appears **only inside** `onepassword.js`'s function bodies — `getClient` and `probePackageLoad` (never at module top level), so a normal packaged startup never loads it. **`main.js` never requires the SDK directly** — it goes through `onepassword.probePackageLoad()` — so the module boundary is airtight.
+- **Enable gate (chord + orchestrator):** `!app.isPackaged || process.env.BLANC_1P_SPIKE === '1'` — dev by default, plus explicit packaged opt-in for the signed-build fallback; never active in a normal shipping build.
+- **Packaging-hook gates:** the GUI hook `initSpikePackaging` is `process.env.BLANC_1P_SPIKE === '1'` **only** (not `!app.isPackaged`); the headless probe `runPackageProbeIfRequested` is `process.env.BLANC_1P_PACKAGE_PROBE === '1'` **only** — it logs one line, sets an exit code, and `app.exit()`s.
+- **`BLANC_1P_ACCOUNT`** env var (account name/UUID) is **required** by `getClient()` and is **never committed**.
+- **Chord contract (physical key, exact modifiers):** `input.type === 'keyDown'` **and** `!input.isAutoRepeat` **and** `input.code === 'KeyP'` (physical — on macOS ⌥ mutates `input.key`) **and** `input.meta && input.alt && !input.control && !input.shift`. A **module-level single-flight boolean** ignores re-triggers until the current fill resolves (released in `.finally()`).
+- **Credentials never leave main-process memory + the verified page.** Never exposed to the chrome/overlay renderer, preloads, logs, or any store. **Every outcome logs one result line — never a credential value.**
+- **Decrypt exactly one secret.** Matching runs on `items.list()` overviews (website URLs present, credential fields absent). `items.get()` — the only call that returns a password — runs only on the single chosen item.
+- **`http(s)`-only allowlist.** Only `http:`/`https:` origins proceed; everything else (`blanc://`, `file://`, `data:`, `view-source:`, blank tab, …) is a no-op. Private tabs **are** allowed.
+- **Main frame only.** Cross-origin iframes are not filled.
+- **Injection uses `executeJavaScript(source)` single-arg, NO `userGesture`** (setting `value` + events needs no activation; `userGesture:true` would grant the page transient activation).
+- **Origin/identity is re-validated, never assumed.** Main-side `wc.getURL() === expectedURL` (Chromium ground truth) before injecting; the injected function's **first act** is the synchronous `location.href === expectedURL && document.hasFocus() && performance.timeOrigin === capturedTimeOrigin` check. Main-world spoofing by a hostile replacement document is an **accepted spike limitation**.
+- **Never `npm run release`** for the packaging check — it publishes an immutable GitHub release, which conflicts with spike removal. Use the explicit non-publishing `electron-builder … --publish never` command in Task 5.
+- **`onepassword.js` does not touch chrome HTML/CSS/renderers**, so no `⌘R`-vs-relaunch caveat applies to the module or main.js logic — but manual fill tests still require a fresh `npm start` because the chord listener is wired at `createTab` time.
+
+---
+
+## File Structure
+
+- **Create `src/main/onepassword.js`** — the entire SDK + credential surface. Pure helpers `matchesHost`/`buildFillScript` (no SDK, no Electron beyond `require('electron').app` for the version) + SDK-backed `getClient`/`findLogins`/`revealCredential`/`probePackageLoad`. Lazy-requires `@1password/sdk` (only inside `getClient`/`probePackageLoad`).
+- **Create `test/unit/onepassword-match.test.js`** — pure `node --test` coverage of `matchesHost` and `buildFillScript`, plus a lazy-require guard. No Electron/SDK/biometrics.
+- **Modify `src/main/main.js`** — spike hooks + a nav-epoch counter:
+  - Module-level (just above `createTab`, ~line 863): `ONE_PASSWORD_SPIKE_ENABLED`, `onePasswordFillInFlight`, `fillActiveTabFrom1Password()`, `runPackageProbeIfRequested()`, `initSpikePackaging()`.
+  - Inside `createTab`: `navEpoch: 0` on the tab object (~line 904), `tab.navEpoch++` in `did-navigate` (line 946) and (main-frame only) `did-navigate-in-page` (line 974), a new `did-start-navigation` handler, and the `before-input-event` chord listener attached to the tab's own `wc` (after line 909).
+  - In the `app.whenReady` body: `if (await runPackageProbeIfRequested()) return;` as the first statement, and a fire-and-forget `initSpikePackaging()` after the ad-blocker/test-hook if/else (~line 2107).
+- **Modify `package.json` / `package-lock.json`** — the exactly-pinned `@1password/sdk@0.4.0` dependency.
+
+---
+
+### Task 1: `onepassword.js` pure helpers (`matchesHost` + `buildFillScript`) + unit tests
+
+The two functions that need no SDK, no Electron, no biometrics — so they're built first, fully TDD. `matchesHost` is the vault-matching predicate; `buildFillScript` produces the string injected into the page (it embeds the credential, which is why it lives in the credential-owning module and why its escaping is unit-tested).
+
+**Files:**
+- Create: `src/main/onepassword.js`
+- Test: `test/unit/onepassword-match.test.js`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks. Node built-ins only (`URL`).
+- Produces:
+  - `matchesHost(itemUrls, host) → boolean` — `itemUrls` is an array of stored website strings (possibly scheme-less or malformed); `host` is the target hostname (e.g. `github.com`). Tolerant hostname extraction (prepend `https://` when scheme-less; skip a still-malformed URL, never throw), `www.`-stripped on both sides, **exact host equality** (never substring).
+  - `buildFillScript({ expectedURL, expectedTimeOrigin, username, password }) → string` — an IIFE source string for `executeJavaScript`. `username`/`password` may be `null`. All four values embedded via `JSON.stringify`. The IIFE resolves to a **status object only**: `{ originMismatch, filledUser, filledPass }` (with an extra `noPasswordField: true` when no visible password field is found).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/unit/onepassword-match.test.js`:
+
+```js
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { matchesHost, buildFillScript } = require('../../src/main/onepassword');
+
+test('matchesHost: exact host matches', () => {
+  assert.equal(matchesHost(['https://github.com/login'], 'github.com'), true);
+});
+
+test('matchesHost: www vs bare host both directions', () => {
+  assert.equal(matchesHost(['https://www.github.com'], 'github.com'), true);
+  assert.equal(matchesHost(['https://github.com'], 'www.github.com'), true);
+});
+
+test('matchesHost: scheme-less stored value matches', () => {
+  assert.equal(matchesHost(['github.com'], 'github.com'), true);
+});
+
+test('matchesHost: subdomain must NOT match', () => {
+  assert.equal(matchesHost(['https://login.github.com'], 'github.com'), false);
+});
+
+test('matchesHost: substring trap must NOT match', () => {
+  assert.equal(matchesHost(['https://github.com.evil.com'], 'github.com'), false);
+});
+
+test('matchesHost: item with multiple urls, one matches', () => {
+  assert.equal(matchesHost(['https://example.org', 'github.com'], 'github.com'), true);
+});
+
+test('matchesHost: item with no urls does not match', () => {
+  assert.equal(matchesHost([], 'github.com'), false);
+});
+
+test('matchesHost: malformed stored url is skipped, not thrown', () => {
+  assert.doesNotThrow(() => matchesHost(['http://', ':::', 'github.com'], 'github.com'));
+  assert.equal(matchesHost(['http://', ':::', 'github.com'], 'github.com'), true);
+});
+
+test('buildFillScript: embeds expectedURL and timeOrigin via JSON.stringify', () => {
+  const s = buildFillScript({ expectedURL: 'https://github.com/login', expectedTimeOrigin: 1234.5, username: 'u', password: 'p' });
+  assert.ok(s.includes(JSON.stringify('https://github.com/login')));
+  assert.ok(s.includes('1234.5'));
+});
+
+test('buildFillScript: dangerous credential chars are safely escaped', () => {
+  const nasty = 'a"b\\c\nd\'e';
+  const s = buildFillScript({ expectedURL: 'https://x.test/', expectedTimeOrigin: 0, username: null, password: nasty });
+  assert.ok(s.includes(JSON.stringify(nasty)));       // embedded encoded
+  assert.ok(!s.includes('"' + nasty + '"'));          // never the raw sequence in double quotes
+});
+
+test('buildFillScript: contains identity guard, visibility check, native setter', () => {
+  const s = buildFillScript({ expectedURL: 'https://x.test/', expectedTimeOrigin: 0, username: 'u', password: 'p' });
+  assert.ok(s.includes('location.href'));
+  assert.ok(s.includes('document.hasFocus()'));
+  assert.ok(s.includes('performance.timeOrigin'));
+  assert.ok(s.includes('offsetParent'));
+  assert.ok(s.includes('HTMLInputElement.prototype'));
+});
+
+test('buildFillScript: null username still embeds a null literal (fills password only)', () => {
+  const s = buildFillScript({ expectedURL: 'https://x.test/', expectedTimeOrigin: 0, username: null, password: 'p' });
+  assert.ok(s.includes('null !== null'));  // the USER !== null guard resolves to false at runtime
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test test/unit/onepassword-match.test.js`
+Expected: FAIL — `Cannot find module '../../src/main/onepassword'`.
+
+- [ ] **Step 3: Write the minimal implementation of the pure helpers**
+
+Create `src/main/onepassword.js` (SDK functions come in Task 2 — this task adds only the pure helpers + module skeleton):
+
+```js
+'use strict';
+
+// SPIKE (1Password fill feasibility) — throwaway; remove or keep env-gated
+// before any release. This module owns the 1Password SDK client and ALL
+// credential handling. `@1password/sdk` is require()d lazily (Task 2) so a
+// normal packaged startup never loads it.
+
+/** Extract a comparable hostname from a possibly scheme-less / malformed
+ * stored 1Password website value. `www.`-stripped. Returns null on garbage
+ * (caller skips it — never throws). */
+function normalizeHost(value) {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(value) ? value : `https://${value}`;
+  let host;
+  try {
+    host = new URL(withScheme).hostname;
+  } catch {
+    return null; // still malformed after prepending a scheme
+  }
+  if (!host) return null;
+  return host.replace(/^www\./i, '').toLowerCase();
+}
+
+/** True iff any of a Login item's stored website URLs resolves to `host`
+ * (both sides `www.`-stripped, EXACT equality — deliberately not substring,
+ * so `github.com.evil.com` cannot match `github.com`). */
+function matchesHost(itemUrls, host) {
+  const target = normalizeHost(host);
+  if (!target || !Array.isArray(itemUrls)) return false;
+  return itemUrls.some((u) => normalizeHost(u) === target);
+}
+
+/** Build the IIFE source injected via executeJavaScript(source). All four
+ * inputs are embedded with JSON.stringify (credential strings included), and
+ * the IIFE resolves to a STATUS OBJECT ONLY — never the credential values.
+ * Its first act is the synchronous identity guard (see the spec's TOCTOU
+ * discussion): a new document changes performance.timeOrigin; an SPA
+ * pushState route change keeps timeOrigin but changes location.href. */
+function buildFillScript({ expectedURL, expectedTimeOrigin, username, password }) {
+  const U = JSON.stringify(expectedURL);
+  const TO = JSON.stringify(expectedTimeOrigin);
+  const USER = JSON.stringify(username ?? null);
+  const PASS = JSON.stringify(password ?? null);
+  return `(function () {
+    if (location.href !== ${U} || !document.hasFocus() || performance.timeOrigin !== ${TO}) {
+      return { originMismatch: true, filledUser: false, filledPass: false };
+    }
+    var isVisible = function (el) {
+      if (!el || el.type === 'hidden' || el.offsetParent === null) return false;
+      var r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    };
+    var setNative = function (el, value) {
+      var d = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+      d.set.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+    var pw = null;
+    var pwlist = document.querySelectorAll('input[type=password]');
+    for (var i = 0; i < pwlist.length; i++) { if (isVisible(pwlist[i])) { pw = pwlist[i]; break; } }
+    if (!pw) return { originMismatch: false, filledUser: false, filledPass: false, noPasswordField: true };
+    var filledPass = false, filledUser = false;
+    if (${PASS} !== null) { setNative(pw, ${PASS}); filledPass = true; }
+    var isText = function (el) { return el && el.tagName === 'INPUT' && (el.type === 'text' || el.type === 'email'); };
+    var user = null;
+    var active = document.activeElement;
+    if (isText(active) && isVisible(active)) {
+      user = active;
+    } else {
+      var scope = pw.form || document;
+      var texts = scope.querySelectorAll('input[type=text], input[type=email]');
+      for (var j = 0; j < texts.length; j++) {
+        if (!isVisible(texts[j])) continue;
+        if (pw.compareDocumentPosition(texts[j]) & Node.DOCUMENT_POSITION_PRECEDING) user = texts[j];
+      }
+    }
+    if (user && ${USER} !== null) { setNative(user, ${USER}); filledUser = true; }
+    return { originMismatch: false, filledUser: filledUser, filledPass: filledPass };
+  })();`;
+}
+
+module.exports = { matchesHost, buildFillScript };
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test test/unit/onepassword-match.test.js`
+Expected: PASS — all `matchesHost` + `buildFillScript` cases green.
+
+- [ ] **Step 5: Run the full unit suite to confirm no regression**
+
+Run: `npm run test:unit`
+Expected: PASS — the new file runs alongside the existing suite; nothing else changes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/onepassword.js test/unit/onepassword-match.test.js
+git commit -m "spike(1p): pure host-match + fill-script builder with unit tests"
+```
+
+---
+
+### Task 2: SDK-backed `getClient` / `findLogins` / `revealCredential` + lazy-require guard
+
+Adds the credential-reading half of `onepassword.js` and pins the SDK. These three functions can't be unit-tested without a live, unlocked 1Password app + biometrics (that's what Task 5 proves), so the automated deliverable here is (a) the dependency resolves and (b) the **lazy-require guarantee** holds — merely `require('./onepassword')` must not pull `@1password/sdk` into the module cache.
+
+**Files:**
+- Modify: `package.json`, `package-lock.json` (via `npm i -E`)
+- Modify: `src/main/onepassword.js` (append SDK functions + exports)
+- Test: `test/unit/onepassword-match.test.js` (add the lazy-require guard test)
+
+**Interfaces:**
+- Consumes: `matchesHost` (Task 1), `@1password/sdk@0.4.0` (`createClient`, `DesktopAuth`).
+- Produces:
+  - `getClient() → Promise<Client>` — lazily constructs + caches one client via `DesktopAuth(process.env.BLANC_1P_ACCOUNT)`; throws if `BLANC_1P_ACCOUNT` is unset; discards the cache only on an unrecoverable failure.
+  - `findLogins(expectedHost) → Promise<Array<{ vaultId, itemId, title }>>` — matches on overviews; **decrypts no secret**. Tolerates an inaccessible vault (skips it).
+  - `revealCredential(vaultId, itemId) → Promise<{ username: string|null, password: string|null }>` — the **only** call that decrypts a secret; reads the built-in `password` (`id === 'password'`) and `username` (`id === 'username'`) fields, **no fieldType fallback**.
+  - `probePackageLoad() → void` — `require('@1password/sdk')` (criterion 3(a)); throws if the package/WASM can't load. Keeps the SDK require out of `main.js`.
+
+- [ ] **Step 1: Pin the SDK**
+
+Run: `npm i -E @1password/sdk@0.4.0`
+Expected: `package.json` `dependencies` gains `"@1password/sdk": "0.4.0"` (no `^`/`~`); `package-lock.json` records it + transitive `@1password/sdk-core`.
+
+Verify the pin:
+
+Run: `node -e "console.log(require('./package.json').dependencies['@1password/sdk'])"`
+Expected output: `0.4.0`
+
+- [ ] **Step 2: Write the failing lazy-require guard test**
+
+Append to `test/unit/onepassword-match.test.js`:
+
+```js
+test('requiring onepassword.js does NOT eagerly load the 1Password SDK', () => {
+  // The module must stay import-light: `@1password/sdk` is loaded only inside
+  // the SDK functions, so a normal packaged startup never pays for it.
+  const resolved = require.resolve('../../src/main/onepassword');
+  delete require.cache[resolved];
+  require('../../src/main/onepassword');
+  const sdkLoaded = Object.keys(require.cache).some((p) => p.includes('@1password' + require('path').sep + 'sdk'));
+  assert.equal(sdkLoaded, false);
+});
+```
+
+- [ ] **Step 3: Run the guard test to verify it fails or passes for the right reason**
+
+Run: `node --test test/unit/onepassword-match.test.js`
+Expected: PASS already (Task 1's module has no top-level SDK require). This test **locks in** that property before Step 4 adds the SDK functions — if Step 4 accidentally hoists the `require` to module scope, this test flips to FAIL.
+
+- [ ] **Step 4: Append the SDK functions**
+
+Add to `src/main/onepassword.js`, immediately above the final `module.exports` line, and extend the exports. **The `require('@1password/sdk')` stays inside `getClient` — never at module top level:**
+
+```js
+const { app } = require('electron');
+
+let cachedClient = null;
+
+/** Lazily construct + cache the SDK client via the native desktop-app bridge
+ * (DesktopAuth → SharedLibCore → dlopen of 1Password's libop_sdk_ipc_client).
+ * BLANC_1P_ACCOUNT is required and never committed. The cache is discarded
+ * only on an unrecoverable failure — the SDK re-authorizes an ordinary
+ * ~10-min session expiry itself. */
+async function getClient() {
+  if (cachedClient) return cachedClient;
+  const account = process.env.BLANC_1P_ACCOUNT;
+  if (!account) throw new Error('BLANC_1P_ACCOUNT is not set');
+  const { createClient, DesktopAuth } = require('@1password/sdk'); // lazy — never at module scope
+  cachedClient = await createClient({
+    auth: new DesktopAuth(account),
+    integrationName: 'Blanc',
+    integrationVersion: app.getVersion(),
+  });
+  return cachedClient;
+}
+
+/** Match Login items against `expectedHost` on OVERVIEWS only — no secret is
+ * decrypted here. Skips a vault that can't be listed (logged by caller). */
+async function findLogins(expectedHost) {
+  const client = await getClient();
+  const matches = [];
+  const vaults = await client.vaults.list();
+  for (const vault of vaults) {
+    let overviews;
+    try {
+      overviews = await client.items.list(vault.id);
+    } catch {
+      continue; // inaccessible vault — skip, don't abort the whole search
+    }
+    for (const ov of overviews) {
+      if (ov.category !== 'Login') continue;
+      const urls = Array.isArray(ov.websites) ? ov.websites.map((w) => w.url) : [];
+      if (matchesHost(urls, expectedHost)) {
+        matches.push({ vaultId: vault.id, itemId: ov.id, title: ov.title });
+      }
+    }
+  }
+  return matches;
+}
+
+/** Decrypt exactly the one chosen item and read its BUILT-IN username +
+ * password fields (by id — no "first Concealed field" fallback, which could
+ * return a custom PIN/recovery secret). A missing built-in field returns null
+ * (a defined outcome), never a guess. */
+async function revealCredential(vaultId, itemId) {
+  const client = await getClient();
+  const item = await client.items.get(vaultId, itemId);
+  const fields = Array.isArray(item.fields) ? item.fields : [];
+  const read = (id) => {
+    const f = fields.find((x) => x.id === id);
+    return f && typeof f.value === 'string' ? f.value : null;
+  };
+  return { username: read('username'), password: read('password') };
+}
+
+/** Criterion 3(a) probe: force-load the SDK package — module resolution +
+ * @1password/sdk-core's eager core_bg.wasm compile — WITHOUT authenticating.
+ * Throws if the package can't load. Lives here (not in main.js) so the
+ * `require('@1password/sdk')` stays confined to this module, alongside
+ * getClient — preserving the lazy-require boundary. Never authenticates, so it
+ * does not dlopen the native 1Password bridge (that's getClient/criterion 3b). */
+function probePackageLoad() {
+  require('@1password/sdk'); // lazy — the only other place this is required
+}
+```
+
+Change the final export line to:
+
+```js
+module.exports = { matchesHost, buildFillScript, getClient, findLogins, revealCredential, probePackageLoad };
+```
+
+- [ ] **Step 5: Confirm the lazy-require guard still passes and the module loads**
+
+Run: `node --test test/unit/onepassword-match.test.js`
+Expected: PASS — the lazy-require guard stays green (SDK not in cache after a bare require), and Task 1's tests are unaffected.
+
+- [ ] **Step 6: Syntax-check the module resolves against the installed SDK**
+
+Run: `node --check src/main/onepassword.js`
+Expected: no output (exit 0) — the file parses.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json package-lock.json src/main/onepassword.js test/unit/onepassword-match.test.js
+git commit -m "spike(1p): pin @1password/sdk@0.4.0 + getClient/findLogins/revealCredential"
+```
+
+---
+
+### Task 3: Fill orchestrator + nav-epoch counter + `⌥⌘P` chord (end-to-end deliverable)
+
+The first manually-runnable deliverable: press `⌥⌘P` on a login page → Touch ID → both fields fill. This is one test cycle (orchestrator, chord, and epoch counter are useless apart), so it's one task with grouped steps. All three edits live in `src/main/main.js` and are commented spike-only.
+
+**Files:**
+- Modify: `src/main/main.js`
+
+**Interfaces:**
+- Consumes: `onepassword.findLogins`, `onepassword.revealCredential`, `onepassword.buildFillScript` (Tasks 1–2); existing `win`, `activeTabId`, `tabs`, `hasLiveWindow`, `dialog`, `app`.
+- Produces: module-level `ONE_PASSWORD_SPIKE_ENABLED` (bool), `onePasswordFillInFlight` (bool), `fillActiveTabFrom1Password() → Promise<void>`; a `navEpoch` field on every tab; a chord listener on each tab's `wc`.
+
+- [ ] **Step 1: Add the `navEpoch` field to the tab object**
+
+In `createTab`'s `tab` object literal (`src/main/main.js`, after `historyEligible: true,` — the last field, ~line 904), add:
+
+```js
+    // SPIKE (1Password fill feasibility) — bumped on any main-frame navigation
+    // start/commit so the async fill can detect a page swap mid-flow.
+    navEpoch: 0,
+```
+
+- [ ] **Step 2: Bump the epoch in the existing navigation handlers**
+
+In `did-navigate` (~line 946), add `tab.navEpoch++;` as the first statement of the handler body:
+
+```js
+  wc.on('did-navigate', (_e, url, httpResponseCode) => {
+    tab.navEpoch++; // SPIKE (1Password fill feasibility)
+    const shouldReclaimChromeFocus = url === tab.url && tabsWantingAddressBarFocus.has(id) && activeTabId === id;
+```
+
+In `did-navigate-in-page` (~line 974), bump the epoch **only for the main frame** — this event fires for *any* frame (a cross-origin ad iframe changing its hash/history during the async Touch ID window would otherwise false-abort a valid fill), and the handler already receives `isMainFrame`:
+
+```js
+  wc.on('did-navigate-in-page', (_e, url, isMainFrame) => {
+    if (isMainFrame) tab.navEpoch++; // SPIKE (1Password fill feasibility) — main frame only
+    syncNavState();
+```
+
+Then add a **new** handler immediately after the `did-navigate-in-page` handler's closing `});` (~line 983) — catches a navigation that *begins* mid-flow, not only one that completes:
+
+```js
+  // SPIKE (1Password fill feasibility) — a main-frame navigation that STARTS
+  // after the orchestrator's main-side URL check would still let
+  // executeJavaScript run in the replacement document; bump the epoch so the
+  // pre-injection re-check aborts. Removed with the rest of the spike.
+  wc.on('did-start-navigation', (_e, _url, _isInPlace, isMainFrame) => {
+    if (isMainFrame) tab.navEpoch++;
+  });
+```
+
+- [ ] **Step 3: Add module-level spike state + the orchestrator**
+
+Immediately **above** `function createTab(...)` (~line 865, after the `TAB_WEB_PREFERENCES` block closes at line 863), add:
+
+```js
+// ─── SPIKE (1Password fill feasibility) — remove before release ───────────
+// Fill the active tab's login form from 1Password behind Touch ID, with no
+// browser extension. Env-gated; credentials live only in main memory + the
+// verified page, and every outcome logs a result line, never a value.
+const ONE_PASSWORD_SPIKE_ENABLED = !app.isPackaged || process.env.BLANC_1P_SPIKE === '1';
+let onePasswordFillInFlight = false;
+
+async function fillActiveTabFrom1Password() {
+  const log = (result, extra) => console.log(`[1p-spike] ${result}${extra ? ' ' + extra : ''}`);
+  const onepassword = require('./onepassword'); // ./onepassword only — the SDK stays lazy inside it
+  let capturedTabId, tab, wc, expectedURL, expectedHost, capturedEpoch, capturedTimeOrigin, chosen;
+
+  // ── PHASE 1 (pre-reveal): NO credential is in memory yet, so err.message is
+  //    safe to log for diagnosis. ──
+  try {
+    if (!hasLiveWindow() || !activeTabId) return log('no-active-tab');
+    capturedTabId = activeTabId;
+    tab = tabs.get(capturedTabId);
+    if (!tab) return log('no-active-tab');
+    wc = tab.view.webContents;
+    expectedURL = wc.getURL();
+    if (!/^https?:\/\//i.test(expectedURL)) return log('non-http-noop');
+    expectedHost = new URL(expectedURL).hostname;
+    capturedEpoch = tab.navEpoch;
+    capturedTimeOrigin = await wc.executeJavaScript('performance.timeOrigin');
+
+    const matches = await onepassword.findLogins(expectedHost);
+    if (matches.length === 0) return log('no-match', expectedHost);
+    chosen = matches[0];
+    if (matches.length > 1) {
+      // The vault search was async — if the window died meanwhile, don't ask
+      // the user to choose a login for a window that no longer exists (the
+      // post-reveal re-validation would abort anyway). Also keeps `win` safe
+      // to pass as the dialog parent (documented overloads only).
+      if (!hasLiveWindow()) return log('abort-window-changed');
+      const buttons = matches.map((m) => m.title || '(untitled)');
+      const cancelId = buttons.length;
+      buttons.push('Cancel');
+      const { response } = await dialog.showMessageBox(win, {
+        type: 'question',
+        title: 'Fill from 1Password',
+        message: `Choose a login for ${expectedHost}`,
+        buttons,
+        cancelId,
+        noLink: true,
+      });
+      if (response < 0 || response >= matches.length) return log('chooser-cancel');
+      chosen = matches[response];
+    }
+  } catch (err) {
+    return log('setup-error', err?.message); // pre-reveal only — credential-free
+  }
+
+  // ── PHASE 2 (reveal + fill): a credential is in memory from revealCredential
+  //    onward. This whole block is a BINDING-LESS try — every failure (a
+  //    page-controlled executeJavaScript rejection, OR any other throw once the
+  //    credential exists) logs a FIXED classification, so no error string can
+  //    ever echo the credential. ──
+  try {
+    const { username, password } = await onepassword.revealCredential(chosen.vaultId, chosen.itemId);
+    if (password == null && username == null) return log('empty-item');
+
+    // Re-validate after the async auth/chooser: same live+focused window, same
+    // active tab, live+focused webContents, unchanged epoch, exact same URL.
+    if (!hasLiveWindow() || !win.isFocused()) return log('abort-window-changed');
+    if (activeTabId !== capturedTabId || !tabs.has(capturedTabId)) return log('abort-tab-changed');
+    if (wc.isDestroyed() || !wc.isFocused()) return log('abort-wc-changed');
+    if (tab.navEpoch !== capturedEpoch) return log('abort-navigated');
+    if (wc.getURL() !== expectedURL) return log('abort-url-changed');
+
+    // Injection runs in the page's MAIN WORLD (a hostile page could override the
+    // value setter to throw an Error echoing the value) — the binding-less catch
+    // below is what makes that message unloggable.
+    const source = onepassword.buildFillScript({ expectedURL, expectedTimeOrigin: capturedTimeOrigin, username, password });
+    const status = await wc.executeJavaScript(source); // single-arg, no userGesture
+    if (status?.originMismatch) return log('origin-or-focus-mismatch');
+    if (status?.noPasswordField) return log('no-password-field');
+    if (status?.filledPass && status?.filledUser) return log('filled', 'user+pass');
+    if (status?.filledPass) return log('filled', 'pass-only (username field not found)');
+    return log('nothing-filled');
+  } catch {
+    return log('fill-error'); // no binding, no message — a credential is in memory
+  }
+}
+
+async function initSpikePackaging() { /* filled in Task 4 */ }
+// ─── end SPIKE ────────────────────────────────────────────────────────────
+```
+
+*(The `initSpikePackaging` stub is a placeholder line so the module parses; Task 4 replaces its body. Leave the stub exactly as shown.)*
+
+- [ ] **Step 4: Wire the chord listener into `createTab`**
+
+In `createTab`, immediately after `const wc = view.webContents;` (~line 909), add:
+
+```js
+  // SPIKE (1Password fill feasibility) — ⌥⌘P on the tab's OWN webContents
+  // (the overlay before-input-event listener never sees page-focused keys).
+  if (ONE_PASSWORD_SPIKE_ENABLED) {
+    wc.on('before-input-event', (event, input) => {
+      if (input.type !== 'keyDown' || input.isAutoRepeat) return;
+      if (input.code !== 'KeyP') return; // physical key — ⌥ mutates input.key on macOS
+      if (!(input.meta && input.alt && !input.control && !input.shift)) return; // one modifier off ⌘P Print
+      // Consume the chord BEFORE the single-flight check — a recognized second
+      // press must not fall through to the page, it just doesn't start a fill.
+      event.preventDefault();
+      if (onePasswordFillInFlight) return; // single-flight
+      onePasswordFillInFlight = true;
+      fillActiveTabFrom1Password()
+        .catch((err) => console.warn('[1p-spike] fill error:', err?.message))
+        .finally(() => { onePasswordFillInFlight = false; });
+    });
+  }
+```
+
+- [ ] **Step 5: Syntax-check main.js**
+
+Run: `node --check src/main/main.js`
+Expected: no output (exit 0).
+
+- [ ] **Step 6: Confirm the unit suite still passes (no accidental cross-file break)**
+
+Run: `npm run test:unit`
+Expected: PASS.
+
+- [ ] **Step 7: Manual smoke — the core success criterion**
+
+Complete the one-time setup prerequisites first (1Password 8 at `/Applications`, unlocked; Settings → Developer → *Integrate with the 1Password SDKs* → *Integrate with other apps*; Settings → Security → Touch ID; a Login item for `github.com`). Then, from a fresh launch (the chord listener wires at `createTab` time — relaunch, don't `⌘R`):
+
+```bash
+op run --env-file=.env.1password --no-masking -- env BLANC_1P_ACCOUNT="<your-account>" npm start
+```
+
+*(`BLANC_1P_ACCOUNT` is required and uncommitted; substitute your account name/UUID. `op run` is only needed if you keep the account id in 1Password — otherwise `BLANC_1P_ACCOUNT=<id> npm start`.)*
+
+Verify against the spec's manual matrix, reading the `[1p-spike]` log lines in the terminal:
+- `https://github.com/login` (matching login) → `⌥⌘P` → Touch ID (first use per ~10-min SDK session) → **both fields populate and retain their values**; log `filled user+pass`. A second `⌥⌘P` within the session fills with no prompt.
+- Two matching logins → native chooser → pick fills; **Cancel** → `chooser-cancel`, no fill.
+- No match → `no-match`, no-op. `blanc://settings/`, `file://…` (page content focused) → `non-http-noop`.
+- A **blank new tab** → safe no-op with **no log line at all**: Blanc parks focus in the address overlay, whose webContents carries no chord listener, so `⌥⌘P` never reaches a tab `wc`. (Clicking into the blank page's content first would surface `non-http-noop`.) Deliberately not "fixed" — the overlay needs no listener for a spike.
+- **Double-press fast** → only one flow runs (keyDown + `!isAutoRepeat` + single-flight); the second press is consumed — no page keystroke, no log.
+- **Reload / cross-doc nav mid-flow** (trigger during the Touch ID prompt, then reload) → `abort-navigated` or `origin-or-focus-mismatch`; nothing written. **SPA `pushState` route change mid-flow** → `abort-url-changed`.
+- **Switch or close the tab/window mid-flow** → `abort-tab-changed` / `abort-window-changed`; nothing written.
+- **Touch ID blur then refocus** → still fills (transient blur alone doesn't abort).
+
+> **Execution record (2026-07-12):** core matrix **passed** — fill+retain (`filled user+pass` on a real login item, values held, no form submission), silent session reuse, single-flight under double-press, `no-match github.com`, blank-tab safe no-op (silent, per above). **Untested** (missing fixtures / un-hittable timing windows): multi-match chooser + Cancel, reload/SPA/tab-switch/window-close mid-auth, Touch ID blur-refocus. Those mid-flow guards stand on code review only — carry them into the spec's Findings (Task 5 Step 6) as untested.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/main/main.js
+git commit -m "spike(1p): fill orchestrator + nav-epoch + ⌥⌘P chord"
+```
+
+---
+
+### Task 4: packaging startup hooks (criteria 3a + 3b)
+
+The packaging criteria need signals a *notarized* build can log: 3(a) that the SDK module even loads in a packaged app, and 3(b) that `createClient(DesktopAuth)` + `vaults.list()` survive the hardened runtime + Gatekeeper. Two entry points: a **headless** `runPackageProbeIfRequested()` that loads the SDK, logs one line, and exits with a **code** (so 3(a) is a clean automated check, not a `grep` of a long-running GUI), and the **GUI** `initSpikePackaging()` that logs both lines during the 3(b) notarized run. This replaces the Task 3 stub and wires both calls.
+
+**Files:**
+- Modify: `src/main/main.js`
+
+**Interfaces:**
+- Consumes: `onepassword.probePackageLoad` + `onepassword.getClient` (Task 2). `initSpikePackaging` gated on `BLANC_1P_SPIKE === '1'`; the headless probe gated on `BLANC_1P_PACKAGE_PROBE === '1'`.
+- Produces:
+  - `runPackageProbeIfRequested() → Promise<boolean>` — **headless** criterion 3(a): if `BLANC_1P_PACKAGE_PROBE === '1'`, load the SDK, log one line, `app.exit(0|1)`; else return `false`. Called first in `app.whenReady`.
+  - `initSpikePackaging() → Promise<void>` — the **GUI** path (fire-and-forget): logs `package probe: PASS|FAIL` (3a) then `core smoke: PASS|FAIL|INCONCLUSIVE` (3b). Called later in `app.whenReady`.
+
+- [ ] **Step 1: Replace the stub body + add the headless probe**
+
+The GUI startup log alone can't be a clean automated check — Blanc is a long-running process, so piping it into `grep` orphans the app and can't distinguish PASS from FAIL by exit status. So there are **two** entry points: a headless, self-terminating probe with a real **exit code** for criterion 3(a), and the GUI hook that logs both lines during the notarized 3(b) run. Both load the SDK through `onepassword.probePackageLoad()` — **no `require('@1password/sdk')` in `main.js`**, so the lazy-require boundary (Global Constraints) still holds.
+
+Replace the `async function initSpikePackaging() { /* filled in Task 4 */ }` line (added in Task 3) with:
+
+```js
+// SPIKE (1Password fill feasibility) — headless criterion 3(a). Gated on its
+// OWN env var so it can run without a GUI/account: load the SDK package inside
+// packaged Electron (asar resolution + @1password/sdk-core's eager core_bg.wasm
+// compile), log ONE line, set a real exit code, and terminate. app.exit() is
+// used (not app.quit()) so native handles the SDK may open can't stall exit.
+async function runPackageProbeIfRequested() {
+  if (process.env.BLANC_1P_PACKAGE_PROBE !== '1') return false;
+  try {
+    require('./onepassword').probePackageLoad();
+    console.log('[1p-spike] package probe: PASS (require resolved + WASM compiled)');
+    app.exit(0);
+  } catch (err) {
+    console.warn(`[1p-spike] package probe: FAIL — ${err?.message || err}`);
+    app.exit(1);
+  }
+  return true; // unreachable after app.exit; kept for call-site clarity
+}
+
+// SPIKE (1Password fill feasibility) — GUI startup checks. Gated
+// BLANC_1P_SPIKE === '1'. Two independent lines:
+//   3(a) package probe — does the SDK module LOAD in this build?
+//   3(b) core smoke    — does DesktopAuth dlopen + authenticate under a
+//                        notarized/hardened build?
+async function initSpikePackaging() {
+  if (process.env.BLANC_1P_SPIKE !== '1') return;
+
+  // 3(a): load the package (asar loader active, eager core_bg.wasm compile).
+  try {
+    require('./onepassword').probePackageLoad();
+    console.log('[1p-spike] package probe: PASS (require resolved + WASM compiled)');
+  } catch (err) {
+    console.warn(`[1p-spike] package probe: FAIL — ${err?.message || err}`);
+  }
+
+  // 3(b): the native bridge round-trip. Decisive by default — everything is a
+  // FAIL unless it matches the biometric-cancel signature (/cancell?ed/i), a
+  // best-effort INCONCLUSIVE (bridge state then unknowable). "denied"/"not
+  // allowed"/policy/auth errors are real FAILs (the round-trip did not work). A
+  // genuine cancel misread as FAIL isn't worth chasing for throwaway code — just
+  // re-run the smoke without cancelling.
+  try {
+    const client = await require('./onepassword').getClient();
+    await client.vaults.list();
+    console.log('[1p-spike] core smoke: PASS (DesktopAuth + vaults.list)');
+  } catch (err) {
+    const msg = err?.message || String(err);
+    if (/cancell?ed/i.test(msg)) {
+      console.log(`[1p-spike] core smoke: INCONCLUSIVE (biometric cancelled) — ${msg}`);
+    } else {
+      const bridge = /dlopen|libop_sdk_ipc_client|image not found|code ?sign|library/i.test(msg);
+      console.warn(`[1p-spike] core smoke: FAIL${bridge ? ' (native bridge did not load)' : ''} — ${msg}`);
+    }
+  }
+}
+```
+
+*(Every `msg` here is a library/auth error string — `vaults.list()` returns no secrets, and neither probe authenticates during the require — so no credential can appear in these lines.)*
+
+- [ ] **Step 2: Wire both calls into startup**
+
+The headless probe must run **before** any window/ad-engine setup and short-circuit startup. Add it as the **first statement** inside the `app.whenReady().then(async () => { … })` callback (find it near the ad-blocker/test-hook block, `src/main/main.js`):
+
+```js
+  if (await runPackageProbeIfRequested()) return; // SPIKE — headless 3(a); app.exit() already fired
+```
+
+Then, immediately after the ad-blocker / test-hook `if (isAcceptanceTest) { … } else { … }` block closes (~line 2107), add the GUI hook:
+
+```js
+  initSpikePackaging(); // SPIKE (1Password fill feasibility) — fire-and-forget, gated on BLANC_1P_SPIKE
+```
+
+- [ ] **Step 3: Syntax-check + unit suite**
+
+Run: `node --check src/main/main.js && npm run test:unit`
+Expected: `node --check` silent (exit 0); unit suite PASS.
+
+- [ ] **Step 4: Manual smoke in dev (sanity before the packaged run in Task 5)**
+
+Run: `BLANC_1P_SPIKE=1 BLANC_1P_ACCOUNT="<your-account>" npm start`
+Expected: on startup, two lines — `[1p-spike] package probe: PASS (require resolved + WASM compiled)`, then a Touch ID prompt → `[1p-spike] core smoke: PASS (DesktopAuth + vaults.list)` (or `INCONCLUSIVE` if you cancel). A `core smoke: FAIL (native bridge did not load)` here means the dev `Electron` binary can't `dlopen` the 1Password bridge — note it; Task 5's signed build is the authoritative check. (In dev, `require()` runs off the unpacked source tree, so the *package probe* is only meaningful once packaged — see Task 5 Step 1.)
+
+Then sanity-check the headless probe exits cleanly with a code (it needs no account):
+
+```bash
+BLANC_1P_PACKAGE_PROBE=1 npm start
+rc=$?   # NOT `status` — that's a read-only special variable in zsh (macOS default shell)
+echo "exit=$rc"
+test "$rc" -eq 0   # same reason as Task 5 Step 1 — don't let echo mask a FAIL
+```
+Expected: one `[1p-spike] package probe: PASS …` line, the app quits on its own, and `exit=0`. *(In dev this loads from `node_modules`, so it should always PASS; the meaningful run is the packaged one in Task 5 Step 1.)*
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/main.js
+git commit -m "spike(1p): initSpikePackaging startup hook for criteria 3(a)+3(b)"
+```
+
+---
+
+### Task 5: Packaging verification (criteria 3a + 3b) — the genuine unknown
+
+Manual verification only — no code. Proves the SDK survives a real build: (a) `require('@1password/sdk')` resolves in a packaged app, and (b) the native `DesktopAuth` bridge `dlopen`s and authenticates under the hardened runtime **+ notarization + Gatekeeper**. These cannot be automated (they need real hardware, a signing environment, and biometrics). **Never use `npm run release`** — it publishes an immutable release, conflicting with spike removal.
+
+**Files:** none (verification of built artifacts).
+
+- [ ] **Step 1: Criterion 3(a) — the SDK module actually loads in a packaged app**
+
+Build an unpacked packaged app and run the **headless probe** (`BLANC_1P_PACKAGE_PROBE=1`) — it needs no account, loads the SDK, logs one line, and self-terminates with an exit code, so the criterion reduces to a captured `rc=$?` + `test`. Do **not** pipe the GUI startup into `grep`: Blanc is long-running, so `grep -m1` would orphan the app, could EPIPE its next write, and (matching PASS *and* FAIL) its exit status wouldn't mean "passed." Also don't try host-Node `require.resolve` against `app.asar`: plain `node` has no ASAR loader hook (false `MODULE_NOT_FOUND`) and `require.resolve` never executes the module, so it can't prove the eager `core_bg.wasm` compile the criterion is about.
+
+```bash
+npm run dist:dir
+BLANC_1P_PACKAGE_PROBE=1 "dist/mac-arm64/Blanc.app/Contents/MacOS/Blanc" --user-data-dir="$(mktemp -d)"
+rc=$?   # NOT `status` — that's a read-only special variable in zsh (macOS default shell)
+echo "exit=$rc"
+test "$rc" -eq 0   # propagates the probe's real result as this block's exit status
+```
+Expected: one line `[1p-spike] package probe: PASS (require resolved + WASM compiled)`, the app quits on its own, and `exit=0` (the `test` succeeds). A `package probe: FAIL` + `exit=1` (the `test` fails) means the module (or its eager `core_bg.wasm`) isn't loadable from inside the asar — add an `asarUnpack` glob for `@1password/sdk` to `package.json` `build.asarUnpack`, rebuild, and re-run. *(The trailing `test` matters: `…; echo "exit=$?"` alone would leave the block's exit status as `echo`'s 0, so an automated executor would read every run as a pass. Per the spec, the native `SharedLibCore` path doesn't itself use the bundled WASM, so the unpack may be unnecessary — this probe decides it. `dist/mac-arm64` is the Apple-Silicon output dir; adjust for an Intel/`--x64` build.)*
+
+- [ ] **Step 2: Criterion 3(b) — build a truly notarized artifact (explicit non-publishing)**
+
+Run the non-publishing command from the spec, restricted to **arm64** — the dev machine is Apple Silicon and the spike's native-bridge check can only be exercised here, so building the x64 slice too would just double the notarization round-trips for an artifact you can't test:
+
+```bash
+op run --env-file=.env.1password --no-masking -- npx electron-builder --mac zip --arm64 --publish never
+```
+Expected: a single signed + notarized `Blanc-<version>-arm64-mac.zip` in `dist/` plus `dist/mac-arm64/Blanc.app` (the repo's `afterSign`/notarize wiring runs). **Do not** use `dist:dir` here (electron-builder treats it as an unsigned/unnotarized unpacked dev artifact), and **never `npm run release`** (it publishes an immutable tag).
+
+- [ ] **Step 3: Verify signature, Gatekeeper, and notarization stapling**
+
+```bash
+codesign --verify --deep --strict --verbose=2 "dist/mac-arm64/Blanc.app"
+spctl -a -vv "dist/mac-arm64/Blanc.app"
+xcrun stapler validate "dist/mac-arm64/Blanc.app"
+```
+Expected: `valid on disk` / `satisfies its Designated Requirement`; `accepted` + `source=Notarized Developer ID`; `The validate action worked!`.
+
+- [ ] **Step 4: Launch the notarized build with the spike enabled + a throwaway profile**
+
+Extract the notarized `.zip`, ensure 1Password is running/unlocked, then run the binary directly (so stdout is readable for the smoke line):
+
+```bash
+BLANC_1P_SPIKE=1 BLANC_1P_ACCOUNT="<your-account>" \
+  "/path/to/extracted/Blanc.app/Contents/MacOS/Blanc" --user-data-dir="$(mktemp -d)"
+```
+*(The throwaway `--user-data-dir` keeps the real profile and single-instance lock untouched.)*
+
+Expected: Touch ID prompt naming `Blanc` → `[1p-spike] core smoke: PASS (DesktopAuth + vaults.list)`. This proves the `dlopen` of `libop_sdk_ipc_client.dylib` works under the hardened runtime + `disable-library-validation`. A `FAIL (native bridge did not load)` is the decisive negative — record it verbatim; `INCONCLUSIVE` means the biometric was cancelled, re-run.
+
+**Notarization evidence comes from Step 3, not this launch.** A locally-extracted zip carries **no** `com.apple.quarantine` attribute, and launching the inner Mach-O directly **skips** the LaunchServices first-launch Gatekeeper assessment — so this run does not by itself exercise the download/first-open path. To additionally confirm Gatekeeper admits the notarized bundle on a real first launch, use a **second, pristine extraction that has never been launched** (re-quarantining the copy you already ran directly isn't a true first-open — LaunchServices may have registered it), stamp quarantine *before* any launch, verify the attribute, then `open`:
+
+```bash
+ZIP="$(ls -t dist/Blanc-*-arm64-mac.zip | head -1)"              # the arm64 artifact from Step 2 (NOT Blanc-<v>-mac.zip, which is x64)
+FRESH="$(mktemp -d)/Blanc.app"
+ditto -xk "$ZIP" "$(dirname "$FRESH")"                           # fresh extraction, never launched
+xattr -w com.apple.quarantine "0081;0;Safari;" "$FRESH"
+xattr -p com.apple.quarantine "$FRESH"                           # verify the attribute is present
+open "$FRESH" --args --user-data-dir="$(mktemp -d)"             # LaunchServices first-open, throwaway profile; expect NO Gatekeeper block, then quit
+```
+*(`open` detaches stdout, so this only proves Gatekeeper admits the bundle — keep using the direct run above to read the smoke line. `--args --user-data-dir=…` keeps this off the real Blanc profile and single-instance lock; it still emits one packaged launch ping under a throwaway `installId` — a harmless orphan, since GUI launches via `open` don't inherit the shell env and this bundle never runs again.)*
+
+- [ ] **Step 5: (Optional) full auth+fill on the signed build**
+
+With the same notarized launch, open `https://github.com/login`, press `⌥⌘P`, confirm Touch ID → both fields fill (the `BLANC_1P_SPIKE=1` flag also enables the chord in a packaged build). This is the end-to-end proof under real signing, not just the headless smoke.
+
+- [ ] **Step 6: Record the spike outcome**
+
+Append a short **Findings** section to the spec file (`docs/superpowers/specs/2026-07-12-1password-autofill-spike-design.md`) — PASS/FAIL per criterion (1, 2, 3a, 3b), the decisive log lines, and whether `asarUnpack` was needed. Commit:
+
+```bash
+git add docs/superpowers/specs/2026-07-12-1password-autofill-spike-design.md
+git commit -m "spike(1p): record feasibility findings"
+```
+
+*(Per the spec: on success, a separate spec designs the real engine; on failure, this documents the dead end. Either way the spike code does not ship — proceed to Task 6.)*
+
+---
+
+### Task 6: Tear down the spike (release-safety gate)
+
+Once findings are recorded, the spike code and its SDK dependency come **out of the branch**. Env-gating alone is not release-safety: the source and `@1password/sdk` (plus its native `dlopen` of a third-party dylib) would still be *packaged* into every shipped build, and any user could enable experimental credential-handling code by setting `BLANC_1P_SPIKE=1`. This task reverts everything the spike added; the only durable artifact is the Findings section in the spec (Task 5 Step 6). **This branch must not merge to `main` with the spike code present** — either this task runs first, or the branch stays unmerged until it does.
+
+**Files:**
+- Delete: `src/main/onepassword.js`, `test/unit/onepassword-match.test.js`
+- Modify: `src/main/main.js` (remove all three hooks + the nav-epoch edits), `package.json`, `package-lock.json`
+
+**Interfaces:** none produced (net-zero to shipping code).
+
+- [ ] **Step 1: Remove the module and its test**
+
+```bash
+git rm src/main/onepassword.js test/unit/onepassword-match.test.js
+```
+
+- [ ] **Step 2: Remove the `main.js` hooks**
+
+Delete, in `src/main/main.js`: the `// ─── SPIKE …` block above `createTab` (module-level `ONE_PASSWORD_SPIKE_ENABLED`/`onePasswordFillInFlight`, `fillActiveTabFrom1Password`, `runPackageProbeIfRequested`, `initSpikePackaging`); the `before-input-event` chord listener inside `createTab`; both `app.whenReady` calls (`if (await runPackageProbeIfRequested()) return;` and `initSpikePackaging();`); the new `did-start-navigation` handler; the `navEpoch: 0` tab field; and the `tab.navEpoch++` lines in `did-navigate` / `did-navigate-in-page`. Grep to confirm nothing remains:
+
+Run: `grep -n 'navEpoch\|SPIKE\|1p-spike\|onePassword\|runPackageProbe\|initSpikePackaging\|ONE_PASSWORD_SPIKE\|BLANC_1P' src/main/main.js`
+Expected: no output.
+
+- [ ] **Step 3: Remove the dependency**
+
+Run: `npm uninstall @1password/sdk`
+Then confirm it (and its transitive core) are gone from the manifests:
+
+Run: `grep -n '1password' package.json package-lock.json`
+Expected: no output.
+
+- [ ] **Step 4: Verify the app is back to a clean baseline**
+
+Run: `node --check src/main/main.js && npm run test:unit`
+Expected: `node --check` silent (exit 0); unit suite PASS (the `onepassword-match` file is gone, everything else green).
+
+Run: `git grep -n '1p-spike\|@1password' -- ':!docs'`
+Expected: no output outside `docs/` (the Findings in the spec are the only retained trace).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "spike(1p): tear down feasibility spike (findings retained in spec)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- *Behavior* trigger/capture/match/reveal/re-validate/inject → Task 3 orchestrator + Task 1 `buildFillScript`. ✅
+- `http(s)`-only allowlist, private tabs allowed → Task 3 Step 3 (`/^https?:\/\//i`); private tabs aren't excluded. ✅
+- Zero/one/multiple-match handling + native chooser (webauthn pattern) → Task 3 Step 3. ✅
+- Three re-validation layers (window/tab/wc/epoch/exact-URL, then in-page `location.href`+`timeOrigin`+`hasFocus`) → Task 3 Steps 2–3 + Task 1 `buildFillScript`. ✅
+- *Architecture*: `onepassword.js` (getClient/findLogins/revealCredential/probePackageLoad + matchesHost/buildFillScript) → Tasks 1–2; the `main.js` spike hooks (orchestrator, chord, headless probe + GUI packaging hook) → Tasks 3–4; nav-epoch on `did-navigate`/`did-navigate-in-page` (main-frame)/`did-start-navigation` → Task 3 Step 2; pinned `@1password/sdk@0.4.0` (+ transitive core) → Task 2 Step 1; lazy require (SDK never in `main.js`) → Task 2 Step 4 + guard test Step 2. ✅
+- Chord contract (physical `KeyP`, exact modifiers, keyDown, `!isAutoRepeat`, single-flight, on tab `wc` not overlay) → Task 3 Step 4. ✅
+- Injection via single-arg `executeJavaScript`, no `userGesture`; native setter + bubbling events; visible-field detection; status-object-only return → Task 1 `buildFillScript` + Task 3 Step 3. ✅
+- `revealCredential` reads built-in `password`/`username` by id, no fieldType fallback, null = defined outcome → Task 2 Step 4. ✅
+- Security posture (credentials main-only, one decrypt, exact-URL authority, main-world spoofing accepted, native bridge under hardened runtime) → Global Constraints + Tasks 2–3. ✅
+- Success criteria 1/2/3a/3b + setup prerequisites → Task 3 Step 7, Task 4, Task 5. ✅
+- Testing (unit matchesHost matrix + manual matrix + packaging) → Task 1 Step 1, Task 3 Step 7, Task 5. ✅
+- Non-goals (no Dashlane, no isolated world, no save/TOTP/iframe, no `/1password` substrate, no settings UI) → none introduced. ✅
+- Spike removal / release-safety → Task 6 tears out the module, hooks, nav-epoch, and dependency; Global Constraints declare the do-not-merge-with-spike gate. ✅
+
+**Code-review fixes applied (Codex, round 1):**
+- *3(a) can't be host-Node `require.resolve` through asar* → the SDK is loaded by a real `require()` inside packaged Electron (via `probePackageLoad`); Task 5 Step 1 runs it and reads the `package probe` line. ✅
+- *Page-world error message could leak the password to logs* → the injection's failure path logs a fixed classification, never the page-controlled message. ✅
+- *`did-navigate-in-page` fires for subframes* → Task 3 Step 2 guards the in-page epoch bump with `if (isMainFrame)`. ✅
+- *Smoke cancel-classification too broad* → Task 4 narrows INCONCLUSIVE to `/cancell?ed/i` (best-effort; a genuine cancel misread as FAIL is simply re-run — no regex-tightening step to strand); everything else defaults to FAIL. ✅
+- *Quarantine claim inaccurate* → Task 5 Step 4 attributes notarization evidence to Step 3's `spctl`/`stapler` and adds an explicit `xattr`+`open` first-launch check. ✅
+
+**Code-review fixes applied (Codex, round 2):**
+- *Packaged probe had no reliable termination/status* (`grep -m1` orphans the GUI, can EPIPE, matches PASS+FAIL alike) → Task 4 adds a **headless** `runPackageProbeIfRequested()` gated on `BLANC_1P_PACKAGE_PROBE`: loads the SDK, logs one line, `app.exit(0|1)`. Task 5 Step 1 keys off `echo $?`. ✅
+- *Lazy-require constraint contradicted the direct `require('@1password/sdk')` in `main.js`* → added `onepassword.probePackageLoad()` (Task 2); both packaging hooks call it, so `main.js` never requires the SDK. Global Constraints + Architecture updated. ✅
+- *Outer-catch comment was false (credential already revealed before the re-validation/`buildFillScript` ops)* → Task 3 splits the orchestrator into a pre-reveal phase (`setup-error`, message logged) and a **binding-less** post-reveal phase (`fill-error`, no message) — the guarantee is now structural, and the comment is accurate. ✅
+- *Quarantine check reused an already-launched bundle* → Task 5 Step 4 now uses a **second pristine extraction**, stamps + verifies `com.apple.quarantine` before any launch, then `open`s it. ✅
+
+**Code-review fixes applied (Codex, round 3):**
+- *`; echo "exit=$?"` masked a probe failure as success* → Task 5 Step 1 now captures the code (`rc=$?` — not `status`, which zsh reserves read-only; found by executing the block) and ends on `test "$rc" -eq 0`, so the block's exit status is the probe's. ✅
+- *Quarantine `open` used the real profile* → Task 5 Step 4 passes a throwaway profile through LaunchServices: `open "$FRESH" --args --user-data-dir="$(mktemp -d)"`. ✅
+- *Wrong-arch zip name* (`Blanc-<v>-mac.zip` is x64; arm64 is `Blanc-<v>-arm64-mac.zip`, per `scripts/release.sh`) → Task 5 Step 2 builds `--arm64` only and Step 4 globs `dist/Blanc-*-arm64-mac.zip`. ✅
+- *Dangling "tighten the cancel regex in Task 5" with no such step* → reworded to best-effort INCONCLUSIVE; a misclassified cancel is simply re-run (no stranded step). ✅
+
+**Code-review fixes applied (Codex, round 4 — on the Task 3 implementation):**
+- *Second recognized chord press leaked to the page* → `event.preventDefault()` moved before the single-flight check: a recognized chord is always consumed; in-flight just means no new fill. ✅
+- *Chooser could call `dialog.showMessageBox(undefined, options)` (undocumented overload) after window closure* → pre-gate with `if (!hasLiveWindow()) return log('abort-window-changed');` and pass `win` plainly — matching the documented-overloads-only discipline of `webauthn.js`. ✅
+
+**Placeholder scan:** the only intentional stub is `initSpikePackaging()` in Task 3 Step 3, explicitly replaced with full code in Task 4 Step 1 (called out in both places). No `TODO`/"handle edge cases"/uncoded steps remain.
+
+**Type consistency:** `findLogins → {vaultId, itemId, title}` is consumed as `chosen.vaultId`/`chosen.itemId` and passed to `revealCredential(vaultId, itemId)` → `{username, password}`, consumed by name in the orchestrator and fed to `buildFillScript({expectedURL, expectedTimeOrigin, username, password})`, whose IIFE returns `{originMismatch, filledUser, filledPass, noPasswordField?}` — the exact keys the orchestrator branches on. `navEpoch` is set once and read as `tab.navEpoch`/`capturedEpoch` consistently. `ONE_PASSWORD_SPIKE_ENABLED` / `onePasswordFillInFlight` names match across definition and use.

--- a/docs/superpowers/specs/2026-07-12-1password-autofill-spike-design.md
+++ b/docs/superpowers/specs/2026-07-12-1password-autofill-spike-design.md
@@ -1,0 +1,361 @@
+# 1Password fill — feasibility spike
+
+**Date:** 2026-07-12
+**Status:** Approved for implementation planning (rev. 7) — after three external reviews + two adversarial passes
+
+## What
+
+A throwaway **spike** that proves whether Blanc can fill a web login form from a 1Password
+vault **without any browser extension** — the capability that would, if it works, reopen
+password-manager support that Blanc removed with the Chrome extension runtime. This is not a
+shipping feature; it is a de-risking experiment whose only output is a yes/no and a set of
+learnings. If it succeeds, a separate spec designs the real engine; if it fails, we document
+the dead end and stop. **The spike code must be removed (or gated out) before any release.**
+
+The spike does exactly one thing when triggered on a web page: look up 1Password Login items
+whose website matches the active tab's origin, and populate the page's username + password
+fields with a match — behind a Touch ID prompt.
+
+### Feasibility context (why this is the only path)
+
+Three research threads + a manual test settled the landscape (2026-07-12):
+
+- **Full autofill parity by integrating either vendor's *own* autofill is impossible without
+  a WebExtension runtime.** Both 1Password and Dashlane ship autofill only as a browser
+  extension, and no OS/Chromium hook injects a third-party manager's *passwords* into a
+  non-Safari browser's web content.
+- **⌘\ (1Password Universal Autofill) is empirically dead in Blanc** — tested live: it finds
+  the login and offers to fill, but the value never lands, because it fills from the *outside*
+  via macOS Accessibility, which Chromium web fields reject. There is no zero-code stopgap.
+- **The one viable storeless path is a Blanc-native engine that fills from the *inside*** —
+  Blanc already injects into its own `WebContentsView` (ad-block cosmetic filtering), so field
+  population is a solved capability. The **1Password JavaScript SDK** (`@1password/sdk`,
+  `DesktopAuth`) can read the user's *personal* vault behind biometrics from the Node/Electron
+  main process — confirmed one of three officially supported languages, and desktop-app auth
+  inherits the signed-in user's vault access (unlike service-account tokens, which can't reach
+  Personal/Private vaults). **Dashlane has no equivalent** (no desktop app, no personal-vault
+  SDK; only a read-only `dcli`), so it is out of scope for the spike.
+
+The spike validates the two unknowns that decide the full engine's worth:
+1. **Auth + read** — the JS SDK authenticates from Electron main (via its native desktop-app
+   bridge, see Architecture) and reads a matching personal-vault Login behind Touch ID, and that
+   native bridge survives a signed/hardened/notarized build.
+2. **Inside-injection** — Blanc populates a real, framework-controlled web field so the value
+   is retained (the exact move ⌘\ could not make).
+
+## Behavior
+
+Trigger: a **keyboard chord** (proposed **⌥⌘P**), enabled iff `!app.isPackaged ||
+process.env.BLANC_1P_SPIKE === '1'` — dev by default, plus an explicit opt-in for a packaged
+build **solely** for the signed-build fallback (see Risks); never active in a normal shipping
+build. Deliberately *not* the `/1password` slash command yet — that would publish an
+experimental, desktop-only command into the governed cross-platform slash-command substrate. A
+real `/1password` command is part of the *full engine*.
+
+On trigger, with an `http(s)` tab active:
+
+1. Blanc captures the triggering **window**, the tab id (`capturedTabId`), the tab's
+   **navigation epoch** (see Architecture), a **document-identity token** — the page's
+   `performance.timeOrigin`, read once at trigger via `executeJavaScript` (unique per document
+   load) — the **exact URL** `expectedURL = wc.getURL()`, and its **full origin**
+   `expectedOrigin = new URL(expectedURL).origin` (e.g. `https://github.com` — scheme + host +
+   optional port; *not* the bare hostname). The hostname for vault matching is derived from it
+   (`new URL(expectedOrigin).hostname`).
+2. It asks 1Password for **Login items whose stored website host matches** the expected origin's
+   hostname. This runs on *overviews* — no credential is decrypted (see Architecture). First use
+   in a session raises the 1Password desktop app's authorization prompt (Touch ID), naming the
+   requesting process and account.
+3. **Zero matches** → no-op (logged). **One match** → decrypt that one item and fill.
+   **Multiple matches** → a native chooser (`dialog.showMessageBox`, the pattern
+   [webauthn.js](../../../src/main/webauthn.js) already uses) lists the titles with a **Cancel**
+   button (`cancelId`); on selection the chosen item is decrypted and filled; on cancel/dismiss
+   it is a no-op (logged), mirroring `chooseWebAuthnAccount`'s return-undefined.
+4. Before injecting, Blanc **re-validates** (§Security): the captured window is still live and
+   focused, the captured tab still exists and is still active, its `webContents` is alive and
+   focused, its navigation epoch is unchanged, and `wc.getURL()` still **exactly** equals
+   `expectedURL` (which subsumes the origin check). It then injects; the injected function's **first
+   act is a synchronous check of `location.href === expectedURL && document.hasFocus() &&
+   performance.timeOrigin === capturedTimeOrigin`** — three complementary identity layers: a new
+   document (reload, cross-document nav) changes `timeOrigin`; an SPA `pushState`/`replaceState`
+   route change keeps `timeOrigin` and origin but changes `location.href`; a cross-origin nav
+   changes both. All run before touching any field. On a match the fields visibly populate and
+   retain their values.
+
+**Guard — explicit `http(s)`-only allowlist.** Only `http:`/`https:` origins proceed; everything
+else (`blanc://`, `file://`, `data:`, `view-source:`, blank new tab, …) is a no-op. (Private tabs
+*are* allowed — the SDK session is app-global; Blanc writes no history or store entry, though
+1Password keeps its normal session and user-auditing behavior.)
+
+## Architecture
+
+One new self-contained module plus **three** clearly-marked spike hooks in `main.js` (fill
+orchestrator, chord listener, packaging-smoke init). No IPC namespace, store, setting, preload, or
+renderer change. **Footprint:** adds `src/main/onepassword.js`, a unit test
+`test/unit/onepassword-match.test.js`, the three `main.js` hooks (the fill orchestrator also adds a
+small navigation-epoch counter to the tab's existing `did-navigate`/`did-navigate-in-page`
+handlers), and — in `package.json` / `package-lock.json` — an exactly-pinned `@1password/sdk@0.4.0`
+(plus its transitive `@1password/sdk-core`). See Risks re: whether an `asarUnpack` glob is even
+needed. That is the whole delta.
+
+- **`src/main/onepassword.js`** — owns the SDK client and *all* credential handling. The SDK is
+  **`require`d lazily** (only inside these functions / behind the env gate) so a normal packaged
+  startup never loads it.
+  - `async function getClient()` — lazily constructs and caches a client:
+    `createClient({ auth: new DesktopAuth(accountName), integrationName: 'Blanc',
+    integrationVersion: app.getVersion() })`, where `accountName = process.env.BLANC_1P_ACCOUNT`
+    (**required** — do not commit an account identifier). **Native path, not WASM:** when an
+    account name is present the SDK builder selects `SharedLibCore`, which `process.dlopen()`s
+    `/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib` (the native IPC
+    bridge inside the *installed* 1Password app) — the bundled `core_bg.wasm` is the
+    *service-account/token* path and is **not** used here. Only discard the cached client on an
+    **unrecoverable** failure; the SDK re-authorizes/retries an ordinary ~10-min session expiry
+    itself. Pin `@1password/sdk@0.4.0`.
+  - `async function findLogins(expectedHost)` — **matches on overviews; decrypts no
+    secret/credential.** `items.list(vaultId)` returns `ItemOverview`s, which — verified against
+    the SDK type (`ItemOverview.websites: Website[]`, each `Website` carrying `url`; `types.ts`
+    v0.4.0) — carry the item's website URLs; only the credential `fields` are absent (the overview
+    is decrypted metadata, but holds no secret). Flow: `vaults.list()` → for each accessible vault
+    `items.list(vaultId)` → keep `category === 'Login'` overviews → for each,
+    `matchesHost(overview.websites.map(w => w.url), expectedHost)`. Returns metadata only
+    (`{ vaultId, itemId, title }`). `matchesHost(itemUrls, host)` is a pure helper (unit-testable):
+    for each stored URL it extracts the hostname **tolerantly** — 1Password website fields are
+    often scheme-less (`github.com`), which `new URL()` rejects, so it prepends `https://` when no
+    scheme is present, and a still-malformed URL is skipped, not thrown — normalizes a leading
+    `www.` off both sides, and requires **exact host equality** (deliberately not substring —
+    `includes` would match `github.com.evil.com`).
+  - `async function revealCredential(vaultId, itemId)` — the **only** call that decrypts a secret,
+    run on exactly the one chosen item: `items.get(vaultId, itemId)` → from `item.fields[]` read
+    the **built-in** password (field `id === 'password'`, expected `fieldType === 'Concealed'`) and
+    username (field `id === 'username'`, expected `'Text'`). **No fieldType fallback** — a Login can
+    carry custom concealed fields (a PIN, a recovery answer), so "first `Concealed` field" could
+    return the wrong secret; if a built-in field is absent, return the defined missing-field outcome
+    rather than guess. Returns `{ username, password }` (either may be null → a defined outcome,
+    below). TOTP deferred to the full engine.
+- **`src/main/main.js`** — three hooks, each commented spike-only:
+  - `async function fillActiveTabFrom1Password()` — orchestrates the flow, **wrapped end-to-end in
+    try/catch** (logs the outcome only — *never* a credential). It captures the window,
+    `capturedTabId`, `expectedURL` + `expectedOrigin`, the document-identity `capturedTimeOrigin`
+    (read via `executeJavaScript`), and a **navigation epoch** — a per-tab counter bumped in the
+    tab's existing
+    `did-navigate` / `did-navigate-in-page` handlers **and on main-frame `did-start-navigation`** (so
+    a navigation that *begins* mid-flow is detectable, not only one that has completed;
+    [main.js:946/974](../../../src/main/main.js) + a new `did-start-navigation` increment).
+    Because auth/chooser are async, **re-validates before injecting**: the captured window is live
+    and focused (`!win.isDestroyed() && win.isFocused()` — do *not* abort merely because Touch ID
+    transiently blurred Blanc; require focus to have **returned** by fill time), the captured tab
+    exists and is active (`activeTabId === capturedTabId`), its `webContents` is alive
+    (`!isDestroyed()`), its epoch is unchanged, and `wc.getURL() === expectedURL` (exact URL, which
+    subsumes origin).
+    It injects via `executeJavaScript(source)` — single-arg (matching [main.js:637](../../../src/main/main.js));
+    **no `userGesture`** (setting `value` + events needs no activation, and `userGesture:true`
+    would grant the page transient activation for popups/downloads). The injected function: **(a)
+    first checks `location.href === EXPECTED_URL && document.hasFocus() && performance.timeOrigin ===
+    EXPECTED_TIME_ORIGIN` synchronously, aborting on mismatch** (the exact-URL + `timeOrigin` pair is
+    the in-page proof that this is still the captured document *and* route — `timeOrigin` alone would
+    miss an SPA `pushState` that keeps the document; together they close the same-origin race); (b)
+    finds the password field — first **visible** main-frame `input[type=password]`
+    (visible = `offsetParent !== null`, non-zero client rect, not `type=hidden`, skipping
+    honeypots); (c) finds the username — focused text/email element, else the visible text/email
+    input preceding the password field (in its form if any, else nearest preceding in document
+    order); (d) sets each via the **native setter**
+    (`Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set`) + bubbling
+    `input`/`change` events; (e) returns a **status object only**
+    (`{ originMismatch, filledUser, filledPass }`), never the values. `EXPECTED` and all credential
+    strings are embedded with `JSON.stringify`. **Every outcome logs one result line:**
+    matched+injected / no-match / origin-or-focus-mismatch / tab-or-window-changed abort /
+    chooser-cancel / auth-denied / inaccessible-vault / no-password-field / partial (password
+    filled, username missing → fill password only, don't abort) / injection-error.
+  - **A `before-input-event` listener attached to each tab's `wc` inside `createTab`**
+    ([main.js:865](../../../src/main/main.js), `wc = view.webContents`) — **not** the overlay
+    listener at [main.js:417](../../../src/main/main.js), which is bound to `overlayView` and never
+    sees keystrokes while page content has focus. Exact contract: `input.type === 'keyDown'`
+    (mirroring [main.js:418](../../../src/main/main.js) — without it, keyUp double-fires) **and**
+    `!input.isAutoRepeat` **and** the **physical** key `input.code === 'KeyP'` (on macOS ⌥ mutates
+    `input.key`, so `key === 'p'` may never fire) **and** exact modifiers `input.meta && input.alt
+    && !input.control && !input.shift` (note ⌥⌘P sits one modifier from the ⌘P Print accelerator at
+    [main.js:1781](../../../src/main/main.js)). A **module-level single-flight boolean** ignores a
+    second trigger until the current fill resolves, released in a `.finally()`. On match it calls
+    `fillActiveTabFrom1Password()` fire-and-forget (`.catch(log).finally(releaseFlag)`) and
+    `event.preventDefault()`. Enabled iff `!app.isPackaged || process.env.BLANC_1P_SPIKE === '1'`.
+  - **`initSpikeCoreSmoke()`** — startup hook, runs **only** when `process.env.BLANC_1P_SPIKE ===
+    '1'`. With the setup prerequisites satisfied (1Password running, integration on,
+    `BLANC_1P_ACCOUNT` set), it calls `getClient()` then a trivial `vaults.list()` in try/catch and
+    classifies **strictly**: **PASS** only if `createClient(DesktopAuth)` **and** `vaults.list()`
+    both succeed (matching criterion 3(b)); **INCONCLUSIVE** if the user cancels the biometric prompt
+    (the bridge state is unknowable); **FAIL** on every other error, logged with **sanitized**
+    diagnostics — an error referencing `dlopen` / `libop_sdk_ipc_client` / library-not-found /
+    code-signature is specifically the *native-bridge-didn't-load* failure, while auth/connection
+    errors are also FAIL (3(b) requires the round-trip to work). Never a credential in the log.
+
+**Security posture** (models Blanc's main-only secret handling — the supporter key and sync-crypto
+never cross into a renderer):
+
+- Credentials are **never** exposed to Blanc's chrome/overlay renderer, its preload bridges, its
+  logs, or any store. They live only in **main-process memory** — transiently — and are written
+  into the **verified active page** for the fill (inherent to any autofill). The accurate guarantee
+  is confinement to main + the verified page.
+- **Only the chosen item's credential fields are decrypted.** (Overviews are themselves decrypted
+  metadata — the precise claim is that *no secret* is decrypted during matching.) Matching runs on
+  `items.list()` overviews (website URLs present, credential `fields` absent); `items.get()` — the
+  only call returning a password — runs on the single selected item after selection. When done,
+  Blanc releases its reference and
+  does not intentionally cache the credential (best-effort; no memory-zeroization guarantee in
+  JS/the SDK).
+- **Origin/identity defense — layered, and honest about which layer is authoritative.** The
+  **unspoofable** authority is the main-side `wc.getURL()` (Chromium ground truth the page cannot
+  forge), re-checked for **exact-URL** equality before injection — but a main-side check followed by
+  `executeJavaScript` is **not atomic** (a navigation can slip in). The injected
+  `location.href`/`performance.timeOrigin`/`document.hasFocus()` check closes that TOCTOU race, but
+  runs in the page's **main world**, so a hostile *replacement* document could spoof those getters or
+  tamper the setter — it is best-effort, **not** the authoritative layer. Together they cover each
+  other's gap; main-world spoofing is an **accepted spike limitation** (a full engine could inject
+  into an isolated world).
+- **Window + tab + document identity re-validated, not assumed.** Because auth/chooser are async and
+  Blanc keeps tabs alive after a window closes, the fill requires the *originating window* still live
+  and focused, the same active tab, a live focused `webContents`, and an unchanged navigation epoch
+  (bumped on `did-start-navigation` too). A navigation that *begins* after the main-side check would
+  still let `executeJavaScript` run in the replacement/updated document, so the closing guarantee is
+  the injected **`location.href === expectedURL && performance.timeOrigin === captured`** pair: a new
+  document changes `timeOrigin`; an SPA `pushState`/`replaceState` route change (same document, so
+  `timeOrigin` alone would miss it) changes `location.href`; a cross-origin nav changes both.
+  (Subject to the accepted main-world spoofing limitation above.) Net: a credential is never filled
+  into a background/closed window, a switched tab, or a silently-navigated page.
+- **Native bridge under the hardened runtime.** DesktopAuth `process.dlopen()`s AgileBits' (Team-ID
+  ≠ Blanc's) `libop_sdk_ipc_client.dylib`; this is *entitlement-permitted* by Blanc's
+  `com.apple.security.cs.disable-library-validation` (present in both `build/entitlements.mac.plist`
+  and `.inherit.plist`) under `hardenedRuntime: true` — but must be proven in a notarized build
+  (criterion 3b).
+- **Main frame only.** Cross-origin iframes are not filled in the spike.
+
+## Non-goals (this is a spike; these are the *full engine's* work)
+
+- Sophisticated origin matching — subdomains, ports, public-suffix, IDN, redirects, and 1Password's
+  per-item `AnywhereOnWebsite`/`ExactDomain`/`Never` rules. The spike does a plain **exact
+  normalized-host** match (`www.`-stripped) against overview website URLs.
+- Isolated-world injection — the spike injects into the page main world and accepts the main-world
+  spoofing limitation above.
+- Robust login-vs-signup/change-password disambiguation — fills the first visible password field;
+  a combined form may fill the wrong field. Accepted; target a mainstream login page.
+- Save/update, TOTP, inline suggestions, cross-origin iframes, account-selection UX.
+- Any Dashlane path, settings UI, `/1password` slash command or substrate wiring.
+- Robustness across non-standard 1Password install locations (the dlopen path is hardcoded to the
+  standard `/Applications` bundle).
+
+## Setup prerequisites (one-time, before any run)
+
+- **1Password 8 installed at the standard path** (`/Applications/1Password.app` on macOS — the
+  native bridge is `dlopen`ed from inside it), running and unlocked.
+- In the app: **Settings → Developer → Integrate with the 1Password SDKs → Integrate with other
+  apps** (without it `DesktopAuth` cannot connect); **Settings → Security → Touch ID** for biometric
+  approval.
+- **`BLANC_1P_ACCOUNT`** env var set to the target account name/UUID (**required** — not committed).
+- Install and exactly pin: `npm i -E @1password/sdk@0.4.0`.
+
+## Success criteria
+
+1. On `https://github.com/login` (or any site with a matching Login), the chord → Touch ID prompt
+   (**first use per ~10-min SDK session**; a re-run within it fills with no prompt) → **both fields
+   populate and retain their values** via `npm start`.
+2. The SDK authenticates and reads a **personal/private-vault** item from Electron main.
+3. **The native bridge survives a real build** — two checks (per the SharedLibCore path):
+   - **(a)** `require('@1password/sdk')` resolves in a packaged app (module + any eagerly `require`d
+     WASM present). A quick `dist:dir` unpacked build suffices for this check.
+   - **(b)** a **truly notarized** distribution build — a `zip`/`dmg` target built under the repo's
+     notarization environment via an **explicit non-publishing** command
+     (`op run --env-file=.env.1password --no-masking -- npx electron-builder --mac zip --publish
+     never`), **not** `dist:dir` (which electron-builder treats as an unsigned/unnotarized unpacked
+     dev artifact) and **never `npm run release`** — that publishes an immutable GitHub release,
+     which conflicts with the spike-removal requirement. Verify the artifact
+     with `codesign --verify`, `spctl -a`, and `xcrun stapler validate`; then launch the
+     installed/extracted app with `BLANC_1P_SPIKE=1` and a throwaway `--user-data-dir` (so it never
+     touches the real profile or the single-instance lock). `initSpikeCoreSmoke()` →
+     `createClient(DesktopAuth)` + `vaults.list()` must log PASS — proving the `process.dlopen()` of
+     1Password's `libop_sdk_ipc_client.dylib` works under the hardened runtime +
+     `disable-library-validation` + **Gatekeeper/notarization**. This — not WASM packaging — is the
+     genuine unknown. The same flag also enables the chord in that build for the full auth+fill
+     fallback.
+
+A failure at (1) after (2) succeeds is decisive — inside-injection is harder than the ad-block
+precedent implies — **but only after ruling out the origin/host, focus, and field-detection details
+above**, so a silent no-op isn't misread as that signal.
+
+## Risks & open questions
+
+- **Native IPC bridge under the hardened runtime (the real packaging risk).** DesktopAuth
+  `process.dlopen()`s `/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib`
+  (AgileBits-signed, different Team ID). Permitted by Blanc's `disable-library-validation`
+  entitlement (verified in both plists) under `hardenedRuntime`, but **unproven** in a notarized
+  build + Gatekeeper, and a hard dependency on 1Password at the standard install path. Criterion
+  3(b) surfaces this. (`core_bg.wasm` is the *token* path, unused here; asarUnpack of it only
+  matters if `require('@1password/sdk')` eagerly resolves it — check 3(a).)
+- **Dev-process authorization.** In `npm start` the requesting process is unsigned `Electron`, not
+  `Blanc`; the desktop-app channel is human-in-the-loop, so it should still prompt, naming the dev
+  binary. If it refuses, run the full auth+fill against the signed `BLANC_1P_SPIKE=1` build (3b).
+- **SDK v0 API churn** — `vaults.list`/`items.list`/`items.get`/`ItemOverview.websites`/
+  `DesktopAuth`/`SharedLibCore` are per `@1password/sdk@0.4.0`; pin exactly, re-verify on bump.
+- **Field detection** — native-setter + events is standard, but selection can miss on non-standard
+  inputs or combined login/signup forms (see Non-goals); target a mainstream login page first.
+
+## Testing
+
+- **Unit — `test/unit/onepassword-match.test.js`** (pure, `node --test`, no Electron/SDK): cover
+  `matchesHost(itemUrls, host)` — exact match; `www.` vs bare; **scheme-less stored value**
+  (`github.com`) matches host `github.com`; **subdomain must NOT match** (`login.github.com` vs
+  `github.com`); substring trap (`github.com.evil.com` must NOT match); item with multiple URLs (one
+  matches); item with no URLs; a **malformed stored URL is skipped, not thrown**.
+- **Manual**, via a fresh `npm start` (chrome loads once at window creation — relaunch, don't ⌘R):
+  - `https://github.com/login` with a matching login → Touch ID → both fields fill.
+  - Two matching logins → chooser → pick fills; **Cancel** → no-op.
+  - No match → no-op (logged). `blanc://settings/`, `file://`, blank tab → no-op.
+  - **Double-press** fast → only one flow (keyDown + `!isAutoRepeat` + single-flight).
+  - **Same-document reload / cross-doc nav** mid-flow → `performance.timeOrigin` mismatch aborts.
+    **SPA `pushState` route change** mid-flow (same document, `timeOrigin` unchanged) → the
+    `location.href !== expectedURL` guard aborts.
+  - **Switch or close the tab/window** mid-flow → identity/focus re-check aborts; nothing written.
+  - **Touch ID blur then refocus** → the flow still fills (blur alone doesn't abort).
+- **Packaging** — 3(a): `require('@1password/sdk')` resolves in a `dist:dir` app. 3(b): a
+  **notarized** `zip`/`dmg` built with the explicit non-publishing command (`op run … electron-builder
+  --mac zip --publish never` — **never `npm run release`**), verified with `codesign`/`spctl`/`xcrun
+  stapler`, launched with `BLANC_1P_SPIKE=1` + throwaway `--user-data-dir` + desktop app running →
+  `initSpikeCoreSmoke` logs PASS only if `createClient(DesktopAuth)` + `vaults.list()` succeed
+  (INCONCLUSIVE on biometric cancel; FAIL otherwise). The flag also enables the chord for the
+  auth+fill fallback.
+
+## Findings (executed 2026-07-12)
+
+**Verdict: FEASIBLE.** Every success criterion passed. A Blanc-native engine that fills
+from the inside via the 1Password SDK is a viable path to storeless password-manager
+support. The spike code was removed after these findings were recorded (plan Task 6);
+the implementation plan (`docs/superpowers/plans/2026-07-12-1password-autofill-spike.md`)
+holds the working reference code in its Task 1–4 blocks.
+
+| Criterion | Result | Evidence |
+|---|---|---|
+| 1 — fill + retain via `npm start` | **PASS** | `[1p-spike] filled user+pass` on a real Login item (Instagram); both fields populated and retained, no form submission. Silent reuse within the ~10-min SDK session. |
+| 2 — SDK auth + vault read from Electron main | **PASS (with one caveat)** | `DesktopAuth` authorized via Touch ID (initial Task 3 fill) → `vaults.list`/`items.list` overview matching worked; only the chosen item decrypted and filled. **Caveat:** the filled Instagram item's specific vault (Personal/Private vs a shared vault) was **not separately confirmed**, so the "personal-vault" half is asserted from the SDK's design (desktop-app `DesktopAuth` inherits the signed-in user's Personal/Private access — the property that distinguishes it from service-account tokens) rather than directly observed. Confirm the item's vault before relying on the personal-vault claim in the full engine. |
+| 3(a) — packaged module + eager WASM | **PASS** | `[1p-spike] package probe: PASS (require resolved + WASM compiled)` from inside `app.asar`, exit 0 — on both the `dist:dir` and notarized bundles. **No `asarUnpack` needed.** |
+| 3(b) — native bridge under hardened runtime + notarization | **PASS** | Notarized/stapled arm64 build (`codesign` valid, `spctl` `Notarized Developer ID`, staple valid): `[1p-spike] core smoke: PASS (DesktopAuth + vaults.list)` — the `dlopen` of `libop_sdk_ipc_client.dylib` works under `disable-library-validation`. (The signed run reused a cached SDK authorization, so no fresh Touch ID prompt was raised on this launch — the prompt's process-name attribution in a signed build was **not** observed here.) |
+| Signed-build end-to-end fill (optional) | **PASS** | `[1p-spike] filled user+pass` in the notarized build. |
+| Quarantined first-open | **PASS** | Pristine extraction + `com.apple.quarantine` + LaunchServices `open` → launched with no Gatekeeper block (under App Translocation, isolated profile). |
+
+**Untested** (missing fixtures / un-hittable timing windows — guards stand on code review):
+multi-match chooser + Cancel; reload/SPA/tab-switch/window-close mid-auth; Touch ID
+blur-refocus. Exercise these early in the full engine's test plan.
+
+**Learnings for the full engine:**
+- `SharedLibCore` is *not* a public export of `@1password/sdk@0.4.0` — it lives in
+  `dist/shared_lib_core.js`, selected internally by `client_builder.js` when `DesktopAuth`
+  is used. Never referenced directly; re-verify on any SDK bump.
+- The eager `core_bg.wasm` compile loads fine from inside asar — no unpack config, ever,
+  unless an SDK bump changes the loading strategy (the headless probe detects that).
+- A blank new tab is a *silent* no-op for a tab-`wc` chord: Blanc parks focus in the
+  address overlay, which has no listener. A real engine wanting the shortcut to work there
+  must also listen on the overlay's webContents (or use a menu accelerator).
+- `op run` authorization for the notarization env is human-gated and times out unattended —
+  run the packaging build attended.
+- Shell/exec gotchas that bit during execution: `status` is read-only in zsh (use `rc=$?`);
+  piping the build through `tail` swallowed a real failure exit; `codesign`/`spctl`/`stapler`
+  falsely report invalid inside a sandboxed/restricted shell (macOS trust services
+  unavailable) — verify from a normal shell.
+- ⌘\ Universal Autofill remains dead in Blanc (outside-in via Accessibility); the inside
+  path is the only one, as the feasibility context predicted.

--- a/docs/superpowers/specs/2026-07-12-1password-fill-matching-improvements-design.md
+++ b/docs/superpowers/specs/2026-07-12-1password-fill-matching-improvements-design.md
@@ -1,0 +1,289 @@
+# 1Password fill — subdomain + multi-step matching improvements
+
+**Date:** 2026-07-12
+**Status:** Ready for planning (rev. 4 — after three security-review rounds; planning deferred)
+**Branch:** `feature/1password-fill` (builds on the feasibility spike)
+
+## What
+
+Two improvements to Blanc's 1Password fill so it works on more real logins:
+
+1. **Subdomain matching** — an item saved for `google.com` fills on
+   `accounts.google.com` (any `*.google.com`), not only an exact-host page.
+2. **Multi-step logins** — on a username-first screen with no password field yet,
+   `⌥⌘P` fills the username; the second press on the password screen fills the
+   password. Stateless — no credential is held across the navigation.
+
+**Scope note:** improves the **personal dev build**, not the shippable engine.
+Unaffected by the §4.1(e) question
+([`1password-legal-inquiry.md`](../../1password-legal-inquiry.md)): 1Password
+replied 2026-07-17 that they don't pre-approve compliance (no prohibition stated,
+no ruling either way), and **distribution is shelved — personal-only**. Local use
+against one's own vault was never in question. Retains `SPIKE` framing and dev
+env-gating.
+This revision pulls **isolated-world injection** forward from the real-engine
+backlog because the two-phase design below only delivers its security value there.
+
+## Part 1 — Subdomain matching (`src/main/onepassword.js`)
+
+Match on **registrable domain (eTLD+1)** via `tldts-experimental`'s `getDomain`
+**with `allowPrivateDomains: true`**:
+
+- Each host (page + each stored item URL) reduces to its registrable domain;
+  compare for equality.
+  - `accounts.google.com` ↔ item `google.com` → both `google.com` → **match**.
+  - `www.github.com` ↔ `github.com` → **match** (subsumes the `www.` strip).
+  - `github.com.evil.com` vs `github.com` → `evil.com` ≠ `github.com` → **no match**.
+- **`allowPrivateDomains: true` is required.** With the default, `getDomain`
+  collapses PSL *private* suffixes — `user.github.io` → `github.io` — so
+  `alice.github.io` and `bob.github.io` both become `github.io` and
+  **cross-match** (`github.io`, `vercel.app`, `pages.dev`, `herokuapp.com`,
+  `appspot.com`, …). With the flag, `user.github.io` → `user.github.io`. Verified
+  against the pinned `tldts-experimental@7.4.6`; the flag doesn't change ICANN
+  cases (`google.com`, `co.uk`, the `evil.com` trap).
+- **Fallback:** `getDomain` returns `null` for hosts with no suffix (`localhost`,
+  raw IPs, single-label intranet names) — fall back to exact normalized-host
+  equality. Match key: `getDomain(host, { allowPrivateDomains: true }) || host`.
+
+**Behavior (intended):** an item for a bare registrable domain fills across all
+its subdomains, symmetric — 1Password's default "anywhere on website" breadth.
+The multi-match chooser covers several matches; it does **not** mitigate a single
+wrong match, so the PSL flag is load-bearing.
+
+```js
+const { getDomain } = require('tldts-experimental');
+
+// `host` is already normalized by normalizeHost (lowercased, www-stripped).
+function registrableKey(host) {
+  return getDomain(host, { allowPrivateDomains: true }) || host;
+}
+
+function matchesHost(itemUrls, host) {
+  const targetHost = normalizeHost(host);
+  if (!targetHost || !Array.isArray(itemUrls)) return false;
+  const targetKey = registrableKey(targetHost);
+  return itemUrls.some((u) => {
+    const h = normalizeHost(u);
+    return h != null && registrableKey(h) === targetKey;
+  });
+}
+```
+
+`normalizeHost` unchanged. **Dependency:** promote `tldts-experimental` to a
+**direct** dependency, pinned to the tree's resolved `7.4.6` (same physical copy).
+
+## Part 2 — Multi-step fill: two-phase, isolated-world, least-privilege
+
+The fill runs in **two isolated-world injections** so (a) the password is sent to
+the renderer only *after* inspection observes a password field — and written only
+if the isolated fill pass still finds one — and (b) the credential and the
+selection/setter logic live in a JS realm the page cannot hook or scrape.
+
+**Isolated world.** Both injections use
+`wc.executeJavaScriptInIsolatedWorld(FILL_WORLD_ID, [{ code }])`, not
+`executeJavaScript`. **`FILL_WORLD_ID = 1001`** — a dedicated custom world;
+`0` (main world) and `999` (Electron's context-isolation / preload world) are
+**forbidden**, and Electron recommends custom isolated worlds at id ≥ 1000
+([docs](https://www.electronjs.org/docs/latest/api/web-contents#contentsexecutejavascriptinisolatedworldworldid-scripts-usergesture)).
+The page's main-world JS cannot observe or tamper the isolated realm's intrinsics
+(`Object.getOwnPropertyDescriptor`, the `HTMLInputElement` value setter) or read
+the embedded credential.
+
+**Accurate guarantee (not overclaimed).** Isolation protects the credential and
+the decision/setter logic **up to the intended DOM write**. Once Blanc writes the
+value into the field, the page can read that field — inherent to *every* autofill;
+isolation does **not** make a populated field secret from its own page. What it
+does secure: an unused credential (e.g. a password on a username-only step) is
+never written and stays in the isolated realm, and the page cannot hijack the
+selection/setter to redirect or capture the write.
+
+**Flow** (matching + item selection happen before this, as today — `findLogins`
+→ chooser if needed → a chosen item):
+
+1. **Inspect (credential-free, isolated world).** Run the identity guard, collect
+   candidate inputs, run the shared `selectFields`, return booleans only:
+   `{ originMismatch } | { originMismatch: false, hasPassword, hasUsername }`.
+   `originMismatch` → `origin-or-focus-mismatch`; `!hasPassword && !hasUsername`
+   → `no-fillable-field` — **and nothing is decrypted** in that case.
+2. **Reveal (main process).** Only now, with a fillable field confirmed, call
+   `revealCredential(chosen)` — the sole decrypt.
+3. **Re-validate.** After the reveal await, re-check the full identity set
+   (live+focused window, same active tab, live+focused webContents, unchanged
+   `navEpoch`, exact `wc.getURL() === expectedURL`) before the second injection.
+4. **Decide (main process).** `sendPass = hasPassword ? password : null`,
+   `sendUser = hasUsername ? username : null`. On a username-only step the
+   password is never sent to the renderer.
+5. **Fill (isolated world).** Inject with only the non-null credentials. It
+   re-runs the identity guard, then **synchronously** re-runs `selectFields` and
+   sets the fields in the same execution — page JS gets no window between select
+   and set to mutate the DOM or hook the setter. If the expected field is absent
+   (DOM changed since inspect), the credential is simply not written; it never
+   leaves the isolated realm. Returns `{ originMismatch, filledUser, filledPass }`.
+
+**Everything from the reveal (step 2) onward runs inside the binding-less catch
+→ fixed `fill-error`** — once a credential is in main-process memory, no failure
+path may log a page- or SDK-controlled message. (Pre-reveal errors keep the
+detailed `setup-error` line, as today.)
+
+### Shared field logic — pure `selectFields`, embedded by `.toString()`
+
+The decision lives in **one pure function**, unit-tested and identical in both
+injections. `isVisible`, `isSearchLike`, `isNewsletterLike`, `loginEvidence`,
+`collectCandidates` (thin DOM adapter), and `selectFields` are defined once at
+module scope; both injected scripts embed their source via
+`Function.prototype.toString()`, so tested code == shipped code. `selectFields`
+is exported for tests.
+
+- **`collectCandidates()`** (DOM adapter, in page) — ordered array of `input`
+  descriptors in document order:
+  `{ i, type, autocomplete, name, id, placeholder, ariaLabel, formKey, isVisible, isFocused, inSearchScope }`.
+  `type`/`autocomplete` lowercased; `isVisible` = `offsetParent !== null` +
+  non-zero client rect + not `type="hidden"`; `isFocused` = `=== document.activeElement`;
+  `inSearchScope` = inside a `[role="search"]`. **`formKey`** = a stable index
+  assigned per distinct `input.form` **element identity** via a
+  `Map<HTMLFormElement, number>` (`null` when `input.form` is null) — *not*
+  `form.id`, since forms may lack ids or share them.
+- **`selectFields(cands)`** (pure) → `{ passwordIndex, usernameIndex }` (either
+  may be `null`). Helpers over a lowercased `name+id+autocomplete+placeholder+ariaLabel`
+  blob:
+  - `isSearchLike` — `type==='search'`, `inSearchScope`, blob **contains**
+    `search`/`query` (substring, so camelCase `siteSearch`/`queryInput` are
+    caught), or `name`/`id` exactly `q`/`s`.
+  - `isNewsletterLike` — blob contains `newsletter`/`subscribe`/`marketing`/`promo`.
+  - `loginEvidence` → `strong` if `autocomplete==='username'` or blob matches
+    `/user(name)?|login|account|identifier|loginfmt/`; `medium` if `type==='email'`,
+    `autocomplete==='email'`, or blob contains `email`; else `null`.
+  - `candidate` = visible `text`/`email`/`tel`, **not** search-like, **not**
+    newsletter-like.
+  - **`passwordIndex`** = first visible `type==='password'`.
+  - **`usernameIndex`**:
+    - *Password present* (single-page / password step): define the password's
+      **scope** = candidates sharing the password's `formKey` (when it is
+      non-null); if the password has no form (`formKey` null), scope =
+      candidates also with `formKey` null. Within that scope: the focused
+      candidate **if it is in scope**, else the nearest scope candidate preceding
+      the password in document order. A focused field *outside* the password's
+      form is **not** used — otherwise Blanc could type the username into an
+      unrelated field while filling the login form's password.
+    - *No password* (username step): from candidates with `loginEvidence != null`
+      (call them *positives*) — **no lone-field fallback, no bare guessing**:
+      `pool` = the `strong` positives if any, else all positives; if `pool` has
+      exactly one → it; if `pool` has more than one → the focused one **if it is
+      in `pool`**, else `null` (ambiguous → no-op). Focus is only a tie-break
+      among positives.
+
+### Orchestrator outcome map (`fillActiveTabFrom1Password` in `main.js`)
+
+- inspect `originMismatch` → `origin-or-focus-mismatch`
+- inspect `!hasPassword && !hasUsername` → `no-fillable-field`
+- re-validation fails → the existing `abort-*` line
+- fill `originMismatch` → `origin-or-focus-mismatch`
+- `filledPass && filledUser` → `filled` `user+pass`
+- `filledUser && !filledPass` → `filled` `user-only (multi-step step 1)`
+- `filledPass && !filledUser` → `filled` `pass-only (username field not found)`
+- otherwise → `nothing-filled`
+
+Unchanged: `revealCredential` decrypts only the chosen item (and now only after
+inspection confirms a fillable field); fill never submits; the password is sent to
+the renderer only after inspection observes a password field and written only if
+the isolated fill pass still finds one; credentials are never logged.
+
+## Footprint
+
+- **`src/main/onepassword.js`** — `matchesHost` (registrable-domain key +
+  private-domains flag); `tldts-experimental` require + `registrableKey`; shared
+  DOM helpers + pure `selectFields` (+ export); `buildInspectScript` (new,
+  credential-free); `buildFillScript` (rewritten: `collectCandidates` +
+  `selectFields`, synchronous select+set, fill only provided creds).
+- **`src/main/main.js`** — `fillActiveTabFrom1Password`: isolated-world inspect →
+  reveal → re-validate → decide → isolated-world fill; the outcome map above; the
+  `FILL_WORLD_ID = 1001` constant.
+- **`test/unit/onepassword-match.test.js`** — matching + `selectFields`
+  behavioral cases (below).
+- **`package.json` / `package-lock.json`** — pinned `tldts-experimental@7.4.6`.
+
+## Non-goals (unchanged — real-engine backlog)
+
+Shadow-DOM piercing, cross-origin iframes, auto-advance across the multi-step
+navigation (stateless — per-press), TOTP, and 1Password's per-item
+`AnywhereOnWebsite`/`ExactDomain`/`Never` rules.
+
+## Testing
+
+**Unit — `test/unit/onepassword-match.test.js`** (`node --test`, pure):
+
+- **`matchesHost`:** exact; `www.` both ways; **subdomain matches**
+  (`accounts.google.com` ↔ `google.com`); deep-subdomain ↔ parent; substring trap
+  still **fails**; **cross-tenant private domains must NOT match**
+  (`alice.github.io` vs `bob.github.io`; two `*.vercel.app`); `foo.co.uk` vs
+  `bar.co.uk` no match; **localhost + raw-IP fallback**; no URLs; malformed URL
+  skipped.
+- **`selectFields`** (pure, descriptor fixtures — the behavioral core):
+  - single-page login (username + password) → both indices.
+  - password step, no username → password only.
+  - username step, `autocomplete="username"` → that field.
+  - Google/Microsoft style (`type=email` + `autocomplete=username` / `name=loginfmt`)
+    → that field.
+  - **focused *generic* text field, no login evidence** → username `null` (focus
+    is not evidence).
+  - **camelCase search** (`id="siteSearch"`, `name="queryInput"`) focused → `null`.
+  - **focused candidate in a *different* form than the password** → username
+    resolves within the password's form scope, **not** the focused field.
+  - **sole newsletter email** (`id="newsletter-email"`) → `null`.
+  - **login email + newsletter email** → login email (newsletter excluded).
+  - **two positive emails, neither strong, none focused** → `null` (ambiguous).
+  - **two anonymous forms** (login form + newsletter form, both no `id`) →
+    password's username resolves within the **same** `formKey`, not the newsletter
+    field.
+  - hidden/honeypot inputs (`isVisible:false`) → ignored.
+- **`buildInspectScript` / `buildFillScript`** (string assertions, secondary):
+  inspect source carries **no** credential literal; fill source JSON-embeds only
+  provided creds, contains the identity guard + native setter; both embed the same
+  `selectFields`/`collectCandidates` source.
+- **`FILL_WORLD_ID` constant** — assert it is `1001` (or at least `≥ 1000` and
+  neither `0` nor `999`), so a refactor can't silently move the fill into the main
+  or preload world.
+
+**Manual** (fresh `npm start` with `BLANC_1P_ACCOUNT`):
+- `accounts.google.com`, item for `google.com` → `filled user-only`; next screen
+  → password fills.
+- Single-page login on a subdomain of a saved item → `filled user+pass`.
+- Search-only page → `no-fillable-field`.
+- **React/framework page** (e.g. a React or Vue login) → the native-setter +
+  bubbling `input`/`change` events are observed, the value **sticks** through the
+  framework's controlled-input tracking, and submit uses the filled value.
+- **DOM replacement between phases** — after triggering, script-remove the
+  password form before the fill pass; confirm the password is **not** written and
+  no `[1p-spike]` line leaks a value (isolated-realm containment).
+- Regression: exact-host single-page login → `filled user+pass`; `localhost`/IP
+  dev login still matches.
+
+## Risks / edge cases
+
+- **Cross-tenant over-match** — **mitigated for PSL-listed private suffixes** by
+  `allowPrivateDomains: true` (verified: `user.github.io` → `user.github.io`). It
+  cannot guarantee every shared-hosting domain is PSL-registered; an unlisted
+  shared host could still collapse. A single wrong match fills silently (no
+  chooser), so this is load-bearing — covered by the cross-tenant unit tests.
+- **`tldts-experimental` currently transitive** — promoting to a direct pinned
+  dependency removes the adblocker-bump risk.
+- **Isolated-world return plumbing** — `executeJavaScriptInIsolatedWorld` returns
+  `Promise<any>` and, like `executeJavaScript`, resolves with the completion value
+  of a single `WebSource` ending in the status-object expression, so it should
+  round-trip directly. The plan verifies this with a throwaway probe in its first
+  isolated-world step; if the result is unexpectedly `undefined`, the flow **fails
+  closed as `fill-error`** — no persistent cross-call sentinel state (which could
+  go stale across navigation).
+- **Inspect→fill DOM race** — closed for credential exposure by isolated-world +
+  synchronous select-then-set: if the field vanishes, the credential is not
+  written and never leaves the isolated realm. Residual (inherent to all
+  autofill): once written, a populated field is readable by its own page.
+- **DOM adapter not unit-tested** — `collectCandidates` needs a browser; covered
+  by the manual matrix. The security-critical *decision* (`selectFields`) is fully
+  unit-tested. jsdom is not used (its no-layout `offsetParent`/`getBoundingClientRect`
+  make visibility fixtures unreliable).
+- **Username heuristic residual** — search + newsletter exclusion, login-positive
+  evidence required, focus only an in-scope tie-break, no lone-field guess. This
+  makes a wrong-field fill unlikely but **not impossible** (e.g. a page whose
+  login form genuinely contains a mislabeled extra input); the common failure mode
+  is a no-op, and the fixtures cover the known traps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.7",
       "license": "UNLICENSED",
       "dependencies": {
+        "@1password/sdk": "0.4.0",
         "@ghostery/adblocker-electron": "^2.18.1",
         "electron-updater": "^6.8.9"
       },
@@ -20,6 +21,21 @@
         "playwright": "^1.49.0",
         "sharp": "^0.35.3"
       }
+    },
+    "node_modules/@1password/sdk": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@1password/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-RIypujc9R/UeUaobjyClTYokqRFpcaIkHq+EO/X9XoHId98Vg+SbjwGV+yygRC4MyHwYNo1KP1iEbZcqJ4ZTdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@1password/sdk-core": "0.4.0"
+      }
+    },
+    "node_modules/@1password/sdk-core": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@1password/sdk-core/-/sdk-core-0.4.0.tgz",
+      "integrity": "sha512-vjeI1o4wiONY+t1naA4dtUp6HktdLH1D2S+tN1Lh4l41S9XIUHxrljov9B5u6G+VHr7f2MUoxmzXA9zT3aokQQ==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "sharp": "^0.35.3"
   },
   "dependencies": {
+    "@1password/sdk": "0.4.0",
     "@ghostery/adblocker-electron": "^2.18.1",
     "electron-updater": "^6.8.9"
   },

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1416,6 +1416,147 @@ const TAB_WEB_PREFERENCES = {
   preload: path.join(__dirname, 'tab-preload.js'),
 };
 
+// ─── SPIKE (1Password fill feasibility) — remove before release ───────────
+// Fill the active tab's login form from 1Password behind Touch ID, with no
+// browser extension. Env-gated; credentials live only in main memory + the
+// verified page, and every outcome logs a result line, never a value.
+const ONE_PASSWORD_SPIKE_ENABLED = !app.isPackaged || process.env.BLANC_1P_SPIKE === '1';
+let onePasswordFillInFlight = false;
+
+async function fillActiveTabFrom1Password() {
+  const log = (result, extra) => console.log(`[1p-spike] ${result}${extra ? ' ' + extra : ''}`);
+  const onepassword = require('./onepassword'); // ./onepassword only — the SDK stays lazy inside it
+  let capturedTabId, tab, wc, expectedURL, expectedHost, capturedEpoch, capturedTimeOrigin, chosen;
+
+  // ── PHASE 1 (pre-reveal): NO credential is in memory yet, so err.message is
+  //    safe to log for diagnosis. ──
+  try {
+    if (!hasLiveWindow() || !activeTabId) return log('no-active-tab');
+    capturedTabId = activeTabId;
+    tab = tabs.get(capturedTabId);
+    if (!tab) return log('no-active-tab');
+    wc = tab.view.webContents;
+    expectedURL = wc.getURL();
+    if (!/^https?:\/\//i.test(expectedURL)) return log('non-http-noop');
+    expectedHost = new URL(expectedURL).hostname;
+    capturedEpoch = tab.navEpoch;
+    capturedTimeOrigin = await wc.executeJavaScript('performance.timeOrigin');
+
+    const matches = await onepassword.findLogins(expectedHost);
+    if (matches.length === 0) return log('no-match', expectedHost);
+    chosen = matches[0];
+    if (matches.length > 1) {
+      // The vault search was async — if the window died meanwhile, don't ask
+      // the user to choose a login for a window that no longer exists (the
+      // post-reveal re-validation would abort anyway). Also keeps `win` safe
+      // to pass as the dialog parent (documented overloads only).
+      if (!hasLiveWindow()) return log('abort-window-changed');
+      const buttons = matches.map((m) => m.title || '(untitled)');
+      const cancelId = buttons.length;
+      buttons.push('Cancel');
+      const { response } = await dialog.showMessageBox(win, {
+        type: 'question',
+        title: 'Fill from 1Password',
+        message: `Choose a login for ${expectedHost}`,
+        buttons,
+        cancelId,
+        noLink: true,
+      });
+      if (response < 0 || response >= matches.length) return log('chooser-cancel');
+      chosen = matches[response];
+    }
+  } catch (err) {
+    return log('setup-error', err?.message); // pre-reveal only — credential-free
+  }
+
+  // ── PHASE 2 (reveal + fill): a credential is in memory from revealCredential
+  //    onward. This whole block is a BINDING-LESS try — every failure (a
+  //    page-controlled executeJavaScript rejection, OR any other throw once the
+  //    credential exists) logs a FIXED classification, so no error string can
+  //    ever echo the credential. ──
+  try {
+    const { username, password } = await onepassword.revealCredential(chosen.vaultId, chosen.itemId);
+    if (password == null && username == null) return log('empty-item');
+
+    // Re-validate after the async auth/chooser: same live+focused window, same
+    // active tab, live+focused webContents, unchanged epoch, exact same URL.
+    if (!hasLiveWindow() || !win.isFocused()) return log('abort-window-changed');
+    if (activeTabId !== capturedTabId || !tabs.has(capturedTabId)) return log('abort-tab-changed');
+    if (wc.isDestroyed() || !wc.isFocused()) return log('abort-wc-changed');
+    if (tab.navEpoch !== capturedEpoch) return log('abort-navigated');
+    if (wc.getURL() !== expectedURL) return log('abort-url-changed');
+
+    // Injection runs in the page's MAIN WORLD (a hostile page could override the
+    // value setter to throw an Error echoing the value) — the binding-less catch
+    // below is what makes that message unloggable.
+    const source = onepassword.buildFillScript({ expectedURL, expectedTimeOrigin: capturedTimeOrigin, username, password });
+    const status = await wc.executeJavaScript(source); // single-arg, no userGesture
+    if (status?.originMismatch) return log('origin-or-focus-mismatch');
+    if (status?.noPasswordField) return log('no-password-field');
+    if (status?.filledPass && status?.filledUser) return log('filled', 'user+pass');
+    if (status?.filledPass) return log('filled', 'pass-only (username field not found)');
+    return log('nothing-filled');
+  } catch {
+    return log('fill-error'); // no binding, no message — a credential is in memory
+  }
+}
+
+// SPIKE (1Password fill feasibility) — headless criterion 3(a). Gated on its
+// OWN env var so it can run without a GUI/account: load the SDK package inside
+// packaged Electron (asar resolution + @1password/sdk-core's eager core_bg.wasm
+// compile), log ONE line, set a real exit code, and terminate. app.exit() is
+// used (not app.quit()) so native handles the SDK may open can't stall exit.
+async function runPackageProbeIfRequested() {
+  if (process.env.BLANC_1P_PACKAGE_PROBE !== '1') return false;
+  try {
+    require('./onepassword').probePackageLoad();
+    console.log('[1p-spike] package probe: PASS (require resolved + WASM compiled)');
+    app.exit(0);
+  } catch (err) {
+    console.warn(`[1p-spike] package probe: FAIL — ${err?.message || err}`);
+    app.exit(1);
+  }
+  return true; // unreachable after app.exit; kept for call-site clarity
+}
+
+// SPIKE (1Password fill feasibility) — GUI startup checks. Gated
+// BLANC_1P_SPIKE === '1'. Two independent lines:
+//   3(a) package probe — does the SDK module LOAD in this build?
+//   3(b) core smoke    — does DesktopAuth dlopen + authenticate under a
+//                        notarized/hardened build?
+async function initSpikePackaging() {
+  if (process.env.BLANC_1P_SPIKE !== '1') return;
+
+  // 3(a): load the package (asar loader active, eager core_bg.wasm compile).
+  try {
+    require('./onepassword').probePackageLoad();
+    console.log('[1p-spike] package probe: PASS (require resolved + WASM compiled)');
+  } catch (err) {
+    console.warn(`[1p-spike] package probe: FAIL — ${err?.message || err}`);
+  }
+
+  // 3(b): the native bridge round-trip. Decisive by default — everything is a
+  // FAIL unless it matches the biometric-cancel signature (/cancell?ed/i), a
+  // best-effort INCONCLUSIVE (bridge state then unknowable). "denied"/"not
+  // allowed"/policy/auth errors are real FAILs (the round-trip did not work). A
+  // genuine cancel misread as FAIL isn't worth chasing for throwaway code — just
+  // re-run the smoke without cancelling.
+  try {
+    const client = await require('./onepassword').getClient();
+    await client.vaults.list();
+    console.log('[1p-spike] core smoke: PASS (DesktopAuth + vaults.list)');
+  } catch (err) {
+    const msg = err?.message || String(err);
+    if (/cancell?ed/i.test(msg)) {
+      console.log(`[1p-spike] core smoke: INCONCLUSIVE (biometric cancelled) — ${msg}`);
+    } else {
+      const bridge = /dlopen|libop_sdk_ipc_client|image not found|code ?sign|library/i.test(msg);
+      console.warn(`[1p-spike] core smoke: FAIL${bridge ? ' (native bridge did not load)' : ''} — ${msg}`);
+    }
+  }
+}
+// ─── end SPIKE ────────────────────────────────────────────────────────────
+
 function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = null, view = null, pinned = false, muted = false, restoreHistory = null } = {}) {
   if (isUtilityUrl(url)) {
     // Utility pages never become tabs regardless of caller (external
@@ -1473,12 +1614,32 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
     // real navigation shouldn't behave differently from before this flag
     // existed.
     historyEligible: true,
+    // SPIKE (1Password fill feasibility) — bumped on any main-frame navigation
+    // start/commit so the async fill can detect a page swap mid-flow.
+    navEpoch: 0,
   };
   tabs.set(id, tab);
   tabOrder.push(id);
 
   const wc = view.webContents;
   installChromeShortcuts(wc);
+  // SPIKE (1Password fill feasibility) — ⌥⌘P on the tab's OWN webContents
+  // (the overlay before-input-event listener never sees page-focused keys).
+  if (ONE_PASSWORD_SPIKE_ENABLED) {
+    wc.on('before-input-event', (event, input) => {
+      if (input.type !== 'keyDown' || input.isAutoRepeat) return;
+      if (input.code !== 'KeyP') return; // physical key — ⌥ mutates input.key on macOS
+      if (!(input.meta && input.alt && !input.control && !input.shift)) return; // one modifier off ⌘P Print
+      // Consume the chord BEFORE the single-flight check — a recognized second
+      // press must not fall through to the page, it just doesn't start a fill.
+      event.preventDefault();
+      if (onePasswordFillInFlight) return; // single-flight
+      onePasswordFillInFlight = true;
+      fillActiveTabFrom1Password()
+        .catch((err) => console.warn('[1p-spike] fill error:', err?.message))
+        .finally(() => { onePasswordFillInFlight = false; });
+    });
+  }
   // WebRTC IP-handling policy applies per-webContents; this is the single choke
   // point every tab (fresh or adopted window.open child) passes through.
   wc.setWebRTCIPHandlingPolicy(webrtcPolicyFor(settings.getSettings().webrtcPolicy));
@@ -1525,6 +1686,7 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
     scheduleBroadcastTabs();
   });
   wc.on('did-navigate', (_e, url, httpResponseCode) => {
+    tab.navEpoch++; // SPIKE (1Password fill feasibility)
     const shouldReclaimChromeFocus = url === tab.url && tabsWantingAddressBarFocus.has(id) && activeTabId === id;
     if (url !== tab.url) tabsWantingAddressBarFocus.delete(id);
     tab.blockedCount = 0;
@@ -1553,6 +1715,7 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
     if (shouldReclaimChromeFocus) reclaimAddressBarFocus(id);
   });
   wc.on('did-navigate-in-page', (_e, url, isMainFrame) => {
+    if (isMainFrame) tab.navEpoch++; // SPIKE (1Password fill feasibility) — main frame only
     syncNavState();
     if (isMainFrame && tab.historyEligible) history.addVisit(url, wc.getTitle());
     broadcastTabs();
@@ -1562,6 +1725,13 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
     // frequent on SPA-heavy sites (exactly the rebuild-storm case Task 1
     // avoids). The menu may lag slightly behind in-page route changes;
     // it catches up on the next real navigation or tab-lifecycle event.
+  });
+  // SPIKE (1Password fill feasibility) — a main-frame navigation that STARTS
+  // after the orchestrator's main-side URL check would still let
+  // executeJavaScript run in the replacement document; bump the epoch so the
+  // pre-injection re-check aborts. Removed with the rest of the spike.
+  wc.on('did-start-navigation', (_e, _url, _isInPlace, isMainFrame) => {
+    if (isMainFrame) tab.navEpoch++;
   });
   wc.once('did-finish-load', () => {
     if (shouldReclaimAddressBarFocus(id)) {
@@ -2878,6 +3048,7 @@ let lastSecureDns = null;
 let lastSecureDnsTemplate = null;
 
 app.whenReady().then(async () => {
+  if (await runPackageProbeIfRequested()) return; // SPIKE — headless 3(a); app.exit() already fired
   const ses = session.defaultSession;
   const privateSes = getPrivateBrowsingSession();
   const browsingSessions = [ses, privateSes];
@@ -3090,6 +3261,8 @@ app.whenReady().then(async () => {
       getChromeUrl: () => win?.webContents.getURL() ?? '',
     });
   }
+
+  initSpikePackaging(); // SPIKE (1Password fill feasibility) — fire-and-forget, gated on BLANC_1P_SPIKE
 
   // Per-tab blocked-request counter. `request.tabId` is the webContents id
   // of the frame the request came from.

--- a/src/main/onepassword.js
+++ b/src/main/onepassword.js
@@ -1,0 +1,152 @@
+// SPIKE (1Password fill feasibility) — throwaway; MUST be removed before any
+// release (plan Task 6 — env-gating alone is not release-safety). This module
+// owns the 1Password SDK client and ALL credential handling. `@1password/sdk`
+// is require()d lazily so a normal packaged startup never loads it.
+
+/** Extract a comparable hostname from a possibly scheme-less / malformed
+ * stored 1Password website value. `www.`-stripped. Returns null on garbage
+ * (caller skips it — never throws). */
+function normalizeHost(value) {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(value) ? value : `https://${value}`;
+  let host;
+  try {
+    host = new URL(withScheme).hostname;
+  } catch {
+    return null; // still malformed after prepending a scheme
+  }
+  if (!host) return null;
+  return host.replace(/^www\./i, '').toLowerCase();
+}
+
+/** True iff any of a Login item's stored website URLs resolves to `host`
+ * (both sides `www.`-stripped, EXACT equality — deliberately not substring,
+ * so `github.com.evil.com` cannot match `github.com`). */
+function matchesHost(itemUrls, host) {
+  const target = normalizeHost(host);
+  if (!target || !Array.isArray(itemUrls)) return false;
+  return itemUrls.some((u) => normalizeHost(u) === target);
+}
+
+/** Build the IIFE source injected via executeJavaScript(source). All four
+ * inputs are embedded with JSON.stringify (credential strings included), and
+ * the IIFE resolves to a STATUS OBJECT ONLY — never the credential values.
+ * Its first act is the synchronous identity guard (see the spec's TOCTOU
+ * discussion): a new document changes performance.timeOrigin; an SPA
+ * pushState route change keeps timeOrigin but changes location.href. */
+function buildFillScript({ expectedURL, expectedTimeOrigin, username, password }) {
+  const U = JSON.stringify(expectedURL);
+  const TO = JSON.stringify(expectedTimeOrigin);
+  const USER = JSON.stringify(username ?? null);
+  const PASS = JSON.stringify(password ?? null);
+  return `(function () {
+    if (location.href !== ${U} || !document.hasFocus() || performance.timeOrigin !== ${TO}) {
+      return { originMismatch: true, filledUser: false, filledPass: false };
+    }
+    var isVisible = function (el) {
+      if (!el || el.type === 'hidden' || el.offsetParent === null) return false;
+      var r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    };
+    var setNative = function (el, value) {
+      var d = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+      d.set.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+    var pw = null;
+    var pwlist = document.querySelectorAll('input[type=password]');
+    for (var i = 0; i < pwlist.length; i++) { if (isVisible(pwlist[i])) { pw = pwlist[i]; break; } }
+    if (!pw) return { originMismatch: false, filledUser: false, filledPass: false, noPasswordField: true };
+    var filledPass = false, filledUser = false;
+    if (${PASS} !== null) { setNative(pw, ${PASS}); filledPass = true; }
+    var isText = function (el) { return el && el.tagName === 'INPUT' && (el.type === 'text' || el.type === 'email'); };
+    var user = null;
+    var active = document.activeElement;
+    if (isText(active) && isVisible(active)) {
+      user = active;
+    } else {
+      var scope = pw.form || document;
+      var texts = scope.querySelectorAll('input[type=text], input[type=email]');
+      for (var j = 0; j < texts.length; j++) {
+        if (!isVisible(texts[j])) continue;
+        if (pw.compareDocumentPosition(texts[j]) & Node.DOCUMENT_POSITION_PRECEDING) user = texts[j];
+      }
+    }
+    if (user && ${USER} !== null) { setNative(user, ${USER}); filledUser = true; }
+    return { originMismatch: false, filledUser: filledUser, filledPass: filledPass };
+  })();`;
+}
+
+const { app } = require('electron');
+
+let cachedClient = null;
+
+/** Lazily construct + cache the SDK client via the native desktop-app bridge
+ * (DesktopAuth → SharedLibCore → dlopen of 1Password's libop_sdk_ipc_client).
+ * BLANC_1P_ACCOUNT is required and never committed. The cache is discarded
+ * only on an unrecoverable failure — the SDK re-authorizes an ordinary
+ * ~10-min session expiry itself. */
+async function getClient() {
+  if (cachedClient) return cachedClient;
+  const account = process.env.BLANC_1P_ACCOUNT;
+  if (!account) throw new Error('BLANC_1P_ACCOUNT is not set');
+  const { createClient, DesktopAuth } = require('@1password/sdk'); // lazy — never at module scope
+  cachedClient = await createClient({
+    auth: new DesktopAuth(account),
+    integrationName: 'Blanc',
+    integrationVersion: app.getVersion(),
+  });
+  return cachedClient;
+}
+
+/** Match Login items against `expectedHost` on OVERVIEWS only — no secret is
+ * decrypted here. Skips a vault that can't be listed (logged by caller). */
+async function findLogins(expectedHost) {
+  const client = await getClient();
+  const matches = [];
+  const vaults = await client.vaults.list();
+  for (const vault of vaults) {
+    let overviews;
+    try {
+      overviews = await client.items.list(vault.id);
+    } catch {
+      continue; // inaccessible vault — skip, don't abort the whole search
+    }
+    for (const ov of overviews) {
+      if (ov.category !== 'Login') continue;
+      const urls = Array.isArray(ov.websites) ? ov.websites.map((w) => w.url) : [];
+      if (matchesHost(urls, expectedHost)) {
+        matches.push({ vaultId: vault.id, itemId: ov.id, title: ov.title });
+      }
+    }
+  }
+  return matches;
+}
+
+/** Decrypt exactly the one chosen item and read its BUILT-IN username +
+ * password fields (by id — no "first Concealed field" fallback, which could
+ * return a custom PIN/recovery secret). A missing built-in field returns null
+ * (a defined outcome), never a guess. */
+async function revealCredential(vaultId, itemId) {
+  const client = await getClient();
+  const item = await client.items.get(vaultId, itemId);
+  const fields = Array.isArray(item.fields) ? item.fields : [];
+  const read = (id) => {
+    const f = fields.find((x) => x.id === id);
+    return f && typeof f.value === 'string' ? f.value : null;
+  };
+  return { username: read('username'), password: read('password') };
+}
+
+/** Criterion 3(a) probe: force-load the SDK package — module resolution +
+ * @1password/sdk-core's eager core_bg.wasm compile — WITHOUT authenticating.
+ * Throws if the package can't load. Lives here (not in main.js) so the
+ * `require('@1password/sdk')` stays confined to this module, alongside
+ * getClient — preserving the lazy-require boundary. Never authenticates, so it
+ * does not dlopen the native 1Password bridge (that's getClient/criterion 3b). */
+function probePackageLoad() {
+  require('@1password/sdk'); // lazy — the only other place this is required
+}
+
+module.exports = { matchesHost, buildFillScript, getClient, findLogins, revealCredential, probePackageLoad };

--- a/test/unit/onepassword-match.test.js
+++ b/test/unit/onepassword-match.test.js
@@ -1,0 +1,75 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { matchesHost, buildFillScript } = require('../../src/main/onepassword');
+
+test('matchesHost: exact host matches', () => {
+  assert.equal(matchesHost(['https://github.com/login'], 'github.com'), true);
+});
+
+test('matchesHost: www vs bare host both directions', () => {
+  assert.equal(matchesHost(['https://www.github.com'], 'github.com'), true);
+  assert.equal(matchesHost(['https://github.com'], 'www.github.com'), true);
+});
+
+test('matchesHost: scheme-less stored value matches', () => {
+  assert.equal(matchesHost(['github.com'], 'github.com'), true);
+});
+
+test('matchesHost: subdomain must NOT match', () => {
+  assert.equal(matchesHost(['https://login.github.com'], 'github.com'), false);
+});
+
+test('matchesHost: substring trap must NOT match', () => {
+  assert.equal(matchesHost(['https://github.com.evil.com'], 'github.com'), false);
+});
+
+test('matchesHost: item with multiple urls, one matches', () => {
+  assert.equal(matchesHost(['https://example.org', 'github.com'], 'github.com'), true);
+});
+
+test('matchesHost: item with no urls does not match', () => {
+  assert.equal(matchesHost([], 'github.com'), false);
+});
+
+test('matchesHost: malformed stored url is skipped, not thrown', () => {
+  assert.doesNotThrow(() => matchesHost(['http://', ':::', 'github.com'], 'github.com'));
+  assert.equal(matchesHost(['http://', ':::', 'github.com'], 'github.com'), true);
+});
+
+test('buildFillScript: embeds expectedURL and timeOrigin via JSON.stringify', () => {
+  const s = buildFillScript({ expectedURL: 'https://github.com/login', expectedTimeOrigin: 1234.5, username: 'u', password: 'p' });
+  assert.ok(s.includes(JSON.stringify('https://github.com/login')));
+  assert.ok(s.includes('1234.5'));
+});
+
+test('buildFillScript: dangerous credential chars are safely escaped', () => {
+  const nasty = 'a"b\\c\nd\'e';
+  const s = buildFillScript({ expectedURL: 'https://x.test/', expectedTimeOrigin: 0, username: null, password: nasty });
+  assert.ok(s.includes(JSON.stringify(nasty)));       // embedded encoded
+  assert.ok(!s.includes('"' + nasty + '"'));          // never the raw sequence in double quotes
+});
+
+test('buildFillScript: contains identity guard, visibility check, native setter', () => {
+  const s = buildFillScript({ expectedURL: 'https://x.test/', expectedTimeOrigin: 0, username: 'u', password: 'p' });
+  assert.ok(s.includes('location.href'));
+  assert.ok(s.includes('document.hasFocus()'));
+  assert.ok(s.includes('performance.timeOrigin'));
+  assert.ok(s.includes('offsetParent'));
+  assert.ok(s.includes('HTMLInputElement.prototype'));
+});
+
+test('buildFillScript: null username still embeds a null literal (fills password only)', () => {
+  const s = buildFillScript({ expectedURL: 'https://x.test/', expectedTimeOrigin: 0, username: null, password: 'p' });
+  assert.ok(s.includes('null !== null'));  // the USER !== null guard resolves to false at runtime
+});
+
+test('requiring onepassword.js does NOT eagerly load the 1Password SDK', () => {
+  // The module must stay import-light: `@1password/sdk` is loaded only inside
+  // the SDK functions, so a normal packaged startup never pays for it.
+  const resolved = require.resolve('../../src/main/onepassword');
+  delete require.cache[resolved];
+  require('../../src/main/onepassword');
+  const sdkLoaded = Object.keys(require.cache).some((p) => p.includes('@1password' + require('path').sep + 'sdk'));
+  assert.equal(sdkLoaded, false);
+});


### PR DESCRIPTION
Ports the proven 1Password fill onto current `main`, squashing the original 22-commit branch (104 commits behind, purely additive delta).

## What this does
Blanc fills a login form from the user's own 1Password vault **with no browser extension**. `DesktopAuth` authorizes through the desktop app (Touch ID); host matching runs on item *overviews*, so only the one chosen item is ever decrypted before an in-page fill.

## Gating
`ONE_PASSWORD_SPIKE_ENABLED = !app.isPackaged || process.env.BLANC_1P_SPIKE === '1'` — a normal packaged build never activates it.

⚠️ **`@1password/sdk@0.4.0` is a runtime dependency**, so ~10 MB of SDK/WASM ships in the app bundle even though the feature stays dormant. That is a deliberate choice — see `docs/1password-legal-inquiry.md` for the §4.1(e) distribution position.

## Security
Credentials live only in main-process memory and the verified page; every outcome logs a result line, never a value. Before injection: window focus, tab identity, navigation epoch, exact URL, plus an in-page `location.href` + `performance.timeOrigin` check.

## Verification
- 327 unit tests pass — 9 new, covering the subdomain / substring / scheme-less matching traps and the lazy-SDK-load guard
- `npm run substrate:check` clean
- App boots cleanly (main, GPU, network, renderer)
- No new `npm audit` findings from the SDK

Spec + executed findings: `docs/superpowers/specs/2026-07-12-1password-autofill-spike-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)