### PR TITLE
Spike: native Liquid Glass island via cross-window composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ docs/press-outreach-plan.md
 .astro/
 site/.parity/
 site/.parity-shots/
+
+# Native addon build output. node-gyp treats its `build/` as scratch and wipes
+# it, which is exactly why the addon lives in native/<name>/ with its own build
+# dir rather than the repo's build/ (that one holds the signing entitlements,
+# provisioning profile and app icons electron-builder needs).
+native/*/build/

--- a/native/glass/binding.gyp
+++ b/native/glass/binding.gyp
@@ -1,0 +1,21 @@
+{
+  "targets": [
+    {
+      "target_name": "glass",
+      "conditions": [
+        ["OS==\"mac\"", {
+          "sources": ["glass.mm"],
+          "include_dirs": ["<!@(node -p \"require('node-addon-api').include_dir\")"],
+          "libraries": ["-framework AppKit", "-framework QuartzCore"],
+          "xcode_settings": {
+            "CLANG_ENABLE_OBJC_ARC": "YES",
+            "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+            "MACOSX_DEPLOYMENT_TARGET": "11.0",
+            "OTHER_CFLAGS": ["-std=c++17", "-Wno-unguarded-availability-new"]
+          },
+          "defines": ["NAPI_CPP_EXCEPTIONS"]
+        }]
+      ]
+    }
+  ]
+}

--- a/native/glass/glass.mm
+++ b/native/glass/glass.mm
@@ -1,0 +1,200 @@
+// EXPERIMENT — native NSGlassEffectView (macOS 26+) inserted into an Electron
+// window's AppKit view hierarchy.
+//
+// Electron has no binding for macOS 26's Liquid Glass. `BrowserWindow.vibrancy`
+// is NSVisualEffectView with *behind-window* blending: window-shaped, and it
+// samples the desktop rather than the page. NSGlassEffectView is a real view we
+// can size, corner-round to a pill, and order directly above the page's
+// WebContentsView — which is the only way the Island itself can be the glass.
+//
+// The open question this addon exists to answer: does NSGlassEffectView sample
+// the Chromium-composited page in the NSView beneath it, or only the window
+// background? Everything else here is plumbing for that measurement.
+
+#include <napi.h>
+#import <AppKit/AppKit.h>
+
+namespace {
+
+// Electron hands back a Buffer whose bytes are the NSView* of the window's
+// content view (not the NSWindow itself).
+NSView* ContentViewFromHandle(const Napi::Buffer<char>& buf) {
+  if (buf.Length() < sizeof(void*)) return nil;
+  NSView* view = *reinterpret_cast<NSView* const*>(buf.Data());
+  return [view isKindOfClass:[NSView class]] ? view : nil;
+}
+
+NSGlassEffectView* g_glass = nil;
+bool g_below_top = false;
+
+// The island's contents are a separate transparent WebContentsView that must
+// render ABOVE the glass, while the page renders below it. Electron's
+// addChildView only orders views it owns, so it cannot lift a Chromium view
+// over this foreign NSView — the glass has to insert itself into the right slot
+// instead: directly beneath the topmost subview (the contents), above the rest.
+void PlaceGlass(NSView* content, bool below_top) {
+  g_below_top = below_top;
+  NSView* top = content.subviews.lastObject;
+  if (below_top && top && top != g_glass) {
+    [content addSubview:g_glass positioned:NSWindowBelow relativeTo:top];
+  } else {
+    [content addSubview:g_glass positioned:NSWindowAbove relativeTo:nil];
+  }
+}
+
+// Falsification test for "NSView sibling order controls stacking against
+// Chromium content": drop the glass to the BOTTOM of the subview list. If it
+// still appears over the page, ordering is irrelevant — Chromium composites its
+// views into one layer that always sits below native siblings.
+void PlaceGlassBottom(NSView* content) {
+  NSView* bottom = content.subviews.firstObject;
+  if (bottom && bottom != g_glass) {
+    [content addSubview:g_glass positioned:NSWindowBelow relativeTo:bottom];
+  }
+}
+
+bool GlassAvailable() {
+  if (@available(macOS 26.0, *)) {
+    return NSClassFromString(@"NSGlassEffectView") != nil;
+  }
+  return false;
+}
+
+Napi::Value IsSupported(const Napi::CallbackInfo& info) {
+  return Napi::Boolean::New(info.Env(), GlassAvailable());
+}
+
+// attach(handleBuffer, {x, y, width, height, cornerRadius, style, interactive})
+Napi::Value Attach(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!GlassAvailable()) {
+    Napi::Error::New(env, "NSGlassEffectView requires macOS 26+").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  if (info.Length() < 2 || !info[0].IsBuffer() || !info[1].IsObject()) {
+    Napi::TypeError::New(env, "attach(handle, opts)").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  NSView* content = ContentViewFromHandle(info[0].As<Napi::Buffer<char>>());
+  if (!content) {
+    Napi::Error::New(env, "could not resolve NSView from window handle").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  Napi::Object o = info[1].As<Napi::Object>();
+  CGFloat x = o.Get("x").ToNumber().DoubleValue();
+  CGFloat y = o.Get("y").ToNumber().DoubleValue();
+  CGFloat w = o.Get("width").ToNumber().DoubleValue();
+  CGFloat h = o.Get("height").ToNumber().DoubleValue();
+  CGFloat radius = o.Has("cornerRadius") ? o.Get("cornerRadius").ToNumber().DoubleValue() : h / 2.0;
+  bool clear = o.Has("style") && o.Get("style").ToString().Utf8Value() == "clear";
+  bool interactive = o.Has("interactive") && o.Get("interactive").ToBoolean().Value();
+
+  if (@available(macOS 26.0, *)) {
+    if (!g_glass) {
+      g_glass = [[NSGlassEffectView alloc] initWithFrame:NSMakeRect(x, y, w, h)];
+      // AppKit's origin is bottom-left; the caller thinks in top-left CSS
+      // coordinates, so pin to the top edge and let the height float.
+      g_glass.autoresizingMask = NSViewMinYMargin | NSViewWidthSizable;
+    }
+    g_glass.frame = NSMakeRect(x, y, w, h);
+    g_glass.cornerRadius = radius;
+    g_glass.style = clear ? NSGlassEffectViewStyleClear : NSGlassEffectViewStyleRegular;
+    if (@available(macOS 27.0, *)) {
+      g_glass.effectIsInteractive = interactive;
+    }
+    if (o.Has("zOrder") && o.Get("zOrder").ToString().Utf8Value() == "bottom") {
+      PlaceGlassBottom(content);
+    } else {
+      PlaceGlass(content, o.Has("belowTop") && o.Get("belowTop").ToBoolean().Value());
+    }
+  }
+  return Napi::Boolean::New(env, true);
+}
+
+// setFrame({x, y, width, height}) — top-left origin, flipped here.
+Napi::Value SetFrame(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!g_glass || info.Length() < 1 || !info[0].IsObject()) return env.Undefined();
+  Napi::Object o = info[0].As<Napi::Object>();
+  g_glass.frame = NSMakeRect(o.Get("x").ToNumber().DoubleValue(),
+                             o.Get("y").ToNumber().DoubleValue(),
+                             o.Get("width").ToNumber().DoubleValue(),
+                             o.Get("height").ToNumber().DoubleValue());
+  // The resting pill is a capsule and the expanded panel is a 10px-radius card,
+  // so radius travels with every frame change rather than being fixed at attach.
+  if (o.Has("cornerRadius")) {
+    if (@available(macOS 26.0, *)) {
+      g_glass.cornerRadius = o.Get("cornerRadius").ToNumber().DoubleValue();
+    }
+  }
+  return env.Undefined();
+}
+
+// Electron re-orders subviews whenever a tab view is attached; call this to put
+// the glass back on top without recreating it.
+Napi::Value Raise(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!g_glass) return env.Undefined();
+  NSView* super_view = g_glass.superview;
+  if (super_view) PlaceGlass(super_view, g_below_top);
+  return env.Undefined();
+}
+
+// A utility sheet is a deliberate modal surface: the glass is hidden outright
+// rather than left refracting beneath it. Hiding beats detaching — re-attaching
+// would have to re-find its slot in the subview order.
+Napi::Value SetHidden(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!g_glass || info.Length() < 1) return env.Undefined();
+  g_glass.hidden = info[0].ToBoolean().Value();
+  return env.Undefined();
+}
+
+Napi::Value Detach(const Napi::CallbackInfo& info) {
+  if (g_glass) {
+    [g_glass removeFromSuperview];
+    g_glass = nil;
+  }
+  return info.Env().Undefined();
+}
+
+// Diagnostic: Electron's contentView children may be nested inside a container
+// rather than being direct subviews of the window's content view, which changes
+// where the glass has to be inserted. Dump the real tree instead of assuming.
+Napi::Value Describe(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsBuffer()) return env.Undefined();
+  NSView* content = ContentViewFromHandle(info[0].As<Napi::Buffer<char>>());
+  if (!content) return env.Undefined();
+
+  Napi::Array out = Napi::Array::New(env);
+  uint32_t i = 0;
+  for (NSView* v in content.subviews) {
+    NSMutableString* line = [NSMutableString stringWithFormat:@"%@ frame=%@ kids=%lu",
+                             NSStringFromClass([v class]),
+                             NSStringFromRect(v.frame),
+                             (unsigned long)v.subviews.count];
+    for (NSView* k in v.subviews) {
+      [line appendFormat:@" | %@ %@", NSStringFromClass([k class]), NSStringFromRect(k.frame)];
+    }
+    out.Set(i++, Napi::String::New(env, [line UTF8String]));
+  }
+  return out;
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("describe", Napi::Function::New(env, Describe));
+  exports.Set("isSupported", Napi::Function::New(env, IsSupported));
+  exports.Set("attach", Napi::Function::New(env, Attach));
+  exports.Set("setFrame", Napi::Function::New(env, SetFrame));
+  exports.Set("raise", Napi::Function::New(env, Raise));
+  exports.Set("setHidden", Napi::Function::New(env, SetHidden));
+  exports.Set("detach", Napi::Function::New(env, Detach));
+  return exports;
+}
+
+}  // namespace
+
+NODE_API_MODULE(glass, Init)

--- a/native/glass/testing/README.md
+++ b/native/glass/testing/README.md
@@ -1,0 +1,50 @@
+# Liquid Glass spike — validation harnesses
+
+Every measured claim in PR #74 was produced by one of these. They are the
+reproduction, not polished tests: each launches Blanc through Playwright's
+`_electron` with `BLANC_TEST=1 BLANC_GLASS=1`, drives the real IPC surface via
+`globalThis.__blanc`, and asserts on real geometry.
+
+Parked here so the findings can be re-derived if this direction resumes. They
+are **not** wired into `npm test` and are macOS-26-only.
+
+## Prerequisites
+
+The native addon must be built against Electron's ABI first — it is not built
+by `npm install`, and `native/glass/build/` is gitignored:
+
+```
+cd native/glass
+npx node-gyp rebuild \
+  --target=$(node -p "require('../../package.json').devDependencies.electron.replace('^','')") \
+  --arch=arm64 --dist-url=https://electronjs.org/headers
+```
+
+Run each harness from the repo root with `node <path> [outDir]`.
+
+## What each one establishes
+
+| script | question it answers |
+|---|---|
+| `backdrop-probe.mjs` | Does CSS `backdrop-filter` cross the `WebContentsView` boundary? (Yes — with an in-document positive control alongside.) |
+| `native-glass-test.mjs` | Does `NSGlassEffectView` sample the Chromium-composited page? Scrolls the page under a stationary window and compares pill pixels. Also the falsification run: `BLANC_GLASS_Z=bottom` drops the glass to the bottom of the subview list and renders identically, proving NSView order does not stack against Chromium content. |
+| `crosswindow-test.mjs` | Does a transparent child window composite *above* the parent's glass, and does its lifecycle hold? 9 checks: parenting, DOM interaction, keyboard, move, resize, fullscreen, app deactivation. |
+| `phase2.mjs` | The real island split across windows — 16 checks through the shipping IPC path: ⌘L → panel → typing → navigation, Escape/blur dismissal, glass tracking the panel and returning to the pill, address-bar focus reclaim, full window lifecycle. |
+| `harden.mjs` | The three bounds decisions — tight resting island (traffic lights clear), tight panel/find vs full-window palette, utility sheet hiding glass + island. Plus permission prompting and Spaces. |
+| `dump.mjs` | Diagnostic: prints the parent window's real AppKit subview tree via the addon's `describe()`. This is what revealed that ordering was not the problem. |
+
+## Known harness limitations
+
+- **Screenshots.** Several runs used `screencapture -R`, which needs Screen
+  Recording permission for the terminal. That permission was revoked mid-session
+  once; when it fails the message is `could not create image from rect` and the
+  fix is System Settings → Privacy & Security → Screen & System Audio Recording.
+  The behavioural assertions do not depend on screenshots.
+- **Single display.** `harden.mjs` reports multi-display / mixed-scale as
+  UNTESTABLE when only one screen is attached. Re-run it with an external
+  monitor at a different scale factor — that is the largest unverified risk in
+  the migration plan.
+- **Assertion pitfalls found the hard way.** The pill's width changes with the
+  domain string, so compare the glass against the *live* pill, not an earlier
+  capture. The permission bar is narrower than the pill and stacks below it, so
+  the host grows in height, not width. Both produced false failures first.

--- a/native/glass/testing/backdrop-probe.mjs
+++ b/native/glass/testing/backdrop-probe.mjs
@@ -1,0 +1,116 @@
+// Can CSS backdrop-filter in the overlay WebContentsView sample the tab's
+// WebContentsView beneath it?
+//
+// The overlay is the only chrome surface that genuinely overlaps page content
+// (the strip does not — pageBounds.y = stripHeight), so it is the correct place
+// to ask. Two probes render side by side in the SAME overlay document:
+//
+//   A  cross-boundary — over a transparent region of the overlay, with the
+//      page's saturated gradient directly beneath it in the tab view.
+//   B  positive control — the identical filter over a gradient that lives
+//      INSIDE the overlay document.
+//
+// If B shows the effect and A does not, backdrop-filter is confined to its own
+// renderer's layer tree. If neither shows it, the probe itself is broken and
+// proves nothing — which is exactly what the control is there to catch.
+import { createRequire } from 'node:module';
+const require = createRequire('/Users/anthonyjloria/Projects/Blanc Browser/');
+const { _electron } = require('playwright');
+import { execFileSync } from 'node:child_process';
+import { createServer } from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO = '/Users/anthonyjloria/Projects/Blanc Browser';
+const OUT = process.argv[2];
+fs.mkdirSync(OUT, { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Bold horizontal bands: a blur across them is obvious, an invert unmistakable.
+const html = `<body style="margin:0;height:200vh;background:repeating-linear-gradient(
+  180deg,#ff0040 0 60px,#ffd400 60px 120px,#00e5ff 120px 180px,#0d00ff 180px 240px)"></body>`;
+const server = createServer((_q, res) => {
+  res.writeHead(200, { 'content-type': 'text/html' });
+  res.end(html);
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const PAGE = `http://127.0.0.1:${server.address().port}/`;
+
+const userDataDir = fs.mkdtempSync('/tmp/blanc-probe-');
+const app = await _electron.launch({
+  args: [REPO, `--user-data-dir=${userDataDir}`],
+  env: { ...process.env, BLANC_TEST: '1', BLANC_GLASS: '0' },
+});
+await app.evaluate(() => new Promise((r) => {
+  const t = setInterval(() => { if (globalThis.__blanc) { clearInterval(t); r(); } }, 50);
+}));
+
+const W = 900, H = 620, PAD = 40;
+const WIN = { x: 260, y: 180, width: W, height: H };
+await app.evaluate(({ BrowserWindow }, b) => {
+  const w = BrowserWindow.getAllWindows()[0];
+  w.setBounds(b); w.show(); w.focus();
+}, WIN);
+
+const tabId = await app.evaluate((_e, u) => globalThis.__blanc.openTab(u), PAGE);
+await sleep(2500);
+await app.evaluate((_e, id) => globalThis.__blanc.activateTab(id), tabId);
+await sleep(1200);
+const st = await app.evaluate(() => {
+  const s = globalThis.__blanc.state();
+  return { active: s.activeTabId, tabs: s.tabs.map((t) => `${t.id}:${t.url.slice(0, 40)}`) };
+});
+console.log('tab state:', JSON.stringify(st));
+
+await app.evaluate(() => globalThis.__blanc.openPanel());
+await sleep(1200);
+
+// Inject both probes into the overlay renderer.
+const injected = await app.evaluate(async ({ webContents }) => {
+  const wc = webContents.getAllWebContents().find((w) => w.getURL().includes('overlay.html'));
+  if (!wc) return 'NO OVERLAY WEBCONTENTS';
+  return wc.executeJavaScript(`(() => {
+    // Clear the overlay's own chrome out of the probe area so nothing in this
+    // document sits behind probe A. Whatever A picks up must cross the boundary.
+    const bd = document.querySelector('#backdrop'); if (bd) bd.style.display = 'none';
+    for (const el of document.querySelectorAll('body > *')) el.style.visibility = 'hidden';
+
+    const FILTER = 'invert(1) blur(6px)';
+    const host = document.createElement('div');
+    host.id = '__probe';
+    host.style.cssText = 'position:fixed;inset:0;z-index:999999;visibility:visible;font:600 13px system-ui';
+
+    // A — cross-boundary. Transparent overlay here; the tab view is beneath.
+    host.innerHTML = \`
+      <div style="position:absolute;left:40px;top:150px;width:340px;height:220px;
+                  outline:3px solid #000;visibility:visible">
+        <div style="position:absolute;inset:0;backdrop-filter:\${FILTER};
+                    -webkit-backdrop-filter:\${FILTER}"></div>
+        <div style="position:absolute;bottom:-24px;left:0;color:#000;background:#fff;padding:2px 6px">
+          A — cross-boundary (page beneath)</div>
+      </div>
+
+      <!-- B — positive control. Same filter, over a gradient in THIS document. -->
+      <div style="position:absolute;left:440px;top:150px;width:340px;height:220px;
+                  outline:3px solid #000;visibility:visible;
+                  background:repeating-linear-gradient(180deg,#ff0040 0 60px,#ffd400 60px 120px,
+                             #00e5ff 120px 180px,#0d00ff 180px 240px)">
+        <div style="position:absolute;inset:0;backdrop-filter:\${FILTER};
+                    -webkit-backdrop-filter:\${FILTER}"></div>
+        <div style="position:absolute;bottom:-24px;left:0;color:#000;background:#fff;padding:2px 6px">
+          B — control (gradient in overlay doc)</div>
+      </div>\`;
+    document.body.appendChild(host);
+    return CSS.supports('backdrop-filter', 'invert(1)') ? 'supported' : 'UNSUPPORTED';
+  })()`);
+});
+console.log('backdrop-filter support in overlay renderer:', injected);
+await sleep(1500);
+
+execFileSync('/usr/sbin/screencapture', ['-x', '-R',
+  `${WIN.x - PAD},${WIN.y - PAD},${W + PAD * 2},${H + PAD * 2}`,
+  path.join(OUT, 'boundary-probe.png')]);
+console.log('captured -> ', OUT);
+
+await app.close();
+server.close();

--- a/native/glass/testing/crosswindow-test.mjs
+++ b/native/glass/testing/crosswindow-test.mjs
@@ -1,0 +1,260 @@
+// CROSS-WINDOW COMPOSITION PROOF
+//
+// Parent window: full-bleed page + native NSGlassEffectView.
+// Child window:  transparent, frameless, parented — carries the island's HTML.
+//
+// The question is whether the WindowServer composites the child's Chromium
+// pixels ON TOP of the parent's finished output (glass included) while the
+// parent's glass keeps sampling the page inside the parent.
+import { createRequire } from 'node:module';
+const require = createRequire('/Users/anthonyjloria/Projects/Blanc Browser/');
+const { _electron } = require('playwright');
+import { execFileSync } from 'node:child_process';
+import { createServer } from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO = '/Users/anthonyjloria/Projects/Blanc Browser';
+const OUT = process.argv[2];
+fs.mkdirSync(OUT, { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const results = [];
+const record = (name, pass, detail) => {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name} — ${detail}`);
+};
+
+const html = `<body style="margin:0;height:400vh;background:repeating-linear-gradient(
+  180deg,#ff0040 0 70px,#ffd400 70px 140px,#00e5ff 140px 210px,#0d00ff 210px 280px)"></body>`;
+const server = createServer((_q, res) => {
+  res.writeHead(200, { 'content-type': 'text/html' });
+  res.end(html);
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const PAGE = `http://127.0.0.1:${server.address().port}/`;
+
+const userDataDir = fs.mkdtempSync('/tmp/blanc-xwin-');
+const app = await _electron.launch({
+  args: [REPO, `--user-data-dir=${userDataDir}`],
+  env: { ...process.env, BLANC_TEST: '1', BLANC_GLASS: '1' },
+});
+await app.evaluate(() => new Promise((r) => {
+  const t = setInterval(() => { if (globalThis.__blanc) { clearInterval(t); r(); } }, 50);
+}));
+
+const W = 900, H = 600, PAD = 30;
+let WIN = { x: 280, y: 200, width: W, height: H };
+await app.evaluate(({ BrowserWindow }, b) => {
+  const w = BrowserWindow.getAllWindows().find((x) => !x.getParentWindow());
+  w.setBounds(b); w.show(); w.focus();
+}, WIN);
+
+const tabId = await app.evaluate((_e, u) => globalThis.__blanc.openTab(u), PAGE);
+await sleep(2600);
+await app.evaluate((_e, id) => globalThis.__blanc.activateTab(id), tabId);
+await sleep(1500);
+
+// ---- helpers -------------------------------------------------------------
+// The display is finite: an unclamped -R that runs past an edge makes
+// screencapture fail outright ("could not create image from rect"), which would
+// abort the run rather than just produce a bad frame.
+const SCREEN = await app.evaluate(({ screen }) => screen.getPrimaryDisplay().bounds);
+
+async function shot(name, rect = WIN, pad = PAD) {
+  await sleep(600);
+  const x = Math.max(SCREEN.x, rect.x - pad);
+  const y = Math.max(SCREEN.y, rect.y - pad);
+  const w = Math.min(rect.width + pad * 2, SCREEN.x + SCREEN.width - x);
+  const h = Math.min(rect.height + pad * 2, SCREEN.y + SCREEN.height - y);
+  const R = `${x},${y},${w},${h}`;
+  try {
+    execFileSync('/usr/sbin/screencapture', ['-x', '-R', R, path.join(OUT, `${name}.png`)]);
+  } catch (err) {
+    // A failed frame must not abort the behavioural checks — they are the point.
+    console.log(`  [shot ${name} FAILED] rect=${R} screen=${JSON.stringify(SCREEN)} :: ${String(err.stderr).trim()}`);
+    return null;
+  }
+  return path.join(OUT, `${name}.png`);
+}
+
+const childEval = (fn) => app.evaluate(async ({ BrowserWindow }, src) => {
+  const child = BrowserWindow.getAllWindows().find((w) => w.getParentWindow());
+  if (!child) return { __missing: true };
+  return child.webContents.executeJavaScript(src);
+}, fn);
+
+async function scrollTo(px) {
+  await app.evaluate(async ({ webContents }, y) => {
+    const wc = webContents.getAllWebContents().find((w) => w.getURL().startsWith('http://127.'));
+    await wc.executeJavaScript(`window.scrollTo(0, ${y});`);
+  }, px);
+  await sleep(900);
+}
+
+// ---- 0. the child window exists and is a real NSWindow child --------------
+const topology = await app.evaluate(({ BrowserWindow }) => {
+  const all = BrowserWindow.getAllWindows();
+  const child = all.find((w) => w.getParentWindow());
+  return {
+    count: all.length,
+    hasChild: !!child,
+    childBounds: child ? child.getBounds() : null,
+    parentId: child ? child.getParentWindow().id : null,
+  };
+});
+record('child window created & parented', topology.hasChild && topology.parentId != null,
+  JSON.stringify(topology));
+
+await shot('01-initial');
+
+// ---- 1. page scrolling still changes the glass ----------------------------
+const samples = [];
+for (const y of [0, 70]) {
+  await scrollTo(y);
+  samples.push(await shot(`02-scroll-${y}`));
+}
+
+// ---- 2. child text sharp / 3. clicks / keyboard ---------------------------
+const before = await childEval('window.__probe()');
+
+// Click the hit target: it sits just right of the address input.
+const childRect = topology.childBounds;
+await app.evaluate(({ BrowserWindow }) => {
+  const child = BrowserWindow.getAllWindows().find((w) => w.getParentWindow());
+  child.focus();
+});
+await sleep(400);
+await childEval("document.getElementById('hit').click(); null");
+await sleep(300);
+await childEval("document.getElementById('domain').focus(); null");
+await sleep(300);
+const afterFocus = await childEval('window.__probe()');
+record('child DOM interactive (synthetic click + focus)',
+  afterFocus.clicks === before.clicks + 1 && afterFocus.focused === 'domain',
+  JSON.stringify(afterFocus));
+
+// Real OS-level keystrokes into the focused child input.
+await app.evaluate(({ BrowserWindow }) => {
+  const child = BrowserWindow.getAllWindows().find((w) => w.getParentWindow());
+  child.webContents.focus();
+  for (const ch of 'XY') {
+    child.webContents.sendInputEvent({ type: 'char', keyCode: ch });
+  }
+});
+await sleep(600);
+const afterType = await childEval('window.__probe()');
+record('keyboard reaches child window',
+  afterType.domainValue !== before.domainValue,
+  `"${before.domainValue}" -> "${afterType.domainValue}"`);
+await shot('03-after-interaction');
+
+// ---- 4. parent move / resize ---------------------------------------------
+WIN = { ...WIN, x: 200, y: 300 };
+await app.evaluate(({ BrowserWindow }, b) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).setBounds(b);
+}, WIN);
+await sleep(1200);
+let geo = await app.evaluate(({ BrowserWindow }) => {
+  const all = BrowserWindow.getAllWindows();
+  const parent = all.find((w) => !w.getParentWindow());
+  const child = all.find((w) => w.getParentWindow());
+  return { parent: parent.getContentBounds(), child: child.getBounds() };
+});
+let expectedX = geo.parent.x + Math.round((geo.parent.width - 430) / 2);
+record('child follows parent MOVE',
+  Math.abs(geo.child.x - expectedX) <= 2 && Math.abs(geo.child.y - (geo.parent.y + 12)) <= 2,
+  `child=${geo.child.x},${geo.child.y} expected≈${expectedX},${geo.parent.y + 12}`);
+await shot('04-after-move');
+
+WIN = { ...WIN, width: 1150, height: 700 };
+await app.evaluate(({ BrowserWindow }, b) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).setBounds(b);
+}, WIN);
+await sleep(1200);
+geo = await app.evaluate(({ BrowserWindow }) => {
+  const all = BrowserWindow.getAllWindows();
+  const parent = all.find((w) => !w.getParentWindow());
+  const child = all.find((w) => w.getParentWindow());
+  return { parent: parent.getContentBounds(), child: child.getBounds() };
+});
+expectedX = geo.parent.x + Math.round((geo.parent.width - 430) / 2);
+record('child re-centres on parent RESIZE',
+  Math.abs(geo.child.x - expectedX) <= 2,
+  `child.x=${geo.child.x} expected≈${expectedX}`);
+await shot('05-after-resize');
+
+// ---- 6. child must not float above unrelated apps -------------------------
+// Activate Finder, then look at whether Blanc's child is still painted on top.
+execFileSync('/usr/bin/osascript', ['-e', 'tell application "Finder" to activate']);
+await sleep(1800);
+const occluded = await app.evaluate(({ BrowserWindow }) => {
+  const all = BrowserWindow.getAllWindows();
+  const child = all.find((w) => w.getParentWindow());
+  return { childVisible: child.isVisible(), appFocused: all.some((w) => w.isFocused()) };
+});
+await shot('06-other-app-active', { x: 0, y: 0, width: 1512, height: 950 }, 0);
+record('app deactivates cleanly (child not always-on-top)',
+  occluded.appFocused === false,
+  JSON.stringify(occluded));
+
+// Refocus Blanc. System Events needs Accessibility permission, which may not be
+// granted — fall back to Electron's own activation rather than aborting.
+try {
+  execFileSync('/usr/bin/osascript', ['-e',
+    'tell application "System Events" to set frontmost of (first process whose unix id is ' +
+    (await app.evaluate(() => process.pid)) + ') to true']);
+} catch {
+  await app.evaluate(({ app: a, BrowserWindow }) => {
+    a.focus({ steal: true });
+    BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).focus();
+  });
+}
+await sleep(1500);
+record('app refocuses with child intact',
+  (await app.evaluate(({ BrowserWindow }) => {
+    const all = BrowserWindow.getAllWindows();
+    return all.find((w) => w.getParentWindow())?.isVisible() === true;
+  })), 'child still visible after app reactivation');
+await shot('07-refocused');
+
+// ---- 5. fullscreen --------------------------------------------------------
+await app.evaluate(({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).setFullScreen(true);
+});
+await sleep(3000);
+const fsGeo = await app.evaluate(({ BrowserWindow }) => {
+  const all = BrowserWindow.getAllWindows();
+  const parent = all.find((w) => !w.getParentWindow());
+  const child = all.find((w) => w.getParentWindow());
+  return {
+    fullScreen: parent.isFullScreen(),
+    parent: parent.getContentBounds(),
+    child: child.getBounds(),
+    childVisible: child.isVisible(),
+  };
+});
+await shot('08-fullscreen', { x: 0, y: 0, width: 1512, height: 950 }, 0);
+const fsExpectedX = fsGeo.parent.x + Math.round((fsGeo.parent.width - 430) / 2);
+record('fullscreen keeps child aligned & visible',
+  fsGeo.fullScreen && fsGeo.childVisible && Math.abs(fsGeo.child.x - fsExpectedX) <= 2,
+  JSON.stringify(fsGeo));
+
+await app.evaluate(({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).setFullScreen(false);
+});
+await sleep(2500);
+const restored = await app.evaluate(({ BrowserWindow }) => {
+  const all = BrowserWindow.getAllWindows();
+  const parent = all.find((w) => !w.getParentWindow());
+  const child = all.find((w) => w.getParentWindow());
+  return { fullScreen: parent.isFullScreen(), child: child.getBounds(), parent: parent.getContentBounds() };
+});
+record('leaves fullscreen without losing the child',
+  !restored.fullScreen &&
+    Math.abs(restored.child.x - (restored.parent.x + Math.round((restored.parent.width - 430) / 2))) <= 2,
+  JSON.stringify(restored));
+
+fs.writeFileSync(path.join(OUT, 'results.json'), JSON.stringify(results, null, 2));
+console.log('\n=== ' + results.filter((r) => r.pass).length + '/' + results.length + ' passed ===');
+await app.close();
+server.close();

--- a/native/glass/testing/dump.mjs
+++ b/native/glass/testing/dump.mjs
@@ -1,0 +1,19 @@
+import { createRequire } from 'node:module';
+const require = createRequire('/Users/anthonyjloria/Projects/Blanc Browser/');
+const { _electron } = require('playwright');
+
+const app = await _electron.launch({
+  args: ['/Users/anthonyjloria/Projects/Blanc Browser', '--user-data-dir=/tmp/blanc-dump'],
+  env: { ...process.env, BLANC_TEST: '1', BLANC_GLASS: '1' },
+});
+await app.evaluate(() => new Promise((r) => {
+  const t = setInterval(() => { if (globalThis.__blanc) { clearInterval(t); r(); } }, 50);
+}));
+await new Promise((r) => setTimeout(r, 3000));
+
+const tree = await app.evaluate(({ BrowserWindow }) =>
+  globalThis.__glass
+    ? globalThis.__glass.describe(BrowserWindow.getAllWindows()[0])
+    : ['__glass missing']);
+console.log(tree.join('\n'));
+await app.close();

--- a/native/glass/testing/harden.mjs
+++ b/native/glass/testing/harden.mjs
@@ -1,0 +1,224 @@
+// HARDENING PASS — validates the three design decisions through real flows.
+//   1. resting island child is TIGHT to the pill (traffic lights + drag space)
+//   2. panel/find tight; full-window overlay child reserved for palette
+//   3. a utility sheet hides the glass and the island child outright
+// Plus permission prompting under the new bounds, Spaces, and display handling.
+import { createRequire } from 'node:module';
+const require = createRequire('/Users/anthonyjloria/Projects/Blanc Browser/');
+const { _electron } = require('playwright');
+import { createServer } from 'node:http';
+import fs from 'node:fs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const results = [];
+const rec = (name, pass, detail) => {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name} — ${detail}`);
+};
+const note = (name, detail) => {
+  results.push({ name, pass: null, detail });
+  console.log(`NOTE  ${name} — ${detail}`);
+};
+
+const server = createServer((_q, res) => {
+  res.writeHead(200, { 'content-type': 'text/html' });
+  res.end(`<title>Fixture</title><body style="margin:0;height:400vh;background:repeating-linear-gradient(
+    180deg,#ff0040 0 70px,#ffd400 70px 140px,#00e5ff 140px 210px,#0d00ff 210px 280px)"></body>`);
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const PAGE = `http://127.0.0.1:${server.address().port}/`;
+
+const app = await _electron.launch({
+  args: ['/Users/anthonyjloria/Projects/Blanc Browser',
+         `--user-data-dir=${fs.mkdtempSync('/tmp/blanc-h-')}`],
+  env: { ...process.env, BLANC_TEST: '1', BLANC_GLASS: '1' },
+});
+await app.evaluate(() => new Promise((r) => {
+  const t = setInterval(() => { if (globalThis.__blanc) { clearInterval(t); r(); } }, 50);
+}));
+const PARENT = { x: 240, y: 190, width: 1040, height: 660 };
+await app.evaluate(({ BrowserWindow }, b) => {
+  const w = BrowserWindow.getAllWindows().find((x) => !x.getParentWindow());
+  w.setBounds(b); w.show(); w.focus();
+}, PARENT);
+const tabId = await app.evaluate((_e, u) => globalThis.__blanc.openTab(u), PAGE);
+await sleep(2600);
+await app.evaluate((_e, i) => globalThis.__blanc.activateTab(i), tabId);
+await sleep(1600);
+
+const snap = () => app.evaluate(({ BrowserWindow, screen }) => {
+  const all = BrowserWindow.getAllWindows();
+  const parent = all.find((w) => !w.getParentWindow());
+  const kids = all.filter((w) => w.getParentWindow());
+  const by = (f) => kids.find((w) => w.webContents.getURL().includes(f));
+  const island = by('index.html'); const overlay = by('overlay.html');
+  const tree = globalThis.__glass?.describe(parent) || [];
+  const line = tree.find((l) => l.startsWith('NSGlassEffectView'));
+  const m = line && line.match(/frame=\{\{([-\d.]+), ([-\d.]+)\}, \{([-\d.]+), ([-\d.]+)\}\}/);
+  return {
+    parent: parent.getContentBounds(),
+    island: island ? { b: island.getBounds(), visible: island.isVisible() } : null,
+    overlay: overlay ? { b: overlay.getBounds(), visible: overlay.isVisible() } : null,
+    glass: m ? { x: +m[1], y: +m[2], w: +m[3], h: +m[4] } : null,
+    glassHidden: !line ? null : /NSGlassEffectView/.test(line) ? undefined : null,
+    mode: globalThis.__blanc.overlayMode(),
+    displays: screen.getAllDisplays().map((d) => ({ id: d.id, sf: d.scaleFactor, b: d.bounds })),
+  };
+});
+
+// ---- DECISION 1: tight resting island ------------------------------------
+let s = await snap();
+const TRAFFIC_LIGHT_ZONE = 92; // native lights occupy roughly the first 92pt
+rec('resting island child is tight to the pill, not a full-width band',
+  s.island.b.width < s.parent.width * 0.6 && s.island.b.height < 64,
+  `island=${s.island.b.width}x${s.island.b.height} parent.w=${s.parent.width}`);
+rec('traffic lights + left drag space are clear of the island child',
+  s.island.b.x > s.parent.x + TRAFFIC_LIGHT_ZONE,
+  `island.x=${s.island.b.x} lights end ≈${s.parent.x + TRAFFIC_LIGHT_ZONE}`);
+rec('glass matches the tight pill',
+  s.glass && Math.abs(s.glass.w - s.island.b.width) <= 3,
+  `glass.w=${s.glass?.w} island.w=${s.island.b.width}`);
+const restIslandW = s.island.b.width;
+
+// ---- DECISION 2: tight panel/find, full-window palette --------------------
+await app.evaluate(() => globalThis.__blanc.openPanel());
+await sleep(1400);
+s = await snap();
+rec('panel: overlay child is TIGHT (page stays clickable around it)',
+  s.overlay.visible && s.overlay.b.width <= 640 && s.overlay.b.width < s.parent.width * 0.8,
+  `overlay=${s.overlay.b.width}x${s.overlay.b.height} parent.w=${s.parent.width}`);
+await app.evaluate(() => globalThis.__blanc.closeOverlay());
+await sleep(900);
+
+await app.evaluate(() => globalThis.__blanc.openPalette());
+await sleep(1400);
+s = await snap();
+rec('palette: overlay child is FULL-WINDOW (scrim owns outside clicks)',
+  s.overlay.visible && s.overlay.b.width >= s.parent.width - 4,
+  `overlay=${s.overlay.b.width}x${s.overlay.b.height} parent.w=${s.parent.width}`);
+rec('palette glass still tracks only the card, not the whole window',
+  s.glass && s.glass.w <= 640 && s.glass.w > restIslandW,
+  `glass.w=${s.glass?.w}`);
+await app.evaluate(() => globalThis.__blanc.closeOverlay());
+await sleep(900);
+
+await app.evaluate(() => globalThis.__blanc.openFind());
+await sleep(1200);
+s = await snap();
+if (s.mode === 'find') {
+  rec('find: overlay child is TIGHT',
+    s.overlay.b.width <= 520 && s.overlay.b.width < s.parent.width * 0.7,
+    `overlay=${s.overlay.b.width}x${s.overlay.b.height}`);
+  await app.evaluate(() => globalThis.__blanc.closeOverlay());
+  await sleep(800);
+} else {
+  note('find bounds', `find not reachable from the test hook (mode=${s.mode}); panel/palette cover the decision`);
+}
+
+// ---- DECISION 3: utility sheet hides glass + island -----------------------
+const beforeSheet = await snap();
+// main routes utility URLs into the sheet (utility-pages.js isUtilityUrl),
+// so opening one as a "tab" is the real entry point.
+await app.evaluate(() => globalThis.__blanc.openTab('blanc://settings/'));
+await sleep(2200);
+const duringSheet = await app.evaluate(({ BrowserWindow }) => {
+  const all = BrowserWindow.getAllWindows();
+  const parent = all.find((w) => !w.getParentWindow());
+  const island = all.filter((w) => w.getParentWindow())
+    .find((w) => w.webContents.getURL().includes('index.html'));
+  const tree = globalThis.__glass?.describe(parent) || [];
+  return {
+    islandVisible: island.isVisible(),
+    glassInTree: tree.some((l) => l.startsWith('NSGlassEffectView')),
+  };
+});
+rec('utility sheet hides the resting island child',
+  duringSheet.islandVisible === false && beforeSheet.island.visible === true,
+  `island.visible before=${beforeSheet.island.visible} during=${duringSheet.islandVisible}`);
+
+// Summoning the island dismisses the sheet (one floating layer at a time).
+await app.evaluate(() => globalThis.__blanc.openPalette());
+await sleep(1600);
+const afterSheet = await snap();
+rec('island child returns when the sheet closes',
+  afterSheet.island.visible === true,
+  `island.visible=${afterSheet.island.visible}`);
+await app.evaluate(() => globalThis.__blanc.closeOverlay()).catch(() => {});
+await sleep(700);
+
+// ---- permission prompting under the new bounds ---------------------------
+const perm = await app.evaluate(async ({ BrowserWindow }) => {
+  const island = BrowserWindow.getAllWindows().filter((w) => w.getParentWindow())
+    .find((w) => w.webContents.getURL().includes('index.html'));
+  const before = island.getBounds();
+  // Drive the real renderer path: main sends permissions:prompt on this channel.
+  island.webContents.send('permissions:prompt',
+    { id: 'probe-1', origin: 'https://example.com', permission: 'geolocation', mediaTypes: [] });
+  await new Promise((r) => setTimeout(r, 1200));
+  const shown = await island.webContents.executeJavaScript(`(() => {
+    const bar = document.getElementById('permissionBar');
+    const r = bar.getBoundingClientRect();
+    return { hidden: bar.hidden, w: Math.round(r.width), h: Math.round(r.height),
+             text: (bar.textContent || '').replace(/\\s+/g,' ').trim().slice(0, 60) };
+  })()`);
+  return { before, shown, after: island.getBounds() };
+});
+// The bar is narrower than the pill and flows BELOW it, so the host grows in
+// HEIGHT, not width — the first run asserted the wrong axis.
+rec('permission prompt renders in the tight island child and grows its host',
+  perm.shown.hidden === false && perm.shown.w > 0
+    && perm.after.height > perm.before.height
+    && perm.after.height >= perm.shown.h,
+  `bar=${perm.shown.w}x${perm.shown.h} host ${perm.before.width}x${perm.before.height}`
+  + ` -> ${perm.after.width}x${perm.after.height} "${perm.shown.text}"`);
+rec('permission prompt keeps its own opaque surface (not glass)',
+  perm.shown.bg && perm.shown.bg !== 'rgba(0, 0, 0, 0)',
+  `#permissionBar background=${perm.shown.bg}`);
+
+// ---- Spaces / fullscreen -------------------------------------------------
+await app.evaluate(({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).setFullScreen(true);
+});
+await sleep(3600);
+s = await snap();
+rec('native fullscreen (own Space): island tight + centred, glass aligned',
+  s.island.visible && Math.abs(s.island.b.x - (s.parent.x + Math.round((s.parent.width - s.island.b.width) / 2))) <= 3
+    && s.glass && Math.abs(s.glass.w - s.island.b.width) <= 3,
+  `parent=${s.parent.width}x${s.parent.height} island.x=${s.island.b.x} w=${s.island.b.width}`);
+await app.evaluate(({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).setFullScreen(false);
+});
+await sleep(3000);
+s = await snap();
+rec('leaves fullscreen with tight bounds intact',
+  Math.abs(s.island.b.x - (s.parent.x + Math.round((s.parent.width - s.island.b.width) / 2))) <= 3,
+  `island.x=${s.island.b.x} parent=${s.parent.x} ${s.parent.width}`);
+
+const spaces = await app.evaluate(({ BrowserWindow }) => {
+  const kids = BrowserWindow.getAllWindows().filter((w) => w.getParentWindow());
+  return kids.map((w) => ({
+    url: w.webContents.getURL().split('/').pop(),
+    allSpaces: w.isVisibleOnAllWorkspaces(),
+    parented: !!w.getParentWindow(),
+  }));
+});
+rec('children are parented and NOT pinned to all Spaces (they ride the parent)',
+  spaces.every((k) => k.parented && k.allSpaces === false),
+  JSON.stringify(spaces));
+
+// ---- displays ------------------------------------------------------------
+s = await snap();
+if (s.displays.length < 2) {
+  note('multi-display / mixed scale',
+    `UNTESTABLE here — one display attached (${s.displays.map((d) => `${d.b.width}x${d.b.height}@${d.sf}x`).join(', ')}). `
+    + 'Bounds math is DIP-based via getContentBounds, which is display-agnostic; the unverified risks are '
+    + 'backingScaleFactor changes mid-drag and NSWindow child re-homing across screens.');
+} else {
+  note('multi-display', `${s.displays.length} displays present — extend this check`);
+}
+
+fs.writeFileSync(process.argv[2] || '/tmp/harden.json', JSON.stringify(results, null, 2));
+const graded = results.filter((r) => r.pass !== null);
+console.log(`\n=== ${graded.filter((r) => r.pass).length}/${graded.length} passed, ${results.length - graded.length} noted ===`);
+await app.close();
+server.close();

--- a/native/glass/testing/native-glass-test.mjs
+++ b/native/glass/testing/native-glass-test.mjs
@@ -1,0 +1,75 @@
+// Does NSGlassEffectView sample the Chromium-composited page in the NSView
+// beneath it, or only the window background?
+//
+// The page is bold horizontal bands. If the glass samples it, the pill's
+// interior tracks the bands and CHANGES when the page scrolls — with the window
+// stationary and the desktop untouched, so nothing else can explain the delta.
+// Scroll position is the independent variable; window position is not.
+import { createRequire } from 'node:module';
+const require = createRequire('/Users/anthonyjloria/Projects/Blanc Browser/');
+const { _electron } = require('playwright');
+import { execFileSync } from 'node:child_process';
+import { createServer } from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO = '/Users/anthonyjloria/Projects/Blanc Browser';
+const OUT = process.argv[2];
+fs.mkdirSync(OUT, { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const html = `<body style="margin:0;height:400vh;background:repeating-linear-gradient(
+  180deg,#ff0040 0 70px,#ffd400 70px 140px,#00e5ff 140px 210px,#0d00ff 210px 280px)"></body>`;
+const server = createServer((_q, res) => {
+  res.writeHead(200, { 'content-type': 'text/html' });
+  res.end(html);
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const PAGE = `http://127.0.0.1:${server.address().port}/`;
+
+const userDataDir = fs.mkdtempSync('/tmp/blanc-native-');
+const app = await _electron.launch({
+  args: [REPO, `--user-data-dir=${userDataDir}`],
+  env: { ...process.env, BLANC_TEST: '1', BLANC_GLASS: '1' },
+});
+await app.evaluate(() => new Promise((r) => {
+  const t = setInterval(() => { if (globalThis.__blanc) { clearInterval(t); r(); } }, 50);
+}));
+
+const W = 900, H = 600, PAD = 30;
+const WIN = { x: 280, y: 200, width: W, height: H };
+await app.evaluate(({ BrowserWindow }, b) => {
+  const w = BrowserWindow.getAllWindows()[0];
+  w.setBounds(b); w.show(); w.focus();
+}, WIN);
+
+const tabId = await app.evaluate((_e, u) => globalThis.__blanc.openTab(u), PAGE);
+await sleep(2600);
+await app.evaluate((_e, id) => globalThis.__blanc.activateTab(id), tabId);
+await sleep(1400);
+
+async function shot(name) {
+  await sleep(600);
+  execFileSync('/usr/sbin/screencapture', ['-x', '-R',
+    `${WIN.x - PAD},${WIN.y - PAD},${W + PAD * 2},${H + PAD * 2}`,
+    path.join(OUT, `${name}.png`)]);
+  console.log('captured', name);
+}
+
+async function scrollTo(px) {
+  await app.evaluate(async ({ webContents }, y) => {
+    const wc = webContents.getAllWebContents().find((w) => w.getURL().startsWith('http://127.'));
+    await wc.executeJavaScript(`window.scrollTo(0, ${y}); document.title='y'+window.scrollY;`);
+  }, px);
+  await sleep(900);
+}
+
+// Same window position, same desktop, only the page moves underneath.
+for (const y of [0, 35, 70, 105]) {
+  await scrollTo(y);
+  await shot(`scroll-${String(y).padStart(3, '0')}`);
+}
+
+console.log('done ->', OUT);
+await app.close();
+server.close();

--- a/native/glass/testing/phase2.mjs
+++ b/native/glass/testing/phase2.mjs
@@ -1,0 +1,230 @@
+// PHASE TWO — vertical slice through Blanc's REAL island, split across windows.
+// Everything here drives the shipping IPC/preload path (__blanc test hook →
+// main → chrome renderers), not a mock.
+import { createRequire } from 'node:module';
+const require = createRequire('/Users/anthonyjloria/Projects/Blanc Browser/');
+const { _electron } = require('playwright');
+import { createServer } from 'node:http';
+import fs from 'node:fs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const results = [];
+const rec = (name, pass, detail) => {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name} — ${detail}`);
+};
+
+const server = createServer((_q, res) => {
+  res.writeHead(200, { 'content-type': 'text/html' });
+  res.end(`<title>Fixture</title><body style="margin:0;height:400vh;background:repeating-linear-gradient(
+    180deg,#ff0040 0 70px,#ffd400 70px 140px,#00e5ff 140px 210px,#0d00ff 210px 280px)"></body>`);
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const PAGE = `http://127.0.0.1:${server.address().port}/`;
+
+const app = await _electron.launch({
+  args: ['/Users/anthonyjloria/Projects/Blanc Browser',
+         `--user-data-dir=${fs.mkdtempSync('/tmp/blanc-p2-')}`],
+  env: { ...process.env, BLANC_TEST: '1', BLANC_GLASS: '1' },
+});
+await app.evaluate(() => new Promise((r) => {
+  const t = setInterval(() => { if (globalThis.__blanc) { clearInterval(t); r(); } }, 50);
+}));
+await app.evaluate(({ BrowserWindow }) => {
+  const w = BrowserWindow.getAllWindows().find((x) => !x.getParentWindow());
+  w.setBounds({ x: 260, y: 180, width: 1000, height: 660 });
+  w.show(); w.focus();
+});
+await sleep(2500);
+
+// ---- window topology -----------------------------------------------------
+const win = (role) => app.evaluate(({ BrowserWindow }, r) => {
+  const all = BrowserWindow.getAllWindows();
+  const parent = all.find((w) => !w.getParentWindow());
+  const kids = all.filter((w) => w.getParentWindow());
+  const byUrl = (frag) => kids.find((w) => w.webContents.getURL().includes(frag));
+  const w = r === 'parent' ? parent : r === 'island' ? byUrl('index.html') : byUrl('overlay.html');
+  if (!w) return null;
+  return {
+    id: w.id, bounds: w.getBounds(), visible: w.isVisible(), focused: w.isFocused(),
+    url: w.webContents.getURL().split('/').pop(),
+  };
+}, role);
+
+const evalIn = (role, src) => app.evaluate(async ({ BrowserWindow }, p) => {
+  const all = BrowserWindow.getAllWindows();
+  const kids = all.filter((w) => w.getParentWindow());
+  const w = p.role === 'island'
+    ? kids.find((x) => x.webContents.getURL().includes('index.html'))
+    : kids.find((x) => x.webContents.getURL().includes('overlay.html'));
+  if (!w) return { __missing: true };
+  return w.webContents.executeJavaScript(p.src);
+}, { role, src });
+
+const glassFrame = () => app.evaluate(({ BrowserWindow }) => {
+  const parent = BrowserWindow.getAllWindows().find((w) => !w.getParentWindow());
+  const tree = globalThis.__glass?.describe(parent) || [];
+  const line = tree.find((l) => l.startsWith('NSGlassEffectView'));
+  const m = line && line.match(/frame=\{\{([-\d.]+), ([-\d.]+)\}, \{([-\d.]+), ([-\d.]+)\}\}/);
+  return m ? { x: +m[1], y: +m[2], w: +m[3], h: +m[4] } : null;
+});
+
+const t = await Promise.all([win('parent'), win('island'), win('overlay')]);
+rec('three windows: parent + island(index.html) + overlay(overlay.html)',
+  !!t[0] && t[1]?.url === 'index.html' && t[2]?.url === 'overlay.html',
+  JSON.stringify(t.map((x) => x && { url: x.url, visible: x.visible })));
+
+// ---- 1. resting pill renders the REAL island -----------------------------
+const pill = await evalIn('island', `(() => {
+  const p = document.getElementById('islandPill');
+  const r = p.getBoundingClientRect();
+  return { exists: !!p, w: Math.round(r.width), h: Math.round(r.height),
+           domain: document.getElementById('pillDomain')?.textContent?.trim() || null,
+           glass: document.documentElement.getAttribute('data-glass') };
+})()`);
+rec('resting pill is the real #islandPill, glass-scoped',
+  pill.exists && pill.w > 0 && pill.glass === 'on', JSON.stringify(pill));
+
+const restGlass = await glassFrame();
+rec('native glass tracks the resting pill width',
+  !!restGlass && Math.abs(restGlass.w - pill.w) <= 3,
+  `glass.w=${restGlass?.w} pill.w=${pill.w}`);
+
+// ---- 2. ⌘L opens the palette, glass follows the panel ---------------------
+await app.evaluate(() => globalThis.__blanc.openPalette());
+await sleep(1200);
+const ov = await win('overlay');
+const panel = await evalIn('overlay', `(() => {
+  const el = document.querySelector('#islandPanel');
+  const r = el.getBoundingClientRect();
+  return { mode: document.body.dataset.mode, w: Math.round(r.width), h: Math.round(r.height),
+           scrimShown: !document.getElementById('backdrop').hidden,
+           focused: document.activeElement?.id };
+})()`);
+rec('⌘L palette: overlay window shown, panel rendered, address focused',
+  ov.visible && panel.mode === 'palette' && panel.w > 0 && panel.focused === 'addressInput',
+  JSON.stringify(panel));
+
+const panelGlass = await glassFrame();
+rec('native glass grew to the expanded panel',
+  !!panelGlass && Math.abs(panelGlass.w - panel.w) <= 3 && panelGlass.w > restGlass.w,
+  `glass=${panelGlass?.w}x${panelGlass?.h} panel=${panel.w}x${panel.h}`);
+
+rec('palette scrim needs (and gets) a full-window child surface',
+  panel.scrimShown && ov.bounds.width >= 990,
+  `scrim=${panel.scrimShown} overlayWindow.w=${ov.bounds.width}`);
+
+// ---- 3. typing + navigation through the real path ------------------------
+await evalIn('overlay', `(() => {
+  const i = document.getElementById('addressInput');
+  i.focus(); i.value = ${JSON.stringify(PAGE)};
+  i.dispatchEvent(new Event('input', { bubbles: true }));
+  i.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+  return true;
+})()`);
+await sleep(3200);
+const nav = await app.evaluate(() => {
+  const s = globalThis.__blanc.state();
+  return { url: s.tabs.find((x) => x.id === s.activeTabId)?.url, overlay: globalThis.__blanc.overlayMode() };
+});
+rec('typed address navigated the real tab and dismissed the overlay',
+  (nav.url || '').startsWith('http://127.') && !nav.overlay, JSON.stringify(nav));
+
+const afterNavGlass = await glassFrame();
+const pillNow = await evalIn('island',
+  "Math.round(document.getElementById('islandPill').getBoundingClientRect().width)");
+rec('glass returned to tight resting-pill bounds after dismissal',
+  !!afterNavGlass && Math.abs(afterNavGlass.w - pillNow) <= 3 && afterNavGlass.w < 620,
+  `glass.w=${afterNavGlass?.w} livePill=${pillNow} (was ${restGlass.w} showing "new tab")`);
+
+// ---- 4. Escape dismissal -------------------------------------------------
+await app.evaluate(() => globalThis.__blanc.openPalette());
+await sleep(900);
+await app.evaluate(({ BrowserWindow }) => {
+  const w = BrowserWindow.getAllWindows().find((x) => x.webContents.getURL().includes('overlay.html'));
+  w.webContents.sendInputEvent({ type: 'keyDown', keyCode: 'Escape' });
+});
+await sleep(900);
+rec('Escape dismisses across the window boundary',
+  (await app.evaluate(() => globalThis.__blanc.overlayMode())) === null
+    && !(await win('overlay')).visible,
+  'overlayMode=null, overlay window hidden');
+
+// ---- 5. blur dismissal ---------------------------------------------------
+await app.evaluate(() => globalThis.__blanc.openPalette());
+await sleep(900);
+await app.evaluate(({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).focus();
+});
+await sleep(1200);
+rec('parent focus blurs the overlay window and dismisses',
+  (await app.evaluate(() => globalThis.__blanc.overlayMode())) === null,
+  'overlayMode after parent focus');
+
+// ---- 6. focus reclaim on a blank new tab ---------------------------------
+await app.evaluate(({ Menu }) => {
+  // The production path: the menu item passes focusAddress:true, which the
+  // test hook's newTab() does not. Only this exercises the reclaim.
+  const find = (items) => {
+    for (const it of items) {
+      if (it.label === 'New Tab') return it;
+      if (it.submenu) { const hit = find(it.submenu.items); if (hit) return hit; }
+    }
+    return null;
+  };
+  find(Menu.getApplicationMenu().items).click();
+});
+await sleep(2200);
+const reclaim = await app.evaluate(() => ({
+  overlay: globalThis.__blanc.overlayMode(),
+  url: globalThis.__blanc.state().tabs.find((t) => t.id === globalThis.__blanc.state().activeTabId)?.url,
+}));
+const reclaimFocus = reclaim.overlay ? await evalIn('overlay', "document.activeElement?.id") : null;
+rec('blank new tab reclaims address-bar focus into the child window',
+  reclaim.overlay === 'panel' && reclaimFocus === 'addressInput',
+  `mode=${reclaim.overlay} focus=${reclaimFocus} url=${reclaim.url}`);
+await app.evaluate(() => globalThis.__blanc.closeOverlay());
+await sleep(600);
+
+// ---- 7. parent lifecycle -------------------------------------------------
+async function lifecycle(label, fn, settle = 1600) {
+  await app.evaluate(fn);
+  await sleep(settle);
+  const [p, i] = await Promise.all([win('parent'), win('island')]);
+  const expectedX = p.bounds.x + Math.round((p.bounds.width - i.bounds.width) / 2);
+  const aligned = Math.abs(i.bounds.x - expectedX) <= 3 || i.bounds.width >= p.bounds.width - 4;
+  rec(`lifecycle: ${label}`, i.visible && aligned,
+    `parent=${p.bounds.x},${p.bounds.y} ${p.bounds.width}x${p.bounds.height} island=${i.bounds.x},${i.bounds.y} ${i.bounds.width}x${i.bounds.height}`);
+}
+await lifecycle('move', ({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).setBounds({ x: 120, y: 260, width: 1000, height: 660 });
+});
+await lifecycle('resize', ({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).setBounds({ x: 120, y: 260, width: 1240, height: 700 });
+});
+await lifecycle('native fullscreen', ({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).setFullScreen(true);
+}, 3400);
+await lifecycle('leave fullscreen', ({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).setFullScreen(false);
+}, 3000);
+
+// minimize / restore
+await app.evaluate(({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).minimize();
+});
+await sleep(1800);
+const minned = await win('island');
+await app.evaluate(({ BrowserWindow }) => {
+  BrowserWindow.getAllWindows().find((x) => !x.getParentWindow()).restore();
+});
+await sleep(2200);
+const restored = await win('island');
+rec('minimize hides the island child; restore brings it back',
+  minned.visible === false && restored.visible === true,
+  `minimized.visible=${minned.visible} restored.visible=${restored.visible}`);
+
+fs.writeFileSync(process.argv[2] || '/tmp/phase2.json', JSON.stringify(results, null, 2));
+console.log(`\n=== ${results.filter((r) => r.pass).length}/${results.length} passed ===`);
+await app.close();
+server.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "@ghostery/adblocker": "^2.18.1",
         "electron": "^43.3.0",
         "electron-builder": "^26.15.3",
+        "node-addon-api": "^8.9.1",
+        "node-gyp": "^12.4.0",
         "playwright": "^1.49.0",
         "sharp": "^0.35.3"
       }
@@ -3824,6 +3826,16 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-api-version": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "@ghostery/adblocker": "^2.18.1",
     "electron": "^43.3.0",
     "electron-builder": "^26.15.3",
+    "node-addon-api": "^8.9.1",
+    "node-gyp": "^12.4.0",
     "playwright": "^1.49.0",
     "sharp": "^0.35.3"
   },

--- a/src/main/glass-native.js
+++ b/src/main/glass-native.js
@@ -1,0 +1,100 @@
+// EXPERIMENT — thin, failure-tolerant wrapper around the NSGlassEffectView
+// addon (src/native/glass.mm). The addon is built out-of-tree by node-gyp and
+// is absent on every non-mac platform and on any machine that hasn't run the
+// rebuild, so nothing here may throw at require time.
+'use strict';
+
+const path = require('node:path');
+
+let native = null;
+let loadError = null;
+
+if (process.platform === 'darwin') {
+  try {
+    // eslint-disable-next-line import/no-dynamic-require, global-require
+    // native/glass/ has its own build dir on purpose: node-gyp treats `build/`
+    // as scratch and wipes it, and the repo's own build/ holds the signing
+    // entitlements, provisioning profile and app icons electron-builder needs.
+    native = require(
+      path.join(__dirname, '..', '..', 'native', 'glass', 'build', 'Release', 'glass.node')
+    );
+  } catch (err) {
+    loadError = err;
+  }
+}
+
+/** True only when the addon loaded AND the OS actually has macOS 26's glass. */
+function isSupported() {
+  try {
+    return !!native && native.isSupported();
+  } catch {
+    return false;
+  }
+}
+
+function why() {
+  if (process.platform !== 'darwin') return 'not macOS';
+  if (loadError) return `addon not built: ${loadError.message.split('\n')[0]}`;
+  if (!isSupported()) return 'NSGlassEffectView unavailable (needs macOS 26+)';
+  return 'ok';
+}
+
+/**
+ * Frames arrive in CSS coordinates (origin top-left, matching how the rest of
+ * main.js reasons about bounds) and are flipped to AppKit's bottom-left origin
+ * here, so callers never have to think about it.
+ */
+function flip(rect, contentHeight) {
+  return {
+    x: rect.x,
+    y: contentHeight - rect.y - rect.height,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function attach(win, rect, opts = {}) {
+  if (!isSupported()) return false;
+  const { height } = win.getContentBounds();
+  native.attach(win.getNativeWindowHandle(), {
+    ...flip(rect, height),
+    cornerRadius: opts.cornerRadius ?? rect.height / 2,
+    style: opts.style ?? 'regular',
+    interactive: opts.interactive ?? true,
+    // Slot in beneath the topmost subview — the island's contents — so they
+    // render on the glass rather than being refracted by it.
+    belowTop: opts.belowTop ?? true,
+    zOrder: opts.zOrder || process.env.BLANC_GLASS_Z || 'default',
+  });
+  return true;
+}
+
+function setFrame(win, rect, opts = {}) {
+  if (!isSupported()) return;
+  const { height } = win.getContentBounds();
+  native.setFrame({
+    ...flip(rect, height),
+    cornerRadius: Number.isFinite(opts.cornerRadius) ? opts.cornerRadius : rect.height / 2,
+  });
+}
+
+function raise() {
+  if (isSupported()) native.raise();
+}
+
+function setHidden(hidden) {
+  if (isSupported()) native.setHidden(!!hidden);
+}
+
+function detach() {
+  if (isSupported()) native.detach();
+}
+
+module.exports = { isSupported, why, attach, setFrame, raise, setHidden, detach };
+
+/** Diagnostic only — dumps the window's real AppKit subview tree. */
+function describe(win) {
+  if (!native) return ['<addon not loaded>'];
+  return native.describe(win.getNativeWindowHandle()) || [];
+}
+module.exports.describe = describe;

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -10,6 +10,7 @@ const {
   onRequestBlocked,
 } = require('./adblock');
 const { webrtcPolicyFor, hostResolverOptionsFor } = require('./network-privacy');
+const glassNative = require('./glass-native'); // EXPERIMENT — NSGlassEffectView
 const {
   chromeClientHintPlatform,
   chromeClientHintArchitecture,
@@ -442,6 +443,22 @@ function lockPrivilegedNavigation(wc, trustedUrl) {
   wc.setWindowOpenHandler(() => ({ action: 'deny' }));
 }
 
+// EXPERIMENT (opt-in via BLANC_GLASS=1) — liquid glass as the material OF the
+// Island, in both its collapsed and expanded states.
+//
+// Mechanism is CSS backdrop-filter, NOT NSVisualEffectView/NSGlassEffectView.
+// Native vibrancy is a window-level material: it cannot be masked to the pill's
+// shape, and it samples what is behind the WINDOW (the desktop) rather than the
+// page. backdrop-filter can do both, and — measured on this branch — it samples
+// across the WebContentsView boundary, so the island refracts real page content.
+//
+// The expanded states need nothing but CSS: the overlay view already floats
+// over the page. The collapsed pill does not — it lives in the strip, and the
+// page starts below it at y = stripHeight, so there is nothing behind it to
+// refract. Giving it real glass therefore requires the page to run full-bleed
+// with the pill floating above it, which is what glassStripView below does.
+const GLASS_EXPERIMENT = process.env.BLANC_GLASS === '1';
+
 // Window background behind everything so resizes and load flashes stay
 // in-theme. The renderer gets the resolved appearance at the same time: a
 // nativeTheme source change reaches prefers-color-scheme asynchronously, and
@@ -463,7 +480,7 @@ function applyChromeThemeAppearance(appearance) {
     ? appearance
     : resolvedThemeAppearance();
   win.setBackgroundColor(chromeBackgroundColor(resolved));
-  win.webContents.send(
+  chromeWC()?.send(
     'chrome:theme-appearance',
     resolved
   );
@@ -477,7 +494,7 @@ function beginChromeThemeAppearance(appearance) {
   if (appearance === 'dark' || appearance === 'light') {
     win.setBackgroundColor(chromeBackgroundColor(appearance));
   }
-  win.webContents.send('chrome:theme-appearance', appearance ?? 'pending');
+  chromeWC()?.send('chrome:theme-appearance', appearance ?? 'pending');
 }
 
 function refreshActivePageTintForThemeChange() {
@@ -639,12 +656,227 @@ let addressMenuSeq = 0;
 
 function currentChromeLayout() {
   const { width, height } = win.getContentBounds();
-  return calculateChromeLayout({
+  const layout = calculateChromeLayout({
     width,
     height,
     chromeHeight,
     tabLayout,
     verticalTabsWidth: verticalTabsPreferredWidth,
+  });
+  if (!GLASS_EXPERIMENT) return layout;
+  // EXPERIMENT: run the page to the top edge so the collapsed island has live
+  // content behind it to refract. chrome-layout.js stays untouched (it is pure
+  // and unit-tested) — this overrides only the consumed bounds.
+  return { ...layout, pageBounds: { ...layout.pageBounds, y: 0, height } };
+}
+
+// DESIGN DECISION 1: the resting island child is bounded TIGHTLY to the pill,
+// not to a full-width 64px band. That preserves the parent's native traffic
+// lights and its drag space by construction — the child simply isn't over them
+// — instead of relying on click-through toggling.
+//
+// The pill's width is content-driven (the domain string), so main cannot
+// compute it. Each chrome renderer reports the box its window must hold plus
+// the sub-rect that should BE the glass; these are the last reports received.
+const GLASS_ISLAND_TOP = 12;
+/** @type {{width:number,height:number,glass:object}|null} */
+let reportedIslandBox = null;
+/** @type {{width:number,height:number,glass:object}|null} */
+let reportedOverlayBox = null;
+// Pre-first-report fallback so the window has a sane size for one frame.
+const GLASS_PILL = { width: 280, height: 41, top: GLASS_ISLAND_TOP };
+
+// Centre a reported box over the website pane, in parent CONTENT coords.
+function centredBox(box, top) {
+  const layout = currentChromeLayout();
+  const w = Math.max(1, Math.round(box.width));
+  const h = Math.max(1, Math.round(box.height));
+  return {
+    x: layout.pageBounds.x + Math.round((layout.pageBounds.width - w) / 2),
+    y: top,
+    width: w,
+    height: h,
+  };
+}
+
+function glassStripBounds() {
+  return centredBox(
+    reportedIslandBox || { width: GLASS_PILL.width, height: GLASS_PILL.height },
+    GLASS_ISLAND_TOP
+  );
+}
+
+// CSS coords (origin top-left); glass-native.js flips to AppKit for us.
+// The glass sub-rect is reported relative to the child document's origin, so
+// it composes with the window's own position.
+function glassPillRect() {
+  const win_ = glassStripBounds();
+  const g = reportedIslandBox?.glass;
+  if (!g) return { ...win_, height: GLASS_PILL.height };
+  return {
+    x: win_.x + g.x,
+    y: win_.y + g.y,
+    width: g.width,
+    height: g.height,
+  };
+}
+
+// EXPERIMENT — CROSS-WINDOW COMPOSITION.
+//
+// Same-window layering is impossible: Chromium composites all of its views into
+// one layer that always sits below a native sibling, so an NSGlassEffectView is
+// always above every web pixel (proven by moving the glass to the bottom of the
+// subview list and getting an identical render). The remaining escape hatch is
+// a SECOND NSWindow: the WindowServer composites windows independently, so a
+// transparent child window's Chromium pixels land on top of the parent's
+// finished output — glass included — while the parent's glass keeps sampling
+// the page inside the parent.
+// PHASE TWO — the real island, split across child windows.
+//
+// Both chrome surfaces move out of the parent window, because Chromium content
+// can only composite above the native glass by living in a separate NSWindow.
+// The split deliberately mirrors today's: islandWindow carries index.html (what
+// the parent's own webContents renders now), overlayWindow carries
+// overlay.html (what overlayView renders now). Same documents, same preload,
+// same IPC — only the host changes, so the existing renderer code is untouched.
+/** @type {BrowserWindow | null} */
+let islandWindow = null;
+/** @type {BrowserWindow | null} */
+let overlayWindow = null;
+
+const CHILD_WINDOW_OPTS = {
+  frame: false,
+  transparent: true,
+  backgroundColor: '#00000000',
+  hasShadow: false,
+  resizable: false,
+  movable: false,
+  minimizable: false,
+  maximizable: false,
+  fullscreenable: false,
+  skipTaskbar: true,
+  acceptFirstMouse: true,
+};
+
+/** The webContents rendering the strip/resting pill. */
+function chromeWC() {
+  if (GLASS_EXPERIMENT) {
+    return islandWindow && !islandWindow.isDestroyed() ? islandWindow.webContents : null;
+  }
+  return win && !win.isDestroyed() ? win.webContents : null;
+}
+
+/** The webContents rendering the expanded island states. */
+function overlayWC() {
+  if (GLASS_EXPERIMENT) {
+    return overlayWindow && !overlayWindow.isDestroyed() ? overlayWindow.webContents : null;
+  }
+  return overlayView?.webContents ?? null;
+}
+
+/** Content-relative rect → absolute screen rect. */
+function toScreenRect(rect) {
+  const c = win.getContentBounds();
+  return {
+    x: Math.round(c.x + rect.x),
+    y: Math.round(c.y + rect.y),
+    width: Math.max(1, Math.round(rect.width)),
+    height: Math.max(1, Math.round(rect.height)),
+  };
+}
+
+function syncGlassChromeBounds() {
+  if (!GLASS_EXPERIMENT || !win || win.isDestroyed()) return;
+  if (islandWindow && !islandWindow.isDestroyed()) {
+    islandWindow.setBounds(toScreenRect(glassStripBounds()));
+  }
+  if (overlayMode && overlayWindow && !overlayWindow.isDestroyed()) {
+    overlayWindow.setBounds(toScreenRect(overlayBounds()));
+  }
+  // The panel's height cap has to come from the PARENT's height: the overlay
+  // child is sized to its own content, so a vh-based cap there would be
+  // circular. Pushed as a custom property rather than a layout constant.
+  const avail = Math.max(200, win.getContentBounds().height - 24);
+  overlayWC()?.executeJavaScript(
+    `document.documentElement.style.setProperty('--glass-avail-h','${avail}px')`
+  ).catch(() => {});
+}
+
+function createGlassChrome() {
+  console.log('[glass] native NSGlassEffectView:', glassNative.why());
+  globalThis.__glass = glassNative; // EXPERIMENT: reachable from the test driver
+  // The glass lives in the PARENT window, directly over the full-bleed page.
+  glassNative.attach(win, glassPillRect(), { cornerRadius: GLASS_PILL.height / 2 });
+
+  islandWindow = new BrowserWindow({
+    ...toScreenRect(glassStripBounds()),
+    // `parent` makes this a real NSWindow child: it rides with the parent, is
+    // always ordered above it, and — unlike alwaysOnTop — sinks behind other
+    // applications when Blanc is deactivated.
+    parent: win,
+    ...CHILD_WINDOW_OPTS,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+  lockPrivilegedNavigation(islandWindow.webContents, CHROME_INDEX_URL);
+  installChromeShortcuts(islandWindow.webContents);
+  islandWindow.loadFile(CHROME_INDEX_FILE);
+
+  overlayWindow = new BrowserWindow({
+    ...toScreenRect(currentChromeLayout().panelBounds),
+    parent: win,
+    ...CHILD_WINDOW_OPTS,
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+  lockPrivilegedNavigation(overlayWindow.webContents, CHROME_OVERLAY_URL);
+  installChromeShortcuts(overlayWindow.webContents);
+  overlayWindow.loadFile(CHROME_OVERLAY_FILE);
+
+  // Escape at the main-process level, matching createOverlay's handler — the
+  // key must dismiss no matter which element inside the overlay holds focus.
+  overlayWindow.webContents.on('before-input-event', (event, input) => {
+    if (overlayMode && input.type === 'keyDown' && input.key === 'Escape') {
+      event.preventDefault();
+      hideOverlay();
+    }
+  });
+  // Window blur is the cross-window analogue of the overlay view's blur
+  // dismissal. Find is exempt (same as today), and the blank-tab focus-reclaim
+  // guard still applies or the reclaim dance reopens/closes in a loop.
+  overlayWindow.on('blur', () => {
+    if (!overlayMode || overlayMode === 'find') return;
+    if (addressMenuTicket) return;
+    if (activeTabId && tabsWantingAddressBarFocus.has(activeTabId)) return;
+    hideOverlay();
+  });
+
+  // The children are positioned in screen space, so every parent geometry
+  // change has to be mirrored. NSWindow parenting moves them on a title-bar
+  // drag, but not on resize or programmatic setBounds.
+  for (const evt of ['move', 'moved', 'resize', 'resized', 'restore',
+                     'enter-full-screen', 'leave-full-screen']) {
+    win.on(evt, syncGlassChromeBounds);
+  }
+  // A minimized parent leaves NSWindow children orphaned on screen unless they
+  // are explicitly hidden with it.
+  win.on('minimize', () => {
+    setGlassChromeVisible(false);
+    overlayWindow?.hide();
+  });
+  win.on('restore', () => {
+    // A sheet open across a minimize must stay the only surface on restore.
+    if (!utilitySheetUrl) setGlassChromeVisible(true);
+    if (overlayMode) overlayWindow?.showInactive();
   });
 }
 
@@ -660,9 +892,28 @@ function verticalTabsMetrics(layout = currentChromeLayout()) {
 
 function overlayBounds() {
   const layout = currentChromeLayout();
-  if (overlayMode === 'find') return layout.findBounds;
-  if (overlayMode === 'palette') return layout.paletteBounds;
-  return layout.panelBounds;
+  if (!GLASS_EXPERIMENT) {
+    if (overlayMode === 'find') return layout.findBounds;
+    if (overlayMode === 'palette') return layout.paletteBounds;
+    return layout.panelBounds;
+  }
+  // DESIGN DECISION 2: panel and find get TIGHT child bounds, so the rest of
+  // the page stays clickable. Only palette takes the full window, because
+  // there the scrim deliberately owns outside clicks — that surface IS the
+  // dismissal target, not incidental coverage.
+  if (overlayMode === 'palette') return layout.panelBounds;
+  if (reportedOverlayBox) {
+    return centredBox(reportedOverlayBox, overlayMode === 'find' ? chromeHeight : GLASS_ISLAND_TOP);
+  }
+  return overlayMode === 'find' ? layout.findBounds : layout.panelBounds;
+}
+
+/** Parent-content rect of the glass while an expanded state is showing. */
+function glassOverlayRect() {
+  const g = reportedOverlayBox?.glass;
+  if (!g) return null;
+  const b = overlayBounds();
+  return { x: b.x + g.x, y: b.y + g.y, width: g.width, height: g.height, radius: g.radius };
 }
 
 function createOverlay() {
@@ -764,7 +1015,9 @@ function refocusOverlayAfterMenu() {
 }
 
 function showOverlay(mode, { prefill } = {}) {
-  if (!hasLiveWindow() || !overlayView) return;
+  if (!hasLiveWindow()) return;
+  if (!GLASS_EXPERIMENT && !overlayView) return;
+  if (GLASS_EXPERIMENT && (!overlayWindow || overlayWindow.isDestroyed())) return;
   // One floating layer at a time: summoning the island dismisses the sheet
   // (the overlay takes focus itself — no tab refocus in between).
   hideUtilitySheet({ refocusContent: false });
@@ -773,12 +1026,20 @@ function showOverlay(mode, { prefill } = {}) {
   if (mode === 'panel' || mode === 'palette') sync.refreshSession();
   overlayMode = mode;
   overlayPrefill = prefill ?? null;
-  // (Re-)adding moves the overlay to the top of the child-view stack.
-  win.contentView.addChildView(overlayView);
-  overlayView.setBounds(overlayBounds());
-  overlayView.webContents.send('overlay:show', { mode, prefill });
-  overlayView.webContents.focus();
-  win.webContents.send('chrome:island-state', { mode });
+  if (GLASS_EXPERIMENT) {
+    // The window IS the stacking: no re-adding to a child-view list. Bounds
+    // first, then show, so the first painted frame is already in position.
+    overlayWindow.setBounds(toScreenRect(overlayBounds()));
+    overlayWindow.show();
+    overlayWindow.focus();
+  } else {
+    // (Re-)adding moves the overlay to the top of the child-view stack.
+    win.contentView.addChildView(overlayView);
+    overlayView.setBounds(overlayBounds());
+  }
+  overlayWC()?.send('overlay:show', { mode, prefill });
+  overlayWC()?.focus();
+  chromeWC()?.send('chrome:island-state', { mode });
 }
 
 function hideOverlay({ refocusContent = true } = {}) {
@@ -787,12 +1048,23 @@ function hideOverlay({ refocusContent = true } = {}) {
   // A dismissed command bar means the user is done addressing — stop any
   // pending blank-tab focus reclaim so a page click can't reopen it.
   if (activeTabId) tabsWantingAddressBarFocus.delete(activeTabId);
-  if (hasLiveWindow() && overlayView) {
+  if (!hasLiveWindow()) return;
+  if (GLASS_EXPERIMENT) {
+    if (!overlayWindow || overlayWindow.isDestroyed()) return;
+    overlayWC()?.send('overlay:hide');
+    overlayWindow.hide();
+    // Hiding a focused child window leaves the app with no key window; hand
+    // focus back to the parent explicitly or the next keystroke goes nowhere.
+    if (!win.isDestroyed()) win.focus();
+    // Back to the resting pill's tight geometry.
+    glassNative.setFrame(win, glassPillRect());
+  } else {
+    if (!overlayView) return;
     win.contentView.removeChildView(overlayView);
     overlayView.webContents.send('overlay:hide');
-    win.webContents.send('chrome:island-state', { mode: null });
-    if (refocusContent) tabs.get(activeTabId)?.view.webContents.focus();
   }
+  chromeWC()?.send('chrome:island-state', { mode: null });
+  if (refocusContent) tabs.get(activeTabId)?.view.webContents.focus();
 }
 
 // --- Utility sheet (design: 2026-07-22-utility-sheet-design.md) ---
@@ -868,8 +1140,22 @@ function showUtilityPage(url) {
   // 'visible' and never background-throttles — toggle real visibility.
   utilitySheetView.setVisible(true);
   win.contentView.addChildView(utilitySheetView);
+  // DESIGN DECISION 3: a utility sheet is a deliberate modal surface, so the
+  // glass and the resting island go away entirely rather than leaving a
+  // residual pill refracting on top of the sheet. Nothing moves into another
+  // child window — the sheet stays a plain parent-hosted view.
+  setGlassChromeVisible(false);
   resizeActiveView();
   utilitySheetView.webContents.focus();
+}
+
+/** Show/hide the glass + resting island together (utility sheet, minimize). */
+function setGlassChromeVisible(visible) {
+  if (!GLASS_EXPERIMENT) return;
+  glassNative.setHidden(!visible);
+  if (!islandWindow || islandWindow.isDestroyed()) return;
+  if (visible) islandWindow.showInactive();
+  else islandWindow.hide();
 }
 
 function hideUtilitySheet({ refocusContent = true } = {}) {
@@ -878,6 +1164,7 @@ function hideUtilitySheet({ refocusContent = true } = {}) {
   if (hasLiveWindow() && utilitySheetView) {
     win.contentView.removeChildView(utilitySheetView);
     utilitySheetView.setVisible(false);
+    setGlassChromeVisible(true);
     if (refocusContent) tabs.get(activeTabId)?.view.webContents.focus();
   }
 }
@@ -1013,13 +1300,13 @@ function broadcastTabs() {
     tabLayout,
     ...widthMetrics,
   };
-  win.webContents.send('tabs:updated', payload);
-  overlayView?.webContents.send('tabs:updated', payload);
+  chromeWC()?.send('tabs:updated', payload);
+  overlayWC()?.send('tabs:updated', payload);
 }
 
 function broadcastDownloadsActivity() {
   if (!win || win.isDestroyed()) return;
-  win.webContents.send('chrome:downloads', downloadsActivity());
+  chromeWC()?.send('chrome:downloads', downloadsActivity());
 }
 
 // The blocked-request counter can tick many times a second during a page
@@ -1038,6 +1325,10 @@ function resizeActiveView() {
   const layout = currentChromeLayout();
   const tab = activeTabId ? tabs.get(activeTabId) : null;
   if (tab) tab.view.setBounds(layout.pageBounds);
+  if (GLASS_EXPERIMENT) {
+    glassNative.setFrame(win, glassPillRect());
+    syncGlassChromeBounds();
+  }
   if (overlayMode && overlayView) overlayView.setBounds(overlayBounds());
   if (utilitySheetUrl && utilitySheetView) {
     utilitySheetView.setBounds(layout.utilityBounds);
@@ -1045,7 +1336,7 @@ function resizeActiveView() {
   // The BrowserWindow renderer and native child views must move in the same
   // frame. A dedicated geometry event avoids turning every pointermove or
   // window resize into a tab/session-sync broadcast.
-  win.webContents.send('chrome:vertical-tabs-width', verticalTabsMetrics(layout));
+  chromeWC()?.send('chrome:vertical-tabs-width', verticalTabsMetrics(layout));
 }
 
 function applyVerticalTabsWidth(nextWidth) {
@@ -1634,7 +1925,7 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
 
   wc.on('found-in-page', (_e, result) => {
     if (id === activeTabId) {
-      overlayView?.webContents.send('chrome:find-result', { activeMatchOrdinal: result.activeMatchOrdinal, matches: result.matches });
+      overlayWC()?.send('chrome:find-result', { activeMatchOrdinal: result.activeMatchOrdinal, matches: result.matches });
     }
   });
 
@@ -1815,6 +2106,10 @@ function setActiveTab(id, { focusContent = true, focusAddress = false } = {}) {
   // nor above the sheet (defensive: §5 means they shouldn't coexist here,
   // but a race must never paint a tab over either floating layer).
   if (utilitySheetUrl && utilitySheetView) win.contentView.addChildView(utilitySheetView);
+  // EXPERIMENT: the native glass is a raw NSView sibling, invisible to
+  // Electron's child-view ordering, so a freshly attached tab view would cover
+  // it. The island's contents live in a separate window and need no re-stacking.
+  if (GLASS_EXPERIMENT) glassNative.raise();
   if (overlayMode && overlayView) win.contentView.addChildView(overlayView);
   resizeActiveView();
   // Focusing the tab's WebContentsView gives it OS keyboard focus. For a
@@ -2076,7 +2371,7 @@ function toggleIsland() {
   win.focus();
   if (overlayMode === 'panel' || overlayMode === 'palette') {
     overlayView?.webContents.focus();
-    overlayView?.webContents.send('overlay:toggle');
+    overlayWC()?.send('overlay:toggle');
     return;
   }
   showOverlay('palette');
@@ -2087,7 +2382,12 @@ function focusAddressBar() {
   // setActiveTab() may just have handed OS-level keyboard focus to the
   // tab's WebContentsView; showOverlay reclaims it for the overlay's
   // webContents so the address input actually receives keystrokes.
-  win.focus();
+  //
+  // PHASE TWO: focusing the PARENT here would blur the overlay child window and
+  // trip its blur-dismissal, so the reclaim would close the very panel it is
+  // trying to focus. showOverlay focuses the child window directly, which takes
+  // OS focus away from the tab view just as effectively.
+  if (!GLASS_EXPERIMENT) win.focus();
   // Reasserts must not downgrade an already-summoned palette to a panel.
   showOverlay(overlayMode && overlayMode !== 'find' ? overlayMode : 'panel');
 }
@@ -2121,6 +2421,15 @@ function isTrustedChromeSender(event) {
     hasLiveWindow() ? { webContents: win.webContents, url: CHROME_INDEX_URL } : null,
     overlayView && !overlayView.webContents.isDestroyed()
       ? { webContents: overlayView.webContents, url: CHROME_OVERLAY_URL }
+      : null,
+    // PHASE TWO: the same two documents, now hosted in child windows. The
+    // allowlist stays identity + URL pinned — splitting the hosts adds
+    // entries, it does not loosen the check.
+    GLASS_EXPERIMENT && islandWindow && !islandWindow.webContents.isDestroyed()
+      ? { webContents: islandWindow.webContents, url: CHROME_INDEX_URL }
+      : null,
+    GLASS_EXPERIMENT && overlayWindow && !overlayWindow.webContents.isDestroyed()
+      ? { webContents: overlayWindow.webContents, url: CHROME_OVERLAY_URL }
       : null,
   ]);
 }
@@ -2230,13 +2539,50 @@ function registerIpcHandlers() {
     }
   });
 
+  // PHASE TWO: the renderer measures the element that should BE the glass
+  // (#islandPill at rest, #islandPanel expanded) and reports it here, so the
+  // native view tracks a shape main.js cannot compute — the panel's height
+  // depends on its content.
+  // Each chrome renderer reports the box its window must hold plus the sub-rect
+  // that should BE the glass. Main cannot compute either: the pill's width is
+  // driven by the domain string and the panel's height by its content.
+  chromeOn('chrome:glass-rect', (event, payload) => {
+    if (!GLASS_EXPERIMENT || !hasLiveWindow()) return;
+    const box = payload && payload.host;
+    const glass = payload && payload.glass;
+    if (!box || !(box.width > 0) || !glass || !(glass.width > 0)) return;
+    const fromOverlay = event.sender === overlayWC();
+    // Ignore reports from the surface that is not currently in charge, or a
+    // stale frame would resize the window/glass to the wrong state.
+    if (fromOverlay && !overlayMode) return;
+    if (!fromOverlay && overlayMode) return;
+
+    if (fromOverlay) {
+      reportedOverlayBox = { ...box, glass };
+      if (overlayWindow && !overlayWindow.isDestroyed()) {
+        overlayWindow.setBounds(toScreenRect(overlayBounds()));
+      }
+      const r = glassOverlayRect();
+      if (r) glassNative.setFrame(win, r, { cornerRadius: r.radius });
+    } else {
+      reportedIslandBox = { ...box, glass };
+      if (islandWindow && !islandWindow.isDestroyed()) {
+        islandWindow.setBounds(toScreenRect(glassStripBounds()));
+      }
+      const r = glassPillRect();
+      glassNative.setFrame(win, r, { cornerRadius: glass.radius ?? r.height / 2 });
+    }
+  });
+
   chromeOn('chrome:open-island', () => showOverlay('panel'));
   chromeOn('chrome:open-find', () => showOverlay('find'));
   chromeHandle('chrome:open-main-menu', (event, point) => {
     // The rich preload is shared with the overlay, but the visible platform
     // menu button exists only in the strip document. Keep this entry point as
     // narrow as the UI that owns it.
-    if (event.sender !== win?.webContents) return false;
+    // PHASE TWO: the strip document may now live in islandWindow, so compare
+    // against whichever webContents actually renders it.
+    if (event.sender !== chromeWC()) return false;
     return popupPlatformMainMenu({ Menu, window: win, point });
   });
   chromeHandle('chrome:set-tab-layout', (_e, layout) => setTabLayout(layout));
@@ -2744,6 +3090,18 @@ function createMainWindow() {
   installChromeShortcuts(win.webContents);
   win.loadFile(CHROME_INDEX_FILE);
   createOverlay();
+  if (GLASS_EXPERIMENT) {
+    createGlassChrome();
+    // Scope the glass CSS without adding an IPC channel or a renderer branch.
+    // Both child windows carry chrome documents, so both need the flag.
+    for (const wc of [islandWindow.webContents, overlayWindow.webContents]) {
+      wc.on('did-finish-load', () => {
+        wc.executeJavaScript(
+          "document.documentElement.setAttribute('data-glass','on')"
+        ).then(() => syncGlassChromeBounds()).catch(() => {});
+      });
+    }
+  }
   win.on('resize', resizeActiveView);
   win.on('focus', refocusAddressBarIfWanted);
   win.on('closed', () => {
@@ -2752,6 +3110,12 @@ function createMainWindow() {
     overlayMode = null;
     if (overlayView && !overlayView.webContents.isDestroyed()) overlayView.webContents.close();
     overlayView = null;
+    glassNative.detach();
+    for (const w of [islandWindow, overlayWindow]) {
+      if (w && !w.isDestroyed()) w.destroy();
+    }
+    islandWindow = null;
+    overlayWindow = null;
     // The sheet doesn't outlive its window either — dropping the reference
     // without closing would leak the webContents.
     if (utilitySheetView && !utilitySheetView.webContents.isDestroyed()) utilitySheetView.webContents.close();
@@ -2891,7 +3255,7 @@ app.whenReady().then(async () => {
       if (!hasLiveWindow()) return resolve(null);
       const promptId = ++permissionPromptCounter;
       pendingPermissionPrompts.set(promptId, resolve);
-      win.webContents.send('permissions:prompt', { id: promptId, origin, permission, mediaTypes });
+      chromeWC()?.send('permissions:prompt', { id: promptId, origin, permission, mediaTypes });
     })
   );
   chromeOn('permissions:respond', (_e, { id, allow }) => {
@@ -2983,7 +3347,7 @@ app.whenReady().then(async () => {
       showUtilityPage, hideUtilitySheet,
       getUtilitySheetState: () => ({ visible: !!utilitySheetUrl, url: utilitySheetUrl }),
       getUtilitySheetWebContents: () => utilitySheetView?.webContents ?? null,
-      getOverlayWebContents: () => overlayView?.webContents ?? null,
+      getOverlayWebContents: () => overlayWC(),
       getChromeWebContents: () => win?.webContents ?? null,
       setWindowContentSize: (width, height) => {
         if (!hasLiveWindow()) return;
@@ -3051,7 +3415,7 @@ app.whenReady().then(async () => {
   // surfaces (overlay panel; any tab currently on the start page).
   const pushRemoteDevices = () => {
     const devices = sync.listRemoteDevices();
-    overlayView?.webContents.send('chrome:remote-tabs-updated', devices);
+    overlayWC()?.send('chrome:remote-tabs-updated', devices);
     for (const tab of tabs.values()) {
       if (tab.url?.startsWith('blanc://newtab')) {
         tab.view.webContents.send('pages:start:remote-tabs', devices);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -39,6 +39,11 @@ contextBridge.exposeInMainWorld('browserAPI', {
   },
 
   reportChromeLayout: (height) => ipcRenderer.send('chrome:layout', { height }),
+  // EXPERIMENT (BLANC_GLASS): report {host, glass} — the box this child window
+  // must hold, and the sub-rect inside it that should BE the native glass.
+  // Main can compute neither: the pill's width is driven by the domain string
+  // and the panel's height by its content.
+  reportGlassRect: (payload) => ipcRenderer.send('chrome:glass-rect', payload),
   setTabLayout: (layout) => ipcRenderer.invoke('chrome:set-tab-layout', layout),
   previewVerticalTabsWidth: (width) =>
     ipcRenderer.send('chrome:preview-vertical-tabs-width', width),

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -983,6 +983,29 @@
 
   // --- Mode switching (driven by main via overlay:show / overlay:hide) ---
 
+  // EXPERIMENT (BLANC_GLASS): the expanded panel's box drives the native glass
+  // view. Its height depends on content, so only the renderer can measure it.
+  function reportGlass() {
+    if (!window.browserAPI.reportGlassRect) return;
+    if (document.documentElement.getAttribute('data-glass') !== 'on') return;
+    const el = mode === 'find' ? findBar : panelAnchor.querySelector('#islandPanel');
+    if (!el || el.hidden) return;
+    const r = el.getBoundingClientRect();
+    if (!r.width) return;
+    const glass = {
+      x: r.left, y: r.top, width: r.width, height: r.height,
+      radius: mode === 'find' ? r.height / 2 : 10,
+    };
+    // Palette keeps a full-window host so the scrim can own outside clicks;
+    // panel and find are tight to the card.
+    const host = mode === 'palette'
+      ? { width: window.innerWidth, height: window.innerHeight }
+      : { width: r.width, height: r.height };
+    if (mode !== 'palette') { glass.x = 0; glass.y = 0; }
+    window.browserAPI.reportGlassRect({ host, glass });
+  }
+  const glassObserver = new ResizeObserver(() => reportGlass());
+
   function applyMode(next, prefill) {
     const reshow = mode === next;
     // A press the overlay never saw released (dismissed mid-click) must not
@@ -994,6 +1017,17 @@
     backdrop.hidden = next !== 'panel' && next !== 'palette';
     panelAnchor.hidden = next !== 'panel' && next !== 'palette';
     findBar.hidden = next !== 'find';
+
+    // Glass must track the card through every mode change AND every content
+    // resize; two frames of settle for layout, then observe.
+    glassObserver.disconnect();
+    if (next) {
+      const target = next === 'find' ? findBar : panelAnchor.querySelector('#islandPanel');
+      if (target) {
+        glassObserver.observe(target);
+        requestAnimationFrame(() => requestAnimationFrame(reportGlass));
+      }
+    }
 
     if (next === 'panel' || next === 'palette') {
       if (!reshow) {

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -516,4 +516,41 @@
   };
   new ResizeObserver(reportLayout).observe(chromeEl);
   requestAnimationFrame(reportLayout);
+
+  // EXPERIMENT (BLANC_GLASS): the resting pill's box drives the native glass
+  // view's frame. Harmless when the experiment is off — main ignores it.
+  // The window is sized to the union of everything the strip is currently
+  // showing — normally just the pill, but a permission prompt makes it taller
+  // and wider, and the child window has to grow with it or the prompt is
+  // clipped by its own host.
+  const reportGlass = () => {
+    if (!window.browserAPI.reportGlassRect) return;
+    if (document.documentElement.getAttribute('data-glass') !== 'on') return;
+    const pill = islandPill.getBoundingClientRect();
+    if (!pill.width) return;
+    let host = { width: pill.width, height: pill.height };
+    const bar = document.getElementById('permissionBar');
+    if (bar && !bar.hidden) {
+      const b = bar.getBoundingClientRect();
+      if (b.width) {
+        host = {
+          width: Math.max(pill.width, b.width),
+          height: Math.max(pill.bottom, b.bottom) - Math.min(pill.top, b.top),
+        };
+      }
+    }
+    window.browserAPI.reportGlassRect({
+      host,
+      glass: {
+        x: pill.left, y: pill.top, width: pill.width, height: pill.height,
+        radius: pill.height / 2,
+      },
+    });
+  };
+  const glassObserver = new ResizeObserver(reportGlass);
+  glassObserver.observe(islandPill);
+  const permBar = document.getElementById('permissionBar');
+  if (permBar) glassObserver.observe(permBar);
+  requestAnimationFrame(reportGlass);
+  window.__reportGlass = reportGlass;
 })();

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1632,3 +1632,77 @@ body:not(.mac) #permissionBar { right: 118px; } /* clear the window controls */
   .island-row.tab-row .row-remote-pin { transition: none; }
   #strip { transition: none; }
 }
+
+/* ==========================================================================
+   EXPERIMENT — native glass island (BLANC_GLASS=1). Scoped under
+   [data-glass="on"], set by main.js on the island/overlay child windows only.
+   No :root token value is touched, so `npm run substrate:check` stays green.
+
+   The material is a real NSGlassEffectView in the PARENT window, tracking the
+   rect these elements report via reportGlassRect(). So the elements themselves
+   surrender their background/border/shadow — anything painted here would sit
+   ON the glass and hide it.
+
+   Every box below is sized from CONTENT, never from the viewport. The child
+   window is sized to the content, so a viewport-relative rule (100vw/100vh,
+   max-width: calc(100vw - 24px)) would feed the window's own size back into
+   the layout and oscillate.
+   ========================================================================== */
+
+:root[data-glass="on"],
+:root[data-glass="on"] body { background: transparent; }
+
+:root[data-glass="on"] #islandPill,
+:root[data-glass="on"] #islandPanel,
+:root[data-glass="on"] #findBar {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+/* ---- resting island child: the window IS the pill ---- */
+:root[data-glass="on"] html,
+:root[data-glass="on"] body { width: max-content; height: max-content; }
+
+:root[data-glass="on"] #strip {
+  width: max-content;
+  height: auto;
+  min-height: 0;
+  padding: 0;
+  display: block;
+  background: transparent;
+}
+:root[data-glass="on"] #islandPill {
+  margin-top: 0;
+  max-width: none; /* viewport-relative cap would fight the window size */
+}
+/* The parent window still owns the native traffic lights and the platform menu
+   button; the tight island child must not carry duplicates of either. */
+:root[data-glass="on"] #windowControls,
+:root[data-glass="on"] #mainMenuButton { display: none; }
+
+/* A permission prompt widens the host box (renderer.js reports the union), so
+   it lays out beside the pill instead of being pinned to a window edge. */
+:root[data-glass="on"] #permissionBar {
+  position: static;
+  right: auto;
+  margin-top: 8px;
+}
+
+/* ---- expanded child: tight for panel/find, full-window for palette ---- */
+:root[data-glass="on"] body[data-mode="panel"] #panelAnchor,
+:root[data-glass="on"] body[data-mode="find"] #panelAnchor {
+  position: static;
+  display: block;
+}
+:root[data-glass="on"] body[data-mode="panel"] #islandPanel {
+  max-width: 620px;
+  /* Pushed from main as (parent content height - 24) so the list scrolls
+     inside the card rather than the card outgrowing the display. */
+  max-height: var(--glass-avail-h, 600px);
+}
+:root[data-glass="on"] body[data-mode="find"] #findBar {
+  position: static;
+  transform: none;
+  max-width: none;
+}

--- a/test/unit/platform-main-menu.test.js
+++ b/test/unit/platform-main-menu.test.js
@@ -189,7 +189,12 @@ test('chrome markup and IPC keep one native menu definition', () => {
   assert.match(renderer, /getBoundingClientRect\(\)/);
   assert.match(renderer, /window\.browserAPI\.openMainMenu/);
   assert.match(preload, /ipcRenderer\.invoke\('chrome:open-main-menu', point\)/);
-  assert.match(main, /event\.sender !== win\?\.webContents/);
+  // The guard's intent is that only the STRIP document can pop the native menu
+  // — the rich preload is shared with the overlay, so the entry point stays as
+  // narrow as the UI that owns it. The strip's host is no longer always the
+  // parent window (the BLANC_GLASS experiment hosts it in a child window), so
+  // this pins the narrowing itself rather than one spelling of the host.
+  assert.match(main, /event\.sender !== (win\?\.webContents|chromeWC\(\))/);
   assert.match(main, /popupPlatformMainMenu\(\{ Menu, window: win, point \}\)/);
   assert.match(main, /label: 'Help'[\s\S]*isMac \? \[\] : \[[\s\S]*label: 'About Blanc'[\s\S]*showAboutPanel\(\{ app \}\)/);
   assert.match(main, /function installChromeShortcuts\(webContents\) \{[\s\S]*installVerticalTabsShortcut\(webContents\);[\s\S]*installPlatformMainMenuShortcut/);


### PR DESCRIPTION
**Draft / do not merge.** This is a research spike answering "can macOS 26's Liquid Glass be the Island's material?" Everything is behind `BLANC_GLASS=1`, off by default. Opened for review of the findings and the migration plan, not to land.

## The finding

Yes — but not in one window.

`BrowserWindow.vibrancy` is `NSVisualEffectView` with *behind-window* blending: window-shaped, and it samples the desktop rather than the page. A tint band, not an island. `NSGlassEffectView` (macOS 26) is a real view that can be sized and corner-rounded to a pill, so this adds a small N-API addon (`native/glass/`) to reach it, since Electron has no binding.

That works — the glass genuinely refracts live page content (measured: with the window stationary and the desktop untouched, scrolling the page moved the pill's interior through red → peach → yellow → pale-green, tracking the bands beneath it).

**But nothing Chromium draws can sit on top of it.** All of Chromium's views composite into a single layer that always sits below a native sibling, so the Island's own text and icons were refracted into a smear. Verified by falsification: moving the glass to the *bottom* of the subview list rendered identically (`255,135,154` vs `255,141,159` — antialiasing noise). NSView ordering has no effect across that boundary.

The escape hatch is **cross-window composition**. The WindowServer composites windows independently, so a transparent child window's Chromium pixels land on top of the parent's finished output — glass included — while the parent's glass keeps sampling the page. Confirmed: crisp HTML controls on native glass, in both the resting and expanded states.

This is why the conclusion is *not* "rewrite the Island in Swift."

## Architecture under the flag

| surface | host |
|---|---|
| web page (full-bleed) + `NSGlassEffectView` + vertical rail | parent window |
| resting island — `index.html` | child window, bounds **tight to the pill** |
| panel / find — `overlay.html` | child window, **tight** |
| palette — `overlay.html` | child window, **full-window** (the scrim owns outside clicks) |

The chrome documents, preload and IPC are unchanged — only their host moves. Each renderer reports `{host, glass}` because main can compute neither the pill's width (driven by the domain string) nor the panel's height (driven by content).

Glass-scoped CSS is sized from **content, never the viewport**: the child window is sized to its content, so a `100vw`/`calc(100vw - 24px)` rule would feed the window's own size back into its layout and oscillate. The panel's height cap is pushed from the parent as `--glass-avail-h` for the same reason.

## Verification

- **Default path unchanged:** 307/307 unit, 55/55 acceptance scenarios, 364/364 steps, `substrate:check` 4/4.
- **Real-flow slice (16/16):** ⌘L → panel → typing → navigation; Escape / blur / outside-click dismissal; glass grows to the panel (`620×152.5`) and returns to the pill; address-bar focus reclaim on a blank new tab; move / resize / fullscreen / minimize-restore.
- **Hardening (13/14):** resting island `355×36` in a `1040` parent; traffic lights clear by 251pt; panel `620×185`, palette `1040×660`, find `480×42`; utility sheet hides glass + island and restores; permission prompt grows the host `355×36 → 355×82` and keeps its own opaque surface. The one failure was a bad assertion in my harness, not the product.

## One real bug this surfaced

`focusAddressBar()` called `win.focus()` to pull OS focus off the tab view. Across windows that blurs the overlay child and trips its own blur-dismissal — the reclaim closed the very panel it was opening. Fixed by letting `showOverlay` focus the child window directly.

## Reviewer notes

- **Security posture unchanged.** The trusted-sender allowlist gains the child windows and stays identity- and URL-pinned. `platform-main-menu`'s guard test pinned a literal host string (`event.sender !== win?.webContents`); it now pins the *narrowing*, which is what the rule was always about.
- `native/glass/` has its own build dir on purpose: `node-gyp` treats `build/` as scratch and wipes it, and the repo's `build/` holds the signing entitlements, provisioning profile and app icons. It destroyed them once during this work (restored from git); `native/*/build/` is now gitignored.
- Apple's HIG expects controls to sit *on* glass with clear separation from content. Legibility here varies with what's behind the card; a separation layer is not yet implemented.

## Known gaps

- **Vertical tabs** — needs `index.html` split into a rail document (parent, opaque, full-height, no glass) and an island document (child). Currently broken under the flag: the rail renders clipped to 64px.
- **Multi-display / mixed scale factors** — unverified. Single-display machine. Bounds math is DIP-based via `getContentBounds` (display-agnostic); unverified risks are `backingScaleFactor` changing mid-drag and `NSWindow` child re-homing across screens.
- **Packaging** — not started. Needs a universal x64+arm64 addon, a `prebuild` step so `npm install` doesn't require Xcode, and signing/notarization through the existing pinned-certificate pipeline.

## Migration shape (if approved)

Runtime capability gate on `glassNative.isSupported()` — addon loaded **and** `NSClassFromString(@"NSGlassEffectView")` resolves. One build, two paths:

- **macOS 26+** — the architecture above.
- **macOS 12–25** — today's code path untouched: page at `y=stripHeight`, island in the parent, `overlayView` as a child view. The fallback is not a degraded copy; it's the current architecture, and the existing acceptance suite is its regression net.

Estimated 5–8 focused days, weighted toward mixed-display behaviour, signing a universal native module, and lifecycle races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
