### PR TITLE
Release Blanc 1.0.9

### DIFF
--- a/docs/press/release-notes/v1.0.9.md
+++ b/docs/press/release-notes/v1.0.9.md
@@ -1,0 +1,14 @@
+# Blanc 1.0.9
+
+## Added
+
+- The shield's popover now tells you about the connection, not just the blocking. One new line states it plainly — "Uses HTTPS", "Not encrypted", or "Local" for development servers — and says nothing at all while a page is still loading, so it never carries a stale claim across a navigation. It reports what the address proves and no more: Blanc doesn't inspect certificates, so the line deliberately says "Uses HTTPS" rather than claiming the connection is verified.
+- The "Not secure" badge on the island is now a button. On a plain-HTTP site, clicking either the badge or the shield opens the same site controls, anchored under whichever one you clicked — and if the popover is already open, clicking the other control slides it over instead of closing it. Escape puts keyboard focus back on the control that opened it.
+
+## Changed
+
+- The popover's toggle is now labeled "Ad & tracker blocking" instead of "Protection". On an unencrypted site the old wording could read as a safety claim sitting right under a "Not secure" warning; the new label says exactly what the switch does.
+
+## Other platforms
+
+All three platforms are built from the same `v1.0.9` source tag and published with one SHA-256 manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "UNLICENSED",
       "dependencies": {
         "@1password/sdk": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -4,7 +4,7 @@ import BrandMark from '../components/BrandMark.astro';
 import PressIslandDemo from '../components/PressIslandDemo.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 
-const VERSION = '1.0.8';
+const VERSION = '1.0.9';
 const TAG = `v${VERSION}`;
 const RELEASE_BASE = 'https://github.com/bnfy/blanc/releases';
 const RELEASE_URL = `${RELEASE_BASE}/tag/${TAG}`;

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.0.8');
+  assert.equal(packageVersion, '1.0.9');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
Version bump, checked-in release notes, and the press-page version pins for 1.0.9.

## Shipping in 1.0.9

- **Site controls in the shield popover** (#85) — the popover states the connection at scheme level ("Uses HTTPS" / "Not encrypted" / "Local", silent while loading), the "Not secure" badge becomes a second door into the same popover with re-anchoring and Escape-focus-return, and the toggle is relabeled "Ad & tracker blocking".

## Release-gate prerequisites

- `package.json` + `package-lock.json` → 1.0.9
- `docs/press/release-notes/v1.0.9.md` added
- `site/src/pages/press.astro` → `const VERSION = '1.0.9'`
- `test/unit/press-kit.test.js` → pin updated

Electron stays at `^43.3.0` (current stable).

## Verification

- `npm run test:unit` — 365 passing
- `npm run substrate:check` — 4/4 OK
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)