### PR TITLE
Fix Find in page: start a session before stepping through matches

### DIFF
--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -1257,6 +1257,9 @@
     findLastQuery = query;
   }
 
+  // Electron's findNext means "start a NEW find session", not "move to the
+  // next result". A fresh input value must therefore use true; Enter and the
+  // arrow controls continue that session with false.
   // Search live as the user types; Enter/Shift+Enter step through matches.
   findInput.addEventListener('input', () => {
     if (!findInput.value) {
@@ -1265,15 +1268,15 @@
       if (state.activeTabId) window.browserAPI.stopFindInPage(state.activeTabId);
       return;
     }
-    runFind({ forward: true, findNext: false });
+    runFind({ forward: true, findNext: true });
   });
   findInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') {
-      runFind({ forward: !e.shiftKey, findNext: findInput.value === findLastQuery });
+      runFind({ forward: !e.shiftKey, findNext: findInput.value !== findLastQuery });
     }
   });
-  findPrevBtn.addEventListener('click', () => runFind({ forward: false, findNext: true }));
-  findNextBtn.addEventListener('click', () => runFind({ forward: true, findNext: true }));
+  findPrevBtn.addEventListener('click', () => runFind({ forward: false, findNext: false }));
+  findNextBtn.addEventListener('click', () => runFind({ forward: true, findNext: false }));
   findCloseBtn.addEventListener('click', () => window.browserAPI.closeOverlay());
 
   window.browserAPI.onFindResult(({ activeMatchOrdinal, matches }) => {


### PR DESCRIPTION
## Summary

Fixes Find in page (⌘F), which is broken in shipped 1.0.7: typing in the find capsule leaves the counter blank and highlights nothing. Matches only appear once you press Enter.

## Root cause

Electron's `webContents.findInPage(text, options)` defines `findNext` as *"whether to begin a new text finding session with this request — should be `true` for initial requests, and `false` for follow-up requests"* (`electron.d.ts:21613`, Electron 43.3.0, the version this app ships). It does **not** mean "advance to the next match".

All four call sites in the find capsule had it inverted:

| Interaction | Before | After |
|---|---|---|
| typing (`input`) | `findNext: false` — never opened a session | `true` |
| Enter / Shift+Enter | `value === findLastQuery` — restarted when unchanged | `value !== findLastQuery` |
| ‹ previous | `true` — restarted every press | `false` |
| › next | `true` — restarted every press | `false` |

Because the first request never began a session, Chromium emitted no `found-in-page` event at all, so `findCount` stayed empty. Pressing Enter sent `findNext: true`, which *did* open a session — which is why find appeared to work only via Enter.

## Verification

- Contract confirmed against the installed Electron 43.3.0 typings, not from documentation memory.
- The inverted behaviour was reproduced by driving that Electron build directly: main's first request (`findNext: false`) emits no `found-in-page` event across four consecutive keystrokes.
- Corrected sequence traces as: type → `1/3`, Enter → `2/3`, Shift+Enter → `1/3`, no match → `0/0`, recover → `1/3`.
- `npm run test:unit` — 349 passing, 0 failing.
- `npm run substrate:check` — clean (tokens, settings, copy, adblock).

## Test coverage gap (deliberate)

No unit test is added. `overlay.js` is a ~1,600-line IIFE with no test harness on `main`, and a `vm`-based fake DOM for it would be disproportionate to a four-boolean fix. The upstream commit's F8-1 acceptance scenario was intentionally **not** taken: it is bound to a 92-scenario desktop harness that does not exist on `main`. Worth a follow-up once find-in-page has an acceptance home.

## Provenance

Cherry-picked from `db96001` on `codex/post-1.0-development` (production hunk only). The rest of that commit — `test-hook.js`, cucumber config, step definitions, fixtures — is left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
