### PR TITLE
Fix main-process crash when a tab closes during a settings-fanout reload

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2453,7 +2453,13 @@ function reloadTabAfterSettingsFanout(tab) {
   const view = tab?.view;
   if (!view) return;
   setImmediate(() => {
-    if (!view.webContents.isDestroyed()) view.webContents.reload();
+    // Re-read webContents inside the deferred turn: closing the tab in that
+    // window runs closeTab's wc.close(), after which view.webContents is
+    // undefined — dereferencing it here threw an uncaught TypeError that
+    // killed the main process. closeTab (see its own `if (wc && ...)` guard)
+    // already treats this as nullable; this path did not.
+    const wc = view.webContents;
+    if (wc && !wc.isDestroyed()) wc.reload();
   });
 }
 

--- a/test/unit/settings-fanout-reload.test.js
+++ b/test/unit/settings-fanout-reload.test.js
@@ -1,0 +1,77 @@
+'use strict';
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+// reloadTabAfterSettingsFanout lives in main.js, which cannot be required in a
+// unit test. Same approach as web-app-region.test.js: lift the function's real
+// source and run it in a sandbox with a controllable setImmediate, so these
+// assert the shipped code rather than a copy of it.
+const mainSource = fs.readFileSync(path.join(__dirname, '../../src/main/main.js'), 'utf8');
+const fnSource = mainSource.match(
+  /function reloadTabAfterSettingsFanout\(tab\) \{[\s\S]*?\n\}/
+)?.[0];
+
+test('the deferred-reload helper is still present in main.js', () => {
+  assert.ok(fnSource, 'reloadTabAfterSettingsFanout not found — update this test with it');
+});
+
+/** Run the real function; returns a `flush()` that fires the deferred turn. */
+function load() {
+  let deferred = null;
+  const sandbox = { setImmediate: (fn) => { deferred = fn; } };
+  vm.runInNewContext(`${fnSource}\nthis.__fn = reloadTabAfterSettingsFanout;`, sandbox);
+  return {
+    call: (tab) => sandbox.__fn(tab),
+    flush: () => { const fn = deferred; deferred = null; fn?.(); },
+    scheduled: () => deferred !== null,
+  };
+}
+
+const liveView = () => {
+  const calls = { reload: 0 };
+  return {
+    view: { webContents: { isDestroyed: () => false, reload: () => { calls.reload += 1; } } },
+    calls,
+  };
+};
+
+test('a live tab reloads on the deferred turn', () => {
+  const h = load();
+  const { view, calls } = liveView();
+  h.call({ view });
+  assert.equal(calls.reload, 0, 'must not reload synchronously');
+  h.flush();
+  assert.equal(calls.reload, 1);
+});
+
+test('a tab whose webContents was destroyed does not reload', () => {
+  const h = load();
+  let reloads = 0;
+  const view = { webContents: { isDestroyed: () => true, reload: () => { reloads += 1; } } };
+  h.call({ view });
+  h.flush();
+  assert.equal(reloads, 0);
+});
+
+// The regression. closeTab() runs `wc.close()` and the view's webContents then
+// reads back undefined; the deferred turn used to dereference it and throw an
+// uncaught TypeError, which kills the main process. Reachable by closing a tab
+// right after /allow-ads, /block-ads, or the shield popover's toggle.
+test('a tab closed during the deferred turn does not crash the main process', () => {
+  const h = load();
+  const view = { webContents: { isDestroyed: () => false, reload: () => {} } };
+  h.call({ view });
+  view.webContents = undefined; // closeTab() closed it in the intervening turn
+  assert.doesNotThrow(() => h.flush());
+});
+
+test('a missing tab or view schedules nothing at all', () => {
+  for (const tab of [null, undefined, {}, { view: null }]) {
+    const h = load();
+    h.call(tab);
+    assert.equal(h.scheduled(), false, JSON.stringify(tab));
+  }
+});


### PR DESCRIPTION
## The crash

```
TypeError: Cannot read properties of undefined (reading 'isDestroyed')
  at Immediate.<anonymous> (src/main/main.js:2456)
  at process.processImmediate
```

An **uncaught exception in the main process — the app dies.** Observed live during a test run; present unchanged as far back as the `v1.0.9` tag.

## Cause

`reloadTabAfterSettingsFanout` defers its reload by one turn (a deliberate workaround: a settings write and a reload in the same turn crash Chromium). It guarded `if (!view) return` but then dereferenced `view.webContents` *inside* the deferred callback:

```js
setImmediate(() => {
  if (!view.webContents.isDestroyed()) view.webContents.reload();
});
```

Close the tab in that intervening turn and `closeTab` runs `wc.close()`, after which `view.webContents` reads back `undefined`.

The codebase already knew this was nullable — `closeTab` guards it at `main.js:2188` with `if (wc && !wc.isDestroyed())`. Two functions apart, one defended and the other didn't.

## Reachability

`/allow-ads`, `/block-ads`, and — **since 1.0.9** — the shield popover's toggle, which turned this settings-fanout reload from a typed slash command into a one-click control and widened the window considerably. Close a tab right after toggling protection and the app can die.

## The fix

Re-read `webContents` inside the deferred turn and apply the same guard `closeTab` uses. Three lines, no behavior change on any non-crashing path.

## Verification

- New `test/unit/settings-fanout-reload.test.js` lifts the **real function** out of `main.js` and runs it in a `vm` with a controllable `setImmediate` (the existing `web-app-region.test.js` pattern), so it asserts shipped code rather than a copy.
- **Proven discriminating:** with the guard reverted, the regression test fails (`not ok 4`); restored, 5/5 pass. A test that passes either way would guard nothing.
- `npm run test:unit` — **370 passing** (365 + 5 new)
- `npm run substrate:check` — 4/4 OK
- `@F12` scenarios (the affected commands + shield popover) — 7 scenarios / 52 steps passing
- `npm run test:acceptance:desktop` — **64/64 scenarios, 425/425 steps**, no retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)