### PR TITLE
Record Blanc 1.0.9 in the public changelog

### DIFF
--- a/site/src/data/releases.json
+++ b/site/src/data/releases.json
@@ -1,5 +1,87 @@
 [
   {
+    "tag": "v1.0.9",
+    "version": "1.0.9",
+    "name": "1.0.9",
+    "publishedAt": "2026-08-08T15:55:01.000Z",
+    "humanDate": "August 8, 2026",
+    "machineDate": "2026-08-08",
+    "url": "https://github.com/bnfy/blanc/releases/tag/v1.0.9",
+    "anchor": "v1-0-9",
+    "compareUrl": null,
+    "sections": [
+      {
+        "heading": "Added",
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "The shield's popover now tells you about the connection, not just the blocking. One new line states it plainly — \"Uses HTTPS\", \"Not encrypted\", or \"Local\" for development servers — and says nothing at all while a page is still loading, so it never carries a stale claim across a navigation. It reports what the address proves and no more: Blanc doesn't inspect certificates, so the line deliberately says \"Uses HTTPS\" rather than claiming the connection is verified."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "The \"Not secure\" badge on the island is now a button. On a plain-HTTP site, clicking either the badge or the shield opens the same site controls, anchored under whichever one you clicked — and if the popover is already open, clicking the other control slides it over instead of closing it. Escape puts keyboard focus back on the control that opened it."
+                  }
+                ],
+                "url": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Changed",
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "The popover's toggle is now labeled \"Ad & tracker blocking\" instead of \"Protection\". On an unencrypted site the old wording could read as a safety claim sitting right under a \"Not secure\" warning; the new label says exactly what the switch does."
+                  }
+                ],
+                "url": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Other platforms",
+        "blocks": [
+          {
+            "type": "paragraph",
+            "spans": [
+              {
+                "type": "text",
+                "value": "All three platforms are built from the same "
+              },
+              {
+                "type": "code",
+                "value": "v1.0.9"
+              },
+              {
+                "type": "text",
+                "value": " source tag and published with one SHA-256 manifest."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     "tag": "v1.0.8",
     "version": "1.0.8",
     "name": "1.0.8",


### PR DESCRIPTION
Regenerated `site/src/data/releases.json` from the published v1.0.9 release body, per the post-publication step.

Release: https://github.com/bnfy/blanc/releases/tag/v1.0.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)