### PR TITLE
Release Blanc 1.0.10

### DIFF
--- a/docs/press/release-notes/v1.0.10.md
+++ b/docs/press/release-notes/v1.0.10.md
@@ -1,0 +1,9 @@
+# Blanc 1.0.10
+
+## Fixed
+
+- Fixed a crash that could quit Blanc when a tab was closed immediately after changing ad and tracker blocking for that site — from the shield popover's toggle, or from `/allow-ads` and `/block-ads`. Changing those settings schedules the page to reload a moment later, and if the tab was gone by then, Blanc tried to reload something that no longer existed and shut down instead.
+
+## Other platforms
+
+All three platforms are built from the same `v1.0.10` source tag and published with one SHA-256 manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "UNLICENSED",
       "dependencies": {
         "@1password/sdk": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -4,7 +4,7 @@ import BrandMark from '../components/BrandMark.astro';
 import PressIslandDemo from '../components/PressIslandDemo.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 
-const VERSION = '1.0.9';
+const VERSION = '1.0.10';
 const TAG = `v${VERSION}`;
 const RELEASE_BASE = 'https://github.com/bnfy/blanc/releases';
 const RELEASE_URL = `${RELEASE_BASE}/tag/${TAG}`;

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.0.9');
+  assert.equal(packageVersion, '1.0.10');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
**Prepared, not ready to merge** — holding until the Claude Design UI changes land, so the release notes describe the full contents of this build.

## Shipping in 1.0.10

- **Settings-fanout crash fix** (#88) — the only user-facing change, and the only thing in the notes.
- **1.1 M1 window-runtime foundation** (#89) also rides this release. Deliberately **not** in the user-facing notes: it is behaviour-invisible by contract, and describing an internal refactor to users is noise.
- *(pending)* Claude Design UI changes — **the notes will need a section once those land.**

## Release-gate prerequisites

- `package.json` + `package-lock.json` → 1.0.10
- `docs/press/release-notes/v1.0.10.md` added
- `site/src/pages/press.astro` → `const VERSION = '1.0.10'`
- `test/unit/press-kit.test.js` → pin updated

Electron stays at `^43.3.0` (current stable).

## Verification

- `npm run test:unit` — **394 passing**
- `npm run substrate:check` — 4/4 OK
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `test/unit/press-kit.test.js` — 2/2 (both pins agree with the package version)

## Before merging

Update `docs/press/release-notes/v1.0.10.md` with the UI changes, then merge and run `release.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)