### PR TITLE
telemetry: add a coarsened OS version to the launch ping

### DIFF
--- a/cloudflare/ping-worker/README.md
+++ b/cloudflare/ping-worker/README.md
@@ -2,7 +2,8 @@
 
 Collector for Blanc's anonymous launch ping (Settings → "Help improve
 Blanc", on by default, opt-out). Receives `POST /ping` with
-`{installId, sessionId, version, platform, arch}` and tallies counts in Workers KV.
+`{installId, sessionId, version, platform, arch, osVersion}` and tallies counts in
+Workers KV.
 `GET /stats` (bearer-token gated) returns launch totals **and** active-user
 metrics.
 
@@ -12,7 +13,13 @@ no name, account, IP, or browsing data is stored beside it. The Worker uses
 it only to dedupe repeat launches into distinct active users:
 
 - **Launches** — every ping bumps `total`, `day:<date>`, `version:<v>`,
-  `platform:<p>`. Ten launches by one person count as ten.
+  `platform:<p>`, `os:<platform>:<major>`. Ten launches by one person count as
+  ten. `osVersion` arrives already coarsened to a bare major by the client
+  (`coarseOsVersion` in `src/main/telemetry.js`) — enough to size the audience
+  for an OS-gated feature, without a point release's finer fingerprint. The
+  Worker rejects anything that isn't 1–4 digits as `unknown`, so a forged body
+  can't open an unbounded key space. The OS key includes the platform because
+  a bare `11` would otherwise merge macOS 11 with Windows 11.
 - **Active users** — the first ping from an install in a given
   day/week/month sets a `seen:<scope>:<bucket>:<installId>` flag and bumps
   that period's `active:<scope>:<bucket>` unique counter. Those counters
@@ -100,7 +107,8 @@ Returns JSON like:
     "total": 420,
     "byDay": { "2026-07-05": 30, "2026-07-06": 28 },
     "byVersion": { "0.12.0": 400, "0.11.0": 20 },
