### PR TITLE
Ignore ad-hoc dist-local* build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 dist/
+# Ad-hoc local build output (`--dir=dist-local-…`). `dist/` does not cover these,
+# and unpacked electron-builder output runs ~330 MB per directory.
+dist-local*
 out/
 .cache/
 *.log


### PR DESCRIPTION
`dist/` does not match `dist-local-…` directories, so unpacked electron-builder output from `--dir` builds was untracked **but not ignored**.

Five such directories (~1.6 GB total) had accumulated in a worktree and were one `git add -A` away from being committed.

Verified: `git check-ignore` now matches `dist-local-verify/x` against the new pattern, and such directories no longer appear in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)