### PR TITLE
Release Blanc 1.0.8

### DIFF
--- a/docs/press/release-notes/v1.0.8.md
+++ b/docs/press/release-notes/v1.0.8.md
@@ -1,0 +1,18 @@
+# Blanc 1.0.8
+
+## Added
+
+- The shield on the island is now a control, not just a readout. Click it to open a small popover and turn ad and tracker blocking on or off for the site you're on — the same thing `/allow-ads` and `/block-ads` do, without having to remember a command. The chip shows a quiet glyph when there's nothing to report, a count when Blanc has blocked something, and a slashed shield when the site is allow-listed.
+- You can bring your favorites over from another browser. Blanc reads bookmarks from an installed Chrome, Edge, Brave, Chromium, or Vivaldi profile, keeps their folders, and skips anything already saved, so importing twice doesn't create duplicates. It's offered during first run and stays available from the Favorites page. Blanc only goes looking when you press "Look for other browsers", and it only ever opens that browser's bookmarks file — passwords, history, cookies, and open tabs are never read. Firefox and Safari aren't read directly; use the existing "Import HTML…" route for those.
+
+## Fixed
+
+- Find in page now shows matches while you type. Before this fix the counter stayed blank and nothing was highlighted until you pressed Enter — Blanc was telling Chromium to continue a search session it had never started.
+
+## Changed
+
+- The optional launch ping now includes a coarse OS version alongside the platform, so it's possible to tell how many installs could run an OS-gated feature. It is deliberately a single major number — "26" on macOS, "11" or "10" on Windows, a kernel major on Linux — never a full version string, which would narrow a device more than counting audiences requires. It's still one ping per launch with no browsing data, and it's still a single switch in Settings under "Help improve Blanc".
+
+## Other platforms
+
+All three platforms are built from the same `v1.0.8` source tag and published with one SHA-256 manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "UNLICENSED",
       "dependencies": {
         "@1password/sdk": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -4,7 +4,7 @@ import BrandMark from '../components/BrandMark.astro';
 import PressIslandDemo from '../components/PressIslandDemo.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 
-const VERSION = '1.0.7';
+const VERSION = '1.0.8';
 const TAG = `v${VERSION}`;
 const RELEASE_BASE = 'https://github.com/bnfy/blanc/releases';
 const RELEASE_URL = `${RELEASE_BASE}/tag/${TAG}`;

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.0.7');
+  assert.equal(packageVersion, '1.0.8');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
Version bump, checked-in release notes, and the press-page version pins for 1.0.8.

## Shipping in 1.0.8

- **Shield popover** (#76) — the island's shield chip becomes a clickable site-protection control.
- **Favorites import** (#81) — bring favorites from Chrome, Edge, Brave, Chromium, or Vivaldi, with discovery gated behind an explicit action.
- **Find in page fix** (#80) — matches now appear as you type instead of only after Enter.
- **Coarsened OS version on the launch ping** (#78) — major number only, never a full version string.

## Release-gate prerequisites

- `package.json` + `package-lock.json` → 1.0.8
- `docs/press/release-notes/v1.0.8.md` added
- `site/src/pages/press.astro` → `const VERSION = '1.0.8'`
- `test/unit/press-kit.test.js` → `assert.equal(packageVersion, '1.0.8')`

Electron stays at `^43.3.0`, already the latest release, so Chromium is current.

## Verification

- `npm run test:unit` — 355 passing
- `npm run substrate:check` — 4/4 OK
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)