-    "byPlatform": { "darwin": 300, "win32": 90, "linux": 30 }
+    "byPlatform": { "darwin": 300, "win32": 90, "linux": 30 },
+    "byOsVersion": { "darwin:26": 180, "darwin:27": 120, "win32:11": 70, "win32:10": 20 }
   },
   "activeUsers": {
     "daily":   { "2026-07-07": 41, "2026-07-08": 44 },

--- a/cloudflare/ping-worker/src/index.js
+++ b/cloudflare/ping-worker/src/index.js
@@ -24,6 +24,11 @@
 const ALLOWED_PLATFORMS = new Set(['darwin', 'win32', 'linux']);
 const VERSION_RE = /^\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// The client already coarsens the OS to a bare major (src/main/telemetry.js
+// coarseOsVersion). Anything else is a client that predates the field, or a
+// forged body — both become 'unknown' rather than opening an unbounded key
+// space in KV.
+const OS_VERSION_RE = /^\d{1,4}$/;
 
 const GA_MEASUREMENT_ID = 'G-MN8BLY6GE9';
 const GA_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
@@ -68,7 +73,7 @@ async function hashInstallId(env, installId) {
 //      point event, not a timed session.
 // User properties (platform, arch, app_version) are set once per client_id
 // and stick to the user in GA's user-scoped reports / explorations.
-function forwardToGA(env, { version, platform, arch, installId, sessionId }) {
+function forwardToGA(env, { version, platform, arch, osVersion, installId, sessionId }) {
   if (!env.GA_API_SECRET || !installId) return Promise.resolve();
   const url = `${GA_ENDPOINT}?measurement_id=${GA_MEASUREMENT_ID}&api_secret=${env.GA_API_SECRET}`;
   const sid = sessionId || String((Math.random() * 0x7FFFFFFF) >>> 0);
@@ -80,6 +85,7 @@ function forwardToGA(env, { version, platform, arch, installId, sessionId }) {
         app_version: { value: version },
         platform: { value: platform },
         arch: { value: arch },
+        os_version: { value: osVersion },
       },
       events: [{
         name: 'app_launch',
@@ -89,6 +95,7 @@ function forwardToGA(env, { version, platform, arch, installId, sessionId }) {
           app_version: version,
           platform,
           arch,
+          os_version: osVersion,
         },
       }],
     }),
@@ -160,6 +167,9 @@ async function handlePing(request, env, ctx, now) {
     : 'unknown';
   const platform = ALLOWED_PLATFORMS.has(body.platform) ? body.platform : 'unknown';
   const arch = typeof body.arch === 'string' ? body.arch.slice(0, 16) : 'unknown';
+  const osVersion = typeof body.osVersion === 'string' && OS_VERSION_RE.test(body.osVersion)
+    ? body.osVersion
+    : 'unknown';
   // Opaque random token from the client; cap length defensively. Absent for
   // pre-metrics clients — those still count as launches, just not as uniques.
   const installId =
@@ -177,7 +187,7 @@ async function handlePing(request, env, ctx, now) {
 
   // GA mirror is queued before the KV writes so a KV failure can't cost
   // the launch event too.
-  ctx.waitUntil(forwardToGA(env, { version, platform, arch, installId: hashedId, sessionId }));
+  ctx.waitUntil(forwardToGA(env, { version, platform, arch, osVersion, installId: hashedId, sessionId }));
 
   // KV get/put can throw transiently; the counts are best-effort anyway
   // (see bump()), so log and still 204 rather than turning a blip into a
@@ -187,6 +197,8 @@ async function handlePing(request, env, ctx, now) {
     bump(env.PINGS, todayLaunchKey(now)),
     bump(env.PINGS, `version:${version}`),
     bump(env.PINGS, `platform:${platform}`),
+    // Keyed with the platform: a bare '11' would merge macOS 11 and Windows 11.
+    bump(env.PINGS, `os:${platform}:${osVersion}`),
   ];
   if (hashedId) {
     work.push(
@@ -296,11 +308,12 @@ async function handleStats(request, env, now) {
     return new Response('unauthorized', { status: 401 });
   }
 
-  const [total, byDay, byVersion, byPlatform, daily, weekly, monthly] = await Promise.all([
+  const [total, byDay, byVersion, byPlatform, byOsVersion, daily, weekly, monthly] = await Promise.all([
     env.PINGS.get('total'),
     readMap(env.PINGS, 'day:'),
     readMap(env.PINGS, 'version:'),
     readMap(env.PINGS, 'platform:'),
+    readMap(env.PINGS, 'os:'),
     readMap(env.PINGS, 'active:day:'),
     readMap(env.PINGS, 'active:week:'),
     readMap(env.PINGS, 'active:month:'),
@@ -324,6 +337,7 @@ async function handleStats(request, env, now) {
       byDay,
       byVersion,
       byPlatform,
+      byOsVersion,
     },
     activeUsers: {
       daily: pickRecent(daily, 30),

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -47,13 +47,13 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <li>a random install ID — a token that identifies the installation, not you (this makes the ping <em>pseudonymous</em> rather than fully anonymous: repeat launches from the same install can be recognized as such, but nothing links the token to a person)</li>
     <li>a random per-launch session ID</li>
     <li>the app version</li>
-    <li>your operating system and processor type (for example, macOS on arm64)</li>
+    <li>your operating system, its major version, and processor type (for example, macOS 26 on arm64) &mdash; the major version only, never a point release</li>
   </ul>
   <p>That's the entire payload. It carries <strong>no browsing data, no personal details, no account, no name, and no precise location.</strong> Here is exactly what happens to it on our side:</p>
   <ul>
     <li>The raw install ID is never stored. Our collector immediately replaces it with a salted hash (a one-way scramble using a server-side secret), and only that hash is used from then on.</li>
     <li>The hash is used to tell repeat launches apart from distinct installs — daily, weekly, and monthly active-install counts, and whether installs come back month over month. The per-install markers behind those counts expire automatically: after 90 days for daily, and after about 13 months for weekly and monthly.</li>
-    <li>The resulting <em>totals</em> — launch and active-install counts by day, version, and platform, with no install IDs in them — are what we keep long-term.</li>
+    <li>The resulting <em>totals</em> — launch and active-install counts by day, app version, platform, and operating-system version, with no install IDs in them — are what we keep long-term.</li>
     <li>The same hashed token is forwarded to Google Analytics as its "client ID," so app launches appear alongside our website's traffic stats. Since the July 2026 migration described in the transition note below, Google receives only the hashed token, and the event carries only the version/platform details listed above.</li>
   </ul>
   <p>The install ID is kept in its own small file on your device. You can reset it any time with the <strong>"Reset install ID"</strong> button in Settings — from then on you count as a brand-new install — and it's also cleared when you remove the app's data. Development builds send no pings at all.</p>

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -47,7 +47,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <li>a random install ID — a token that identifies the installation, not you (this makes the ping <em>pseudonymous</em> rather than fully anonymous: repeat launches from the same install can be recognized as such, but nothing links the token to a person)</li>
     <li>a random per-launch session ID</li>
     <li>the app version</li>
-    <li>your operating system, its major version, and processor type (for example, macOS 26 on arm64) — the major version only, never a point release</li>
+    <li>your operating system, its major version, and processor type (for example, macOS 26 on arm64)</li>
   </ul>
   <p>That's the entire payload. It carries <strong>no browsing data, no personal details, no account, no name, and no precise location.</strong> Here is exactly what happens to it on our side:</p>
   <ul>

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -47,14 +47,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <li>a random install ID — a token that identifies the installation, not you (this makes the ping <em>pseudonymous</em> rather than fully anonymous: repeat launches from the same install can be recognized as such, but nothing links the token to a person)</li>
     <li>a random per-launch session ID</li>
     <li>the app version</li>
-    <li>your operating system, its major version, and processor type (for example, macOS 26 on arm64) &mdash; the major version only, never a point release</li>
+    <li>your operating system, its major version, and processor type (for example, macOS 26 on arm64) — the major version only, never a point release</li>
   </ul>
   <p>That's the entire payload. It carries <strong>no browsing data, no personal details, no account, no name, and no precise location.</strong> Here is exactly what happens to it on our side:</p>
   <ul>
     <li>The raw install ID is never stored. Our collector immediately replaces it with a salted hash (a one-way scramble using a server-side secret), and only that hash is used from then on.</li>
     <li>The hash is used to tell repeat launches apart from distinct installs — daily, weekly, and monthly active-install counts, and whether installs come back month over month. The per-install markers behind those counts expire automatically: after 90 days for daily, and after about 13 months for weekly and monthly.</li>
     <li>The resulting <em>totals</em> — launch and active-install counts by day, app version, platform, and operating-system version, with no install IDs in them — are what we keep long-term.</li>
-    <li>The same hashed token is forwarded to Google Analytics as its "client ID," so app launches appear alongside our website's traffic stats. Since the July 2026 migration described in the transition note below, Google receives only the hashed token, and the event carries only the version/platform details listed above.</li>
+    <li>The same hashed token is forwarded to Google Analytics as its "client ID," so app launches appear alongside our website's traffic stats. Since the July 2026 migration described in the transition note below, Google receives only the hashed token, and the event carries only the app version, platform, processor type, and operating-system version listed above.</li>
   </ul>
   <p>The install ID is kept in its own small file on your device. You can reset it any time with the <strong>"Reset install ID"</strong> button in Settings — from then on you count as a brand-new install — and it's also cleared when you remove the app's data. Development builds send no pings at all.</p>
   <p>One transition note, in the interest of full honesty: before a migration in July 2026, our collector used the random token directly — in its own storage and in what it forwarded to Google Analytics — rather than a salted hash of it. The pre-hashing markers have been deleted from our storage, and the older Google Analytics events age out under its data-retention settings. Those events contained the same random token and version/platform details described above, and nothing more.</p>

--- a/spec/parity-matrix.md
+++ b/spec/parity-matrix.md
@@ -34,7 +34,7 @@ See [`README.md`](./README.md#status-legend) for meanings.
 | F18 | Session persistence & restore | SHIPPED | PARTIAL | PLANNED | Restore tabs + groups; private tabs excluded; same `session.json` shape (adapted per platform store). | D8 |
 | F19 | Context menu (link/page actions) | SHIPPED | PLANNED | PLANNED | Same actions (open in new/background tab, copy link, etc.); OS hand-off honored. | D4, D7, D20 |
 | F20 | Basic-auth dialog | SHIPPED | PLANNED | PLANNED | Same modal auth prompt behaviour. | — |
-| F21 | Telemetry (usage ping) | SHIPPED | PLANNED | PLANNED | A fresh profile must commit its on/off choice before any ping; the choice is presented on by default and remains device-local. When enabled, packaged builds send one fire-and-forget launch ping with `{installId,sessionId,version,platform,arch}` and no browsing data. | — |
+| F21 | Telemetry (usage ping) | SHIPPED | PLANNED | PLANNED | A fresh profile must commit its on/off choice before any ping; the choice is presented on by default and remains device-local. When enabled, packaged builds send one fire-and-forget launch ping with `{installId,sessionId,version,platform,arch,osVersion}` and no browsing data. | — |
 | F22 | Distribution & updates | SHIPPED | N/A | N/A | User gets updates; no in-app updater fighting the OS store. | D9 |
 | F23 | Zoom / page scaling | SHIPPED | DIVERGENT (D10) | DIVERGENT (D10) | Page can be scaled; desktop discrete zoom vs mobile pinch/native reflow. | D10 |
 | F24 | Password AutoFill / passkeys | N/A | PLANNED | PLANNED | On mobile, native credential provider + platform passkeys work in-webview. | D12 |

--- a/src/main/telemetry.js
+++ b/src/main/telemetry.js
@@ -44,10 +44,33 @@ function resetInstallId(store = ensureInstallStore()) {
   return store.flush() === true;
 }
 
+// Coarsen the OS version to a single major number before it ever leaves the
+// device. `platform` alone can't answer "how many installs could run a
+// macOS-26-only feature", but a full version string ("27.0.1", "10.0.26100")
+// is a finer fingerprint than counting audiences needs. Major-only is enough
+// to gate capabilities and size a rollout, and nothing more.
+//
+// Pure and exported so the mapping is unit-tested rather than only observed in
+// production, where a wrong bucket is invisible.
+function coarseOsVersion(platform, systemVersion) {
+  const parts = String(systemVersion ?? '').split('.').map((n) => parseInt(n, 10));
+  if (!Number.isFinite(parts[0])) return 'unknown';
+  if (platform === 'win32') {
+    // Windows reports 10.0.<build> for BOTH 10 and 11 — the major is useless
+    // on its own and only the build number tells them apart (11 starts at
+    // 22000). Map to the marketing number users and docs actually mean.
+    if (parts[0] === 10) return (Number.isFinite(parts[2]) ? parts[2] : 0) >= 22000 ? '11' : '10';
+    return String(parts[0]);
+  }
+  // macOS reports the marketing version here (26, 27…), not the Darwin build.
+  // Linux reports a kernel major, which is weak signal but harmless.
+  return String(parts[0]);
+}
+
 // On by default (Settings → usagePing, opt-out). Fire-and-forget: a failed or
 // blocked ping must never affect startup or show the user anything. Carries
-// only version/platform/arch plus the pseudonymous install id above — enough
-// to count active users and bucket by version/platform, nothing that
+// only version/platform/arch/osVersion plus the pseudonymous install id above
+// — enough to count active users and bucket by version and OS, nothing that
 // identifies a person.
 function sendLaunchPing() {
   const { app, net } = require('electron');
@@ -61,6 +84,10 @@ function sendLaunchPing() {
     version: app.getVersion(),
     platform: process.platform,
     arch: process.arch,
+    // getSystemVersion() is the OS's own version (macOS marketing number,
+    // Windows 10.0.<build>) — os.release() would give the Darwin build on mac,
+    // which is not what anyone means by "macOS 26".
+    osVersion: coarseOsVersion(process.platform, process.getSystemVersion()),
   });
 
   net.fetch(PING_ENDPOINT, {
@@ -72,4 +99,4 @@ function sendLaunchPing() {
   });
 }
 
-module.exports = { sendLaunchPing, resetInstallId };
+module.exports = { sendLaunchPing, resetInstallId, coarseOsVersion };

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -174,7 +174,7 @@
             <div class="setting">
               <div class="label">
                 <span>Help improve Blanc</span>
-                <span class="hint">Counts active users so we can see how Blanc is growing. On launch, sends the app version, your OS, and a random id for this install (used only to avoid counting one device twice, and stored on our side only as a one-way hash). No browsing data, no account, no way to identify you. Turn this off to stop sending it.</span>
+                <span class="hint">Counts active users so we can see how Blanc is growing. On launch, sends the app version, your OS and its major version (like &ldquo;macOS 26&rdquo;), and a random id for this install (used only to avoid counting one device twice, and stored on our side only as a one-way hash). No browsing data, no account, no way to identify you. Turn this off to stop sending it.</span>
               </div>
               <label class="toggle">
                 <input id="usagePing" type="checkbox" />

--- a/test/unit/ping-worker.test.js
+++ b/test/unit/ping-worker.test.js
@@ -213,3 +213,44 @@ test('purge-legacy-ids is bearer-gated and fails closed without a token', async 
   }
   assert.ok(kv.map.has(`seen:day:2026-07-10:${RAW_ID}`), 'nothing deleted on denial');
 });
+
+test('OS version is bucketed per platform, so macOS 11 and Windows 11 never merge', async () => {
+  const env = { PINGS: fakeKV(), INSTALL_HASH_SECRET: 'test-secret' };
+  await ping(env, { ...PING_BODY, platform: 'darwin', osVersion: '11' });
+  await ping(env, { ...PING_BODY, platform: 'win32', osVersion: '11' });
+  assert.equal(env.PINGS.map.get('os:darwin:11'), '1');
+  assert.equal(env.PINGS.map.get('os:win32:11'), '1');
+});
+
+test('a malformed or absent osVersion degrades to unknown rather than opening the key space', async () => {
+  const env = { PINGS: fakeKV(), INSTALL_HASH_SECRET: 'test-secret' };
+  // Pre-osVersion clients still ping; they must count as launches.
+  await ping(env, PING_BODY);
+  // A forged body must not become a KV key.
+  await ping(env, { ...PING_BODY, osVersion: '../../etc/passwd' });
+  await ping(env, { ...PING_BODY, osVersion: '26.1.4' });
+  await ping(env, { ...PING_BODY, osVersion: 26 });
+  assert.equal(env.PINGS.map.get('os:darwin:unknown'), '4');
+  assert.equal(env.PINGS.map.get('total'), '4');
+  assert.equal([...env.PINGS.map.keys()].filter((k) => k.startsWith('os:')).length, 1);
+});
+
+test('GA receives the OS version as a user property and an event param', async () => {
+  const env = { PINGS: fakeKV(), INSTALL_HASH_SECRET: 'test-secret', GA_API_SECRET: 'ga' };
+  const { gaCalls } = await ping(env, { ...PING_BODY, osVersion: '26' });
+  assert.equal(gaCalls.length, 1);
+  assert.equal(gaCalls[0].body.user_properties.os_version.value, '26');
+  assert.equal(gaCalls[0].body.events[0].params.os_version, '26');
+});
+
+test('/stats exposes the OS-version breakdown', async () => {
+  const env = { PINGS: fakeKV(), INSTALL_HASH_SECRET: 'test-secret', STATS_TOKEN: 't' };
+  await ping(env, { ...PING_BODY, osVersion: '26' });
+  await ping(env, { ...PING_BODY, osVersion: '27' });
+  const res = await worker.fetch(
+    new Request('https://ping.test/stats', { headers: { Authorization: 'Bearer t' } }),
+    env, { waitUntil() {} }
+  );
+  const stats = await res.json();
+  assert.deepEqual(stats.launches.byOsVersion, { 'darwin:26': 1, 'darwin:27': 1 });
+});

--- a/test/unit/public-truth.test.js
+++ b/test/unit/public-truth.test.js
@@ -90,6 +90,6 @@ test('platform specs match the shipped first-run telemetry contract', () => {
   assert.doesNotMatch(telemetryRow, /Opt-in, off by default/i);
   assert.doesNotMatch(services, /usage ping is off by default/i);
   assert.match(matrix, /commit its on\/off choice before any ping/i);
-  assert.match(matrix, /\{installId,sessionId,version,platform,arch\}/);
+  assert.match(matrix, /\{installId,sessionId,version,platform,arch,osVersion\}/);
   assert.match(services, /no telemetry install id exists/i);
 });

--- a/test/unit/telemetry-os-version.test.js
+++ b/test/unit/telemetry-os-version.test.js
@@ -1,0 +1,39 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { coarseOsVersion } = require('../../src/main/telemetry');
+
+// The ping carries a coarsened OS major, never the raw version string. These
+// pin the mapping, because a wrong bucket is invisible in production — the
+// numbers just quietly describe the wrong thing.
+test('macOS reports its marketing major', () => {
+  assert.equal(coarseOsVersion('darwin', '27.0.0'), '27');
+  assert.equal(coarseOsVersion('darwin', '26.1'), '26');
+  assert.equal(coarseOsVersion('darwin', '15.6.1'), '15');
+});
+
+test('Windows 10 and 11 are told apart by build, not by major', () => {
+  // Both report 10.0.<build>; 11 starts at build 22000. Trusting the major
+  // alone would file every Windows 11 install under "10".
+  assert.equal(coarseOsVersion('win32', '10.0.26100'), '11');
+  assert.equal(coarseOsVersion('win32', '10.0.22000'), '11');
+  assert.equal(coarseOsVersion('win32', '10.0.19045'), '10');
+  assert.equal(coarseOsVersion('win32', '10.0'), '10'); // no build component
+});
+
+test('linux falls back to the kernel major', () => {
+  assert.equal(coarseOsVersion('linux', '6.8.0-51-generic'), '6');
+});
+
+test('unparseable input degrades to unknown instead of leaking a raw string', () => {
+  for (const bad of ['', null, undefined, 'sonoma', {}]) {
+    assert.equal(coarseOsVersion('darwin', bad), 'unknown');
+  }
+});
+
+test('the coarsened value never carries a point release', () => {
+  for (const [platform, raw] of [
+    ['darwin', '26.3.1'], ['win32', '10.0.26100'], ['linux', '6.8.0-51-generic'],
+  ]) {
+    assert.match(coarseOsVersion(platform, raw), /^\d{1,4}$/);
+  }
+});


### PR DESCRIPTION
The launch ping carried `platform` (`'darwin'`) but no OS version, so there was no way to answer *"how many installs could actually run an OS-gated feature"* — the question currently blocking a decision on the macOS 26 Liquid Glass work (#74).

## What's sent

A **bare major**, coarsened on the device before it leaves:

```js
osVersion: coarseOsVersion(process.platform, process.getSystemVersion())
```

`"27.0.1"` → `"27"`. A full version string is a finer fingerprint than counting an audience needs; the major is enough to gate capabilities and size a rollout, and nothing more.

Two details a naive `major` would get wrong, both covered by tests:

- **`getSystemVersion()`, not `os.release()`.** On macOS `os.release()` returns the Darwin build, which is not what anyone means by "macOS 26".
- **Windows reports `10.0.<build>` for both 10 and 11.** The major alone would file every Windows 11 install under "10"; the build number is what separates them (11 starts at 22000).

`coarseOsVersion` is pure and exported specifically so the mapping is unit-tested. A wrong bucket is invisible in production — the numbers would just quietly describe the wrong thing.

## Worker

- Validates 1–4 digits, else `unknown` — a forged body can't open an unbounded KV key space.
- Counts under `os:<platform>:<major>`. Keyed **with** the platform, because a bare `11` would otherwise merge macOS 11 with Windows 11.
- `byOsVersion` in `/stats`; `os_version` forwarded to GA4 as both a user property and an event param.

## Public claims updated in the same commit

The payload is enumerated in several places, one of which says *"That's the entire payload"* — that claim goes false the moment this ships, so all of it moves together:

- `site/src/pages/privacy.astro` — the enumerated list, and the "what we keep long-term" line. Now says "its major version … the major version only, never a point release".
- `src/renderer/pages/settings.html` — the Settings hint (it said "your OS", now names the major version with an example).
- `cloudflare/ping-worker/README.md` — payload, KV key, and the `/stats` sample.
- `spec/parity-matrix.md` F21, plus its `public-truth.test.js` guard.

## Verification

349/349 unit tests, `substrate:check` 4/4. New coverage: the mapping (macOS majors, Win 10-vs-11 by build, linux kernel major, unparseable → `unknown`, and that no point release ever survives), plus worker tests for per-platform bucketing, malformed input degrading to `unknown` without adding keys, the GA fields, and the `/stats` breakdown.

## Reviewer note

Nothing backfills — existing installs start reporting on their next launch after this ships, and pre-upgrade pings count under `os:<platform>:unknown`. So the OS split only becomes meaningful a release cycle after it lands, which is worth factoring into when the #74 decision can actually be made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
