### PR TITLE
Island motion: the pill senses your cursor, and the panel grows out of it

### DIFF
--- a/docs/superpowers/specs/2026-08-08-blanc-1-1-roadmap.md
+++ b/docs/superpowers/specs/2026-08-08-blanc-1-1-roadmap.md
@@ -1,7 +1,8 @@
 # Blanc 1.1 roadmap — multi-window and local profiles
 
 **Date:** 2026-08-08
-**Status:** Funded. M1 approved for design; M2/M3 get their own specs when reached.
+**Status:** Funded. M1 shipped. **M2 and M3 deferred to a release after 1.1.0**
+(maintainer's call, 2026-08-08) — see "What 1.1.0 actually is" below.
 
 Blanc 1.1 re-implements the multi-window and local-profile architecture against
 current `main`, using `codex/post-1.0-development` strictly as a **reference
@@ -10,6 +11,29 @@ established why: the branch's true base is the deleted 1Password credential-pick
 spike, only 2 of 19 probed commits applied cleanly onto main (both docs-only), and
 main has since landed features *inside* the functions the branch rewrote. See
 PR #54's closing comment for the full record.
+
+## What 1.1.0 actually is
+
+Not this roadmap. 1.1.0 ships **M1 plus the island work**, and nothing else:
+
+- **M1 — window-runtime foundation.** Merged and released in 1.0.10 as a
+  behaviour-invisible change, exactly as planned below, so it has had real
+  soak time before anything builds on it.
+- **The island UI refresh** — the ten Design System checklist items (#92) and
+  the four revisions that followed review (#93).
+- **Island motion** — the resting pill reacting to the cursor approaching, and
+  the panel growing out of the pill rather than appearing.
+
+**M2 (independent windows) and M3 (local profiles) move to a later release.**
+Their specs below stand and nothing about them is retracted; they are simply
+not in 1.1.0. Both are architecture work of a size that would hold the island
+work hostage, and neither has started.
+
+Consequence worth stating: M1 was scoped as a foundation "for M2 to build on".
+It now ships in a release that contains no M2. That is fine — it is inert by
+design — but it means 1.1.0 carries a runtime boundary with exactly one
+runtime in it, and the second runtime arrives later than the original plan
+assumed.
 
 ## Milestones
 
@@ -24,11 +48,11 @@ ran. Each milestone here lands runnable, counted coverage or none.)
   persistence with a v0 rollback mirror. Ships in a normal patch release for
   real-world soak before M2 builds on it.
   Spec: `2026-08-08-window-runtime-foundation-design.md`.
-- **M2 — Independent windows.** ⌘N / File → New Window, per-window overlay and
+- **M2 — Independent windows.** *(deferred past 1.1.0)* ⌘N / File → New Window, per-window overlay and
   utility sheets, multi-window session restore, and application-menu-follows-
   focus correctness (the reference's version described the wrong window after a
   focus change — reproduced during the audit).
-- **M3 — Local profiles.** Identity model, per-profile stores and sessions, a
+- **M3 — Local profiles.** *(deferred past 1.1.0)* Identity model, per-profile stores and sessions, a
   working rename/delete UI (the reference's is dead — `window.prompt()` throws
   in Electron), with the sync/supporter/telemetry invariants preserved. The
   audit verified the reference's store scoping keeps the default profile on

--- a/src/main/island-proximity.js
+++ b/src/main/island-proximity.js
@@ -1,0 +1,108 @@
+'use strict';
+
+/**
+ * Island proximity — how close the cursor is to the resting pill.
+ *
+ * Main owns this because the cursor spends most of its life over the page,
+ * which is a different WebContentsView from the chrome the pill lives in. The
+ * chrome renderer never sees those moves. Main does (every view reports its
+ * input events), so main measures the distance and hands the renderer a single
+ * number; the renderer only animates.
+ *
+ * Pure functions, no Electron. The clipping invariant below is the reason this
+ * is a module rather than a few lines inline: it needs a test.
+ */
+
+/** How far out the pill starts reacting, in CSS px. */
+const RANGE = 250;
+
+/** Furthest the pill leans toward the cursor, in CSS px. */
+const MAX_LEAN = 6;
+
+/** Geometry of the effect at full closeness. Mirrors styles.css — see fitsInsideStrip. */
+const SCALE_AT_1 = 0.045;   // grows 4.5%
+const RISE_AT_1 = 3.5;      // lifts 3.5px
+
+/** Smoothstep: no edge you can feel at either end of the range. */
+function smoothstep(t) {
+  if (!(t > 0)) return 0;
+  if (t >= 1) return 1;
+  return t * t * (3 - 2 * t);
+}
+
+/**
+ * Shortest distance from a point to a rectangle's edge; 0 when inside.
+ * Measured to the box rather than its centre — otherwise a wide pill reads as
+ * "far" while the cursor is sitting right beside it.
+ */
+function distanceToRect(point, rect) {
+  const dx = Math.max(rect.x - point.x, 0, point.x - (rect.x + rect.width));
+  const dy = Math.max(rect.y - point.y, 0, point.y - (rect.y + rect.height));
+  return Math.hypot(dx, dy);
+}
+
+/** 0 when further than RANGE, 1 when touching the pill. */
+function closeness(point, rect, range = RANGE) {
+  if (!point || !rect || !(rect.width > 0) || !(range > 0)) return 0;
+  const d = distanceToRect(point, rect);
+  const k = smoothstep(1 - Math.min(d, range) / range);
+  // Snap the ends. Dividing by the range leaves float dust at the boundary
+  // (1 - 250/250 comes out at 1e-16, not 0), and an exact 0 is what lets the
+  // sender stop talking to the renderer once you walk away.
+  if (k < 1e-4) return 0;
+  if (k > 1 - 1e-4) return 1;
+  return k;
+}
+
+/**
+ * Which way, and how hard, the pill leans: -1 (cursor far to the left) through
+ * +1. Scaled by closeness so it can only lean while it is also awake.
+ */
+function lean(point, rect, k) {
+  if (!point || !rect || !(rect.width > 0) || !(k > 0)) return 0;
+  const centreX = rect.x + rect.width / 2;
+  const offset = (point.x - centreX) / (rect.width / 2 + RANGE);
+  return Math.max(-1, Math.min(1, offset)) * k;
+}
+
+/**
+ * THE INVARIANT. The pill's shadow currently fades to nothing exactly at the
+ * bottom of the chrome strip — there is no headroom at all (see the
+ * `--shadow-pill` note in tokens/layout.css). Scaling the pill therefore
+ * clips it twice over: the box grows downward, and the shadow grows with it.
+ *
+ * The rise is what pays for both. This returns how far the shadow's bottom
+ * edge sits from the strip's edge at full closeness — positive means clear.
+ * It must never be negative, at any closeness, and because every term is
+ * linear in k, checking k = 1 checks the whole range.
+ *
+ * Keep this in step with the `#islandPill` rules in styles.css.
+ */
+function shadowClearanceAtFullCloseness({
+  pillHeight,
+  shadowReach,
+  scaleAt1 = SCALE_AT_1,
+  riseAt1 = RISE_AT_1,
+}) {
+  // Downward growth of the box, plus the shadow stretching by the same factor.
+  const growth = (pillHeight + shadowReach) * scaleAt1;
+  return riseAt1 - growth;
+}
+
+/** Convenience predicate for the test and for anyone tuning the numbers. */
+function fitsInsideStrip(geometry) {
+  return shadowClearanceAtFullCloseness(geometry) > 0;
+}
+
+module.exports = {
+  RANGE,
+  MAX_LEAN,
+  SCALE_AT_1,
+  RISE_AT_1,
+  smoothstep,
+  distanceToRect,
+  closeness,
+  lean,
+  shadowClearanceAtFullCloseness,
+  fitsInsideStrip,
+};

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -905,8 +905,23 @@ function showOverlay(mode, { prefill } = {}) {
   rt().overlayPrefill = prefill ?? null;
   // (Re-)adding moves the overlay to the top of the child-view stack.
   rt().window.contentView.addChildView(rt().overlayView);
-  rt().overlayView.setBounds(overlayBounds());
-  rt().overlayView.webContents.send('overlay:show', { mode, prefill });
+  const bounds = overlayBounds();
+  rt().overlayView.setBounds(bounds);
+  rt().overlayView.webContents.send('overlay:show', {
+    mode,
+    prefill,
+    // Where the resting pill is, in the overlay's OWN coordinates, so the
+    // panel can start life at the pill's size and grow out of it. The two live
+    // in different views, so this hand-off is the only way the overlay can
+    // know. Null until the chrome renderer has reported a box — the panel then
+    // just appears, which is what it did before this existed.
+    pillRect: rt().islandRect && {
+      x: rt().islandRect.x - bounds.x,
+      y: rt().islandRect.y - bounds.y,
+      width: rt().islandRect.width,
+      height: rt().islandRect.height,
+    },
+  });
   rt().overlayView.webContents.focus();
   rt().window.webContents.send('chrome:island-state', { mode, trigger: mode === 'shield' ? rt().shieldTrigger : null });
 }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2430,10 +2430,14 @@ function cycleCluster(direction) {
 /** Focus an existing tab already on this internal page, or open one. */
 function openInternalPage(url) {
   if (isUtilityUrl(url)) return showUtilityPage(url);
-  const existing = rt().tabOrder.find((id) => tabs.get(id)?.url.startsWith(url));
-  if (existing) {
+  const existing = rt().tabOrder.find((id) => tabs.get(id)?.url?.startsWith(url));
+  const tab = existing ? tabs.get(existing) : null;
+  if (tab) {
     setActiveTab(existing);
-    tabs.get(existing).view.webContents.reload(); // pick up fresh data
+    // Hold the tab from the lookup rather than fetching it again. Re-fetching
+    // was safe only because setActiveTab happens not to mutate `tabs` — the
+    // same unstated assumption that crashed the menu rebuild.
+    tab.view.webContents.reload(); // pick up fresh data
   } else {
     setActiveTab(createTab(url));
   }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -10,6 +10,7 @@ const {
   onRequestBlocked,
 } = require('./adblock');
 const { blockableHostname, resolveBlockAdsCommand } = require('./adblock-exceptions');
+const islandProximity = require('./island-proximity');
 const {
   shieldChipState, shieldPopoverModel, connectionFor, committedUrlOf, activeConnection,
 } = require('./shield-model');
@@ -677,6 +678,84 @@ function currentChromeLayout() {
     tabLayout,
     verticalTabsWidth: verticalTabsPreferredWidth,
   });
+}
+
+/* ---- Island proximity ---------------------------------------------------
+ * The resting pill reacts to the cursor approaching it. The measuring happens
+ * here rather than in the chrome renderer because the cursor is usually over
+ * the page — a different WebContentsView — and the chrome document never sees
+ * those moves. Both views report their input events to main, so main is the
+ * only place that can watch the whole window.
+ *
+ * What crosses the IPC boundary is one number (plus a lean direction), only
+ * when it changes, and at most once a frame. Beyond the range main sends a
+ * single zero and then says nothing at all. */
+
+/** Map a point from a child view's coordinates into the window's. */
+function toWindowPoint(point, offset) {
+  return { x: point.x + (offset?.x ?? 0), y: point.y + (offset?.y ?? 0) };
+}
+
+function sendIslandProximity(runtime, next) {
+  runtime.islandProximity = next;
+  runtime.islandProximitySentAt = Date.now();
+  if (runtime.window && !runtime.window.isDestroyed()) {
+    runtime.window.webContents.send('chrome:island-proximity', next);
+  }
+}
+
+function updateIslandProximity(point) {
+  const runtime = rt();
+  if (!runtime?.window || runtime.window.isDestroyed()) return;
+  const rect = runtime.islandRect;
+  if (!rect) return;
+
+  // Asleep whenever the pill isn't the thing you're looking at: another app has
+  // focus, or the island is already expanded and the pill is hidden behind it.
+  const awake = runtime.window.isFocused() && !runtime.overlayMode;
+  const k = awake ? islandProximity.closeness(point, rect) : 0;
+  const lean = awake ? islandProximity.lean(point, rect, k) : 0;
+
+  // Three decimals is finer than the effect can render, and makes "unchanged"
+  // the common case while you move around away from the pill.
+  const next = { k: Number(k.toFixed(3)), lean: Number(lean.toFixed(3)) };
+  const prev = runtime.islandProximity;
+  if (next.k === prev.k && next.lean === prev.lean) return;
+
+  const since = Date.now() - runtime.islandProximitySentAt;
+  if (since >= 16) {
+    if (runtime.islandProximityTimer) {
+      clearTimeout(runtime.islandProximityTimer);
+      runtime.islandProximityTimer = null;
+    }
+    sendIslandProximity(runtime, next);
+    return;
+  }
+  // Inside the frame budget. Park the value and let a trailing timer deliver
+  // it — but park the NEWEST one: during a fast sweep the moves arrive far
+  // quicker than a frame, and holding the first would animate to a position
+  // the cursor has already left.
+  runtime.islandProximityPending = next;
+  if (runtime.islandProximityTimer) return;
+  runtime.islandProximityTimer = setTimeout(bindWindowRuntime(runtime, () => {
+    runtime.islandProximityTimer = null;
+    const pending = runtime.islandProximityPending;
+    runtime.islandProximityPending = null;
+    if (pending) sendIslandProximity(runtime, pending);
+  }), 16 - since);
+}
+
+/**
+ * Watch one view's mouse moves. `offset` maps its coordinates into the window's
+ * (a function when the offset can move, as it does with vertical tabs). `bind`
+ * puts the whole listener inside its window's runtime — updateIslandProximity
+ * reads rt(), so binding only the offset would throw on the first move.
+ */
+function watchCursorFor(wc, offset, bind) {
+  wc.on('input-event', bind((_event, input) => {
+    if (!input || input.type !== 'mouseMove') return;
+    updateIslandProximity(toWindowPoint(input, typeof offset === 'function' ? offset() : offset));
+  }));
 }
 
 function verticalTabsMetrics(layout = currentChromeLayout()) {
@@ -1737,6 +1816,9 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
   // so owner === primaryRuntime always; the shape is what M2 (multiple
   // runtimes) inherits without changes to this function.
   const boundToTab = (fn) => bindWindowRuntime(owner, fn);
+  // The page covers everything below the strip, so this is where the cursor is
+  // nearly always found. Bounds move with vertical tabs, so read them per event.
+  watchCursorFor(wc, () => currentChromeLayout().pageBounds, boundToTab);
   // SPIKE (1Password fill feasibility) — ⌥⌘P on the tab's OWN webContents
   // (the overlay before-input-event listener never sees page-focused keys).
   if (ONE_PASSWORD_SPIKE_ENABLED) {
@@ -2665,6 +2747,11 @@ function registerIpcHandlers() {
   chromeHandle('tabs:find', (_e, id, query, options) => tabs.get(id)?.view.webContents.findInPage(query, options));
   chromeHandle('tabs:find-stop', (_e, id) => tabs.get(id)?.view.webContents.stopFindInPage('clearSelection'));
 
+  chromeOn('chrome:island-rect', (_e, rect) => {
+    const ok = rect && ['x', 'y', 'width', 'height'].every((f) => Number.isFinite(rect[f]));
+    rt().islandRect = ok && rect.width > 0 ? rect : null;
+  });
+
   chromeOn('chrome:layout', (_e, { height }) => {
     if (typeof height === 'number' && height > 0) {
       rt().chromeHeight = height;
@@ -3201,6 +3288,9 @@ const createMainWindow = bindWindowRuntime(primaryRuntime, function createMainWi
   });
   windowRuntimes.attachWindow(primaryRuntime, { window: newWindow });
   windowRuntimes.registerChromeSurface(primaryRuntime, newWindow.webContents.id);
+  // The strip's own 64px band. Its document IS the window, so no offset.
+  watchCursorFor(newWindow.webContents, { x: 0, y: 0 },
+    (fn) => bindWindowRuntime(primaryRuntime, fn));
 
   lockPrivilegedNavigation(rt().window.webContents, CHROME_INDEX_URL);
   installChromeShortcuts(rt().window.webContents);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2839,11 +2839,16 @@ function tabMenuItems() {
   // Private tabs leave no trace anywhere else in the app (history, session,
   // favorites) — the native menu must not be the one place that leaks a
   // private tab's real title/domain.
-  const orderedIds = clusterSlots()
+  // Resolve to tabs here, once. The rebuild is debounced by 100ms, so
+  // clusterSlots() can still name a tab that has since closed — and dropping
+  // that id has to happen BEFORE anything reads the tab, or it takes the whole
+  // main process down. It did: `tabs.get(id)?.private` let a missing tab
+  // through (not private, therefore keep) and the next line dereferenced it.
+  const openTabs = clusterSlots()
     .flatMap((slot) => slot.tabIds)
-    .filter((id) => !tabs.get(id)?.private);
-  return orderedIds.map((id) => {
-    const tab = tabs.get(id);
+    .map((id) => [id, tabs.get(id)])
+    .filter(([, tab]) => tab && !tab.private);
+  return openTabs.map(([id, tab]) => {
     const group = tab.groupId ? rt().groups.find((g) => g.id === tab.groupId) : null;
     let domain = tab.url;
     try {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -905,6 +905,10 @@ function showOverlay(mode, { prefill } = {}) {
   rt().overlayPrefill = prefill ?? null;
   // (Re-)adding moves the overlay to the top of the child-view stack.
   rt().window.contentView.addChildView(rt().overlayView);
+  if (rt().overlayExitTimer) {
+    clearTimeout(rt().overlayExitTimer);
+    rt().overlayExitTimer = null;
+  }
   const bounds = overlayBounds();
   rt().overlayView.setBounds(bounds);
   rt().overlayView.webContents.send('overlay:show', {
@@ -926,6 +930,9 @@ function showOverlay(mode, { prefill } = {}) {
   rt().window.webContents.send('chrome:island-state', { mode, trigger: mode === 'shield' ? rt().shieldTrigger : null });
 }
 
+/** How long the panel takes to retract. Keep in step with styles.css. */
+const OVERLAY_RETRACT_MS = 200;
+
 function hideOverlay({ refocusContent = true, reason = null } = {}) {
   if (!rt().overlayMode) return;
   const closingMode = rt().overlayMode;
@@ -938,8 +945,28 @@ function hideOverlay({ refocusContent = true, reason = null } = {}) {
   // pending blank-tab focus reclaim so a page click can't reopen it.
   if (rt().activeTabId) rt().tabsWantingAddressBarFocus.delete(rt().activeTabId);
   if (hasLiveWindow() && rt().overlayView) {
-    rt().window.contentView.removeChildView(rt().overlayView);
-    rt().overlayView.webContents.send('overlay:hide');
+    // Tell the overlay to close BEFORE detaching it — the panel retracts into
+    // the pill, and a view that has already been removed has nothing left to
+    // draw. Only the pixels linger: focus and island state hand over below at
+    // once, so the user is never waiting on the animation.
+    const retracts = closingMode === 'panel' || closingMode === 'palette';
+    rt().overlayView.webContents.send('overlay:hide', { retract: retracts });
+    if (rt().overlayExitTimer) {
+      clearTimeout(rt().overlayExitTimer);
+      rt().overlayExitTimer = null;
+    }
+    if (retracts) {
+      rt().overlayExitTimer = setTimeout(bindWindowRuntime(rt(), () => {
+        rt().overlayExitTimer = null;
+        // Re-check: a new overlay may have opened while this was retracting,
+        // in which case the view is legitimately on screen again.
+        if (!rt().overlayMode && hasLiveWindow() && rt().overlayView) {
+          rt().window.contentView.removeChildView(rt().overlayView);
+        }
+      }), OVERLAY_RETRACT_MS);
+    } else {
+      rt().window.contentView.removeChildView(rt().overlayView);
+    }
     // Escape from the shield popover hands focus back to the control that
     // opened it, not to page content — keyboard users should land where they
     // started. The chrome webContents must take focus BEFORE the strip's DOM

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -102,7 +102,7 @@ contextBridge.exposeInMainWorld('browserAPI', {
     return () => ipcRenderer.removeListener('overlay:show', listener);
   },
   onOverlayHide: (callback) => {
-    const listener = () => callback();
+    const listener = (_e, payload) => callback(payload);
     ipcRenderer.on('overlay:hide', listener);
     return () => ipcRenderer.removeListener('overlay:hide', listener);
   },

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -39,6 +39,12 @@ contextBridge.exposeInMainWorld('browserAPI', {
   },
 
   reportChromeLayout: (height) => ipcRenderer.send('chrome:layout', { height }),
+  reportIslandRect: (rect) => ipcRenderer.send('chrome:island-rect', rect),
+  onIslandProximity: (callback) => {
+    const listener = (_e, payload) => callback(payload);
+    ipcRenderer.on('chrome:island-proximity', listener);
+    return () => ipcRenderer.removeListener('chrome:island-proximity', listener);
+  },
   setTabLayout: (layout) => ipcRenderer.invoke('chrome:set-tab-layout', layout),
   previewVerticalTabsWidth: (width) =>
     ipcRenderer.send('chrome:preview-vertical-tabs-width', width),

--- a/src/main/window-runtime-registry.js
+++ b/src/main/window-runtime-registry.js
@@ -60,6 +60,16 @@ function createRuntime() {
     permissionPrompts: new Map(),
     addressMenuTicket: 0,
     addressMenuSeq: 0,
+    /** The resting pill's box in window coordinates, reported by the chrome
+     * renderer. Main needs it to measure how far the cursor is from the pill:
+     * the cursor spends most of its life over the page, which is a different
+     * view from the one the pill lives in, so the chrome never sees it. */
+    islandRect: null,
+    /** Last proximity actually sent, so an unchanged value costs no IPC. */
+    islandProximity: { k: 0, lean: 0 },
+    islandProximitySentAt: 0,
+    islandProximityTimer: null,
+    islandProximityPending: null,
   };
   runtimes.push(runtime);
   return runtime;

--- a/src/main/window-runtime-registry.js
+++ b/src/main/window-runtime-registry.js
@@ -70,6 +70,8 @@ function createRuntime() {
     islandProximitySentAt: 0,
     islandProximityTimer: null,
     islandProximityPending: null,
+    /** Pending detach of the overlay view while its panel retracts. */
+    overlayExitTimer: null,
   };
   runtimes.push(runtime);
   return runtime;

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -1088,7 +1088,7 @@
    * Scale rather than width/height: animating the box would reflow the list on
    * every frame. The contents are held invisible until the growth is underway,
    * so the squash a uniform scale puts on them is never on screen. */
-  const MORPH_MS = 260;
+  const MORPH_MS = 300;
   let morphTimer = null;
 
   function morphPanelFromPill(pillRect) {
@@ -1097,14 +1097,21 @@
     const panelWidth = islandPanel.offsetWidth;
     if (!panelWidth) return;
 
-    const scale = Math.min(1, pillRect.width / panelWidth);
     const panelBox = islandPanel.getBoundingClientRect();
+    if (!panelBox.height) return;
+    // Scale the axes INDEPENDENTLY. The pill is a thin capsule and the panel a
+    // chunky box, so no single factor turns one into the other — a uniform
+    // scale got the width about right and left the height five times too tall,
+    // which reads as a blank blob appearing rather than the pill opening.
+    const scaleX = Math.min(1, pillRect.width / panelBox.width);
+    const scaleY = Math.min(1, pillRect.height / panelBox.height);
     const pillCentre = pillRect.x + pillRect.width / 2;
     const panelCentre = panelBox.left + panelBox.width / 2;
 
     clearTimeout(morphTimer);
     islandPanel.classList.add('morph-start');
-    islandPanel.style.setProperty('--morph-scale', String(scale));
+    islandPanel.style.setProperty('--morph-sx', String(scaleX));
+    islandPanel.style.setProperty('--morph-sy', String(scaleY));
     islandPanel.style.setProperty('--morph-x', `${(pillCentre - panelCentre).toFixed(2)}px`);
     islandPanel.style.setProperty('--morph-y', `${(pillRect.y - panelBox.top).toFixed(2)}px`);
 

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -1094,40 +1094,32 @@
   function morphPanelFromPill(pillRect) {
     if (!pillRect || !pillRect.width) return;          // no box reported yet
     if (prefersReducedMotion()) return;                 // decorative; skip entirely
-    const panelWidth = islandPanel.offsetWidth;
-    if (!panelWidth) return;
-
     const panelBox = islandPanel.getBoundingClientRect();
-    if (!panelBox.height) return;
-    // Scale the axes INDEPENDENTLY. The pill is a thin capsule and the panel a
-    // chunky box, so no single factor turns one into the other — a uniform
-    // scale got the width about right and left the height five times too tall,
-    // which reads as a blank blob appearing rather than the pill opening.
-    const scaleX = Math.min(1, pillRect.width / panelBox.width);
-    const scaleY = Math.min(1, pillRect.height / panelBox.height);
+    if (!panelBox.width || !panelBox.height) return;
+
+    // Animate the panel's actual SIZE, not a transform scale.
+    //
+    // Scaling warps the corners: a round corner under a non-uniform scale
+    // renders as an ellipse, and no amount of pre-compensating the radius
+    // holds it steady, because the radius interpolates linearly while the
+    // scale does not. The panel's resting corner (18px) and the pill's
+    // (half its height, ~19px) are nearly the same, so the corner should
+    // barely move at all — and with real width and height it doesn't.
+    //
+    // It also means the contents are revealed rather than squashed, so they
+    // never rubber out on the way in.
+    const naturalWidth = panelBox.width;
+    const naturalHeight = panelBox.height;
     const pillCentre = pillRect.x + pillRect.width / 2;
     const panelCentre = panelBox.left + panelBox.width / 2;
 
     clearTimeout(morphTimer);
     islandPanel.classList.add('morph-start');
-    islandPanel.style.setProperty('--morph-sx', String(scaleX));
-    islandPanel.style.setProperty('--morph-sy', String(scaleY));
+    islandPanel.style.width = `${pillRect.width.toFixed(1)}px`;
+    islandPanel.style.height = `${pillRect.height.toFixed(1)}px`;
+    islandPanel.style.borderRadius = `${(pillRect.height / 2).toFixed(1)}px`;
     islandPanel.style.setProperty('--morph-x', `${(pillCentre - panelCentre).toFixed(2)}px`);
     islandPanel.style.setProperty('--morph-y', `${(pillRect.y - panelBox.top).toFixed(2)}px`);
-
-    // Corners, pre-compensated for the scale. Two things go wrong if you just
-    // animate 999px down to the panel's radius. 999px is clamped to a capsule
-    // while the box is short, but the VALUE is still enormous once it has
-    // grown — so mid-movement you get a huge rounded corner that only collapses
-    // at the very end. And scaling the axes by different amounts renders a
-    // round corner as a squashed ellipse.
-    //
-    // So start from the pill's real corner (half its height, which is what
-    // makes it a capsule) divided by each axis' scale, so it RENDERS as that
-    // corner at the start and travels evenly to the panel's own radius.
-    const pillCorner = pillRect.height / 2;
-    islandPanel.style.setProperty('--morph-rx', `${(pillCorner / scaleX).toFixed(2)}px`);
-    islandPanel.style.setProperty('--morph-ry', `${(pillCorner / scaleY).toFixed(2)}px`);
 
     // Two frames: one for the start state to be painted, one to leave it. A
     // single frame lands both in the same style recalculation and the panel
@@ -1135,7 +1127,18 @@
     requestAnimationFrame(() => requestAnimationFrame(() => {
       islandPanel.classList.remove('morph-start');
       islandPanel.classList.add('morph-run');
-      morphTimer = setTimeout(() => islandPanel.classList.remove('morph-run'), MORPH_MS + 60);
+      islandPanel.style.width = `${naturalWidth.toFixed(1)}px`;
+      islandPanel.style.height = `${naturalHeight.toFixed(1)}px`;
+      islandPanel.style.borderRadius = '';
+      islandPanel.style.removeProperty('--morph-x');
+      islandPanel.style.removeProperty('--morph-y');
+      morphTimer = setTimeout(() => {
+        // Hand the box back to layout, so the panel resizes normally again
+        // when tabs open and close underneath it.
+        islandPanel.classList.remove('morph-run');
+        islandPanel.style.width = '';
+        islandPanel.style.height = '';
+      }, MORPH_MS + 60);
     }));
   }
 

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -10,6 +10,7 @@
 
   const backdrop = document.getElementById('backdrop');
   const panelAnchor = document.getElementById('panelAnchor');
+  const islandPanel = document.getElementById('islandPanel');
   const addressInput = document.getElementById('addressInput');
   const panelInsecure = document.getElementById('panelInsecure');
   const islandList = document.getElementById('islandList');
@@ -1080,7 +1081,51 @@
     }
     window.browserAPI.closeOverlay();
   });
-  window.browserAPI.onOverlayShow(({ mode: next, prefill }) => applyMode(next, prefill));
+  /* The panel grows out of the resting pill. They are separate views, so the
+   * pill's box arrives from main; we start the panel matching it — same width,
+   * same top, capsule corners — and let one frame later carry it to full size.
+   *
+   * Scale rather than width/height: animating the box would reflow the list on
+   * every frame. The contents are held invisible until the growth is underway,
+   * so the squash a uniform scale puts on them is never on screen. */
+  const MORPH_MS = 260;
+  let morphTimer = null;
+
+  function morphPanelFromPill(pillRect) {
+    if (!pillRect || !pillRect.width) return;          // no box reported yet
+    if (prefersReducedMotion()) return;                 // decorative; skip entirely
+    const panelWidth = islandPanel.offsetWidth;
+    if (!panelWidth) return;
+
+    const scale = Math.min(1, pillRect.width / panelWidth);
+    const panelBox = islandPanel.getBoundingClientRect();
+    const pillCentre = pillRect.x + pillRect.width / 2;
+    const panelCentre = panelBox.left + panelBox.width / 2;
+
+    clearTimeout(morphTimer);
+    islandPanel.classList.add('morph-start');
+    islandPanel.style.setProperty('--morph-scale', String(scale));
+    islandPanel.style.setProperty('--morph-x', `${(pillCentre - panelCentre).toFixed(2)}px`);
+    islandPanel.style.setProperty('--morph-y', `${(pillRect.y - panelBox.top).toFixed(2)}px`);
+
+    // Two frames: one for the start state to be painted, one to leave it. A
+    // single frame lands both in the same style recalculation and the panel
+    // simply appears at full size.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      islandPanel.classList.remove('morph-start');
+      islandPanel.classList.add('morph-run');
+      morphTimer = setTimeout(() => islandPanel.classList.remove('morph-run'), MORPH_MS + 60);
+    }));
+  }
+
+  const prefersReducedMotion = () =>
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  window.browserAPI.onOverlayShow(({ mode: next, prefill, pillRect }) => {
+    const wasOpen = mode === next;
+    applyMode(next, prefill);
+    if (!wasOpen && (next === 'panel' || next === 'palette')) morphPanelFromPill(pillRect);
+  });
   window.browserAPI.onOverlayHide(() => {
     if (mode === 'find') resetFind();
     mode = null;

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -1088,7 +1088,7 @@
    * Scale rather than width/height: animating the box would reflow the list on
    * every frame. The contents are held invisible until the growth is underway,
    * so the squash a uniform scale puts on them is never on screen. */
-  const MORPH_MS = 300;
+  const MORPH_MS = 320;   // long enough for the contents' 190ms delay + fade
   let morphTimer = null;
 
   function morphPanelFromPill(pillRect) {
@@ -1114,6 +1114,20 @@
     islandPanel.style.setProperty('--morph-sy', String(scaleY));
     islandPanel.style.setProperty('--morph-x', `${(pillCentre - panelCentre).toFixed(2)}px`);
     islandPanel.style.setProperty('--morph-y', `${(pillRect.y - panelBox.top).toFixed(2)}px`);
+
+    // Corners, pre-compensated for the scale. Two things go wrong if you just
+    // animate 999px down to the panel's radius. 999px is clamped to a capsule
+    // while the box is short, but the VALUE is still enormous once it has
+    // grown — so mid-movement you get a huge rounded corner that only collapses
+    // at the very end. And scaling the axes by different amounts renders a
+    // round corner as a squashed ellipse.
+    //
+    // So start from the pill's real corner (half its height, which is what
+    // makes it a capsule) divided by each axis' scale, so it RENDERS as that
+    // corner at the start and travels evenly to the panel's own radius.
+    const pillCorner = pillRect.height / 2;
+    islandPanel.style.setProperty('--morph-rx', `${(pillCorner / scaleX).toFixed(2)}px`);
+    islandPanel.style.setProperty('--morph-ry', `${(pillCorner / scaleY).toFixed(2)}px`);
 
     // Two frames: one for the start state to be painted, one to leave it. A
     // single frame lands both in the same style recalculation and the panel

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -1089,6 +1089,8 @@
    * every frame. The contents are held invisible until the growth is underway,
    * so the squash a uniform scale puts on them is never on screen. */
   const MORPH_MS = 320;   // long enough for the contents' 190ms delay + fade
+  const RETRACT_MS = 200; // keep in step with OVERLAY_RETRACT_MS in main.js
+  let lastPillRect = null;
   let morphTimer = null;
 
   function morphPanelFromPill(pillRect) {
@@ -1108,6 +1110,7 @@
     //
     // It also means the contents are revealed rather than squashed, so they
     // never rubber out on the way in.
+    lastPillRect = pillRect;
     const naturalWidth = panelBox.width;
     const naturalHeight = panelBox.height;
     const pillCentre = pillRect.x + pillRect.width / 2;
@@ -1150,12 +1153,58 @@
     applyMode(next, prefill);
     if (!wasOpen && (next === 'panel' || next === 'palette')) morphPanelFromPill(pillRect);
   });
-  window.browserAPI.onOverlayHide(() => {
+  /* Closing: the panel shrinks back into the pill. Main holds the overlay view
+   * on screen for RETRACT_MS so there is something left to draw, and hands
+   * focus back immediately — only the pixels linger. */
+  function retractPanelIntoPill() {
+    const pill = lastPillRect;
+    if (!pill || !pill.width || prefersReducedMotion()) return false;
+    const box = islandPanel.getBoundingClientRect();
+    if (!box.width) return false;
+
+    clearTimeout(morphTimer);
+    // Pin the current size first, or transitioning from `auto` does nothing.
+    islandPanel.classList.add('morph-run', 'retracting');
+    islandPanel.style.width = `${box.width.toFixed(1)}px`;
+    islandPanel.style.height = `${box.height.toFixed(1)}px`;
+
+    requestAnimationFrame(() => {
+      const centreShift = (pill.x + pill.width / 2) - (box.left + box.width / 2);
+      islandPanel.style.width = `${pill.width.toFixed(1)}px`;
+      islandPanel.style.height = `${pill.height.toFixed(1)}px`;
+      islandPanel.style.borderRadius = `${(pill.height / 2).toFixed(1)}px`;
+      islandPanel.style.setProperty('--morph-x', `${centreShift.toFixed(2)}px`);
+      islandPanel.style.setProperty('--morph-y', `${(pill.y - box.top).toFixed(2)}px`);
+    });
+    return true;
+  }
+
+  /** Put the panel back to its resting styles once it is off screen. */
+  function clearMorphStyles() {
+    clearTimeout(morphTimer);
+    islandPanel.classList.remove('morph-start', 'morph-run', 'retracting');
+    islandPanel.style.width = '';
+    islandPanel.style.height = '';
+    islandPanel.style.borderRadius = '';
+    islandPanel.style.removeProperty('--morph-x');
+    islandPanel.style.removeProperty('--morph-y');
+  }
+
+  window.browserAPI.onOverlayHide((payload) => {
+    const retracting = payload?.retract && (mode === 'panel' || mode === 'palette')
+      && retractPanelIntoPill();
     if (mode === 'find') resetFind();
     mode = null;
     document.body.dataset.mode = '';
     backdrop.hidden = true;
-    panelAnchor.hidden = true;
+    if (retracting) {
+      // The anchor stays up until the panel has shrunk away. pointer-events
+      // are dropped in CSS so the page underneath is clickable straight away.
+      morphTimer = setTimeout(() => { panelAnchor.hidden = true; clearMorphStyles(); }, RETRACT_MS);
+    } else {
+      panelAnchor.hidden = true;
+      clearMorphStyles();
+    }
     findBar.hidden = true;
     shieldPop.hidden = true;
     inputTouched = false;

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -583,4 +583,40 @@
   };
   new ResizeObserver(reportLayout).observe(chromeEl);
   requestAnimationFrame(reportLayout);
+
+  // --- Island proximity: the pill reacts to the cursor approaching. ---------
+  // Main does the measuring — the cursor is usually over the page, which this
+  // document never sees — and sends back how close it is. This side only tells
+  // main where the pill is, and paints what comes back.
+  //
+  // The reported box is the RESTING one, with the effect's own transform
+  // divided back out. Reporting the transformed box would let the pill chase
+  // itself: closer reads as bigger reads as closer.
+  const ISLAND_SCALE = 0.045;   // keep in step with #islandPill in styles.css
+  const ISLAND_RISE = 3.5;
+  const ISLAND_LEAN = 6;
+
+  const reportIslandRect = () => {
+    const r = islandPill.getBoundingClientRect();
+    if (!r.width) return;
+    const k = Number(islandPill.style.getPropertyValue('--island-k')) || 0;
+    const lean = Number(islandPill.style.getPropertyValue('--island-lean')) || 0;
+    const scale = 1 + ISLAND_SCALE * k;
+    // transform-origin is the top centre, so the top edge only moves by the rise.
+    const width = r.width / scale;
+    const height = r.height / scale;
+    window.browserAPI.reportIslandRect({
+      x: (r.left + r.width / 2) - ISLAND_LEAN * lean - width / 2,
+      y: r.top + ISLAND_RISE * k,
+      width,
+      height,
+    });
+  };
+  new ResizeObserver(reportIslandRect).observe(islandPill);
+  requestAnimationFrame(reportIslandRect);
+
+  window.browserAPI.onIslandProximity(({ k, lean }) => {
+    islandPill.style.setProperty('--island-k', String(k ?? 0));
+    islandPill.style.setProperty('--island-lean', String(lean ?? 0));
+  });
 })();

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1145,37 +1145,37 @@ body[data-mode="palette"] #backdrop {
 }
 /* Opening: the panel grows out of the resting pill rather than appearing.
    The two are separate views, so overlay.js is handed the pill's box and sets
-   --morph-* from it; 'morph-start' is the pill-shaped state and 'morph-run'
-   carries it home. Corners travel 999px → the panel radius, which is what
-   stops the pill's capsule ends peeking out from behind a square panel.
-   Contents stay invisible through the first half, so the squash a uniform
-   scale puts on them never reaches the screen. */
+   the panel's starting width, height and corner from it.
+
+   SIZE, not transform scale. Scaling warps the corners — a round corner under
+   a non-uniform scale renders as an ellipse, and pre-compensating the radius
+   can only ever approximate it, because the radius interpolates linearly and
+   the scale doesn't. The panel's corner (18px) and the pill's (~19px) are
+   nearly the same, so the corner should barely move; with real width and
+   height it doesn't. It also means the contents are revealed as the box grows
+   rather than squashed and rubbering back out. */
+#islandPanel.morph-start,
+#islandPanel.morph-run {
+  overflow: hidden;
+  transform: translate(var(--morph-x, 0), var(--morph-y, 0));
+}
 #islandPanel.morph-start {
-  transform:
-    translate(var(--morph-x, 0), var(--morph-y, 0))
-    scale(var(--morph-sx, 1), var(--morph-sy, 1));
-  /* Elliptical on purpose — see the note in overlay.js. This renders as the
-     pill's own capsule corner once the non-uniform scale is applied. */
-  border-radius: var(--morph-rx, 999px) / var(--morph-ry, 999px);
+  opacity: 0;
   transition: none;
 }
 #islandPanel.morph-start > * { opacity: 0; }
-/* Steadier than the DS's snappy curve: that one front-loads so hard the whole
-   movement was over inside 60ms, which reads as a flash rather than a morph. */
-#islandPanel.morph-start { opacity: 0; }
 #islandPanel.morph-run {
   opacity: 1;
   transition:
-    transform 300ms cubic-bezier(0.4, 0, 0.2, 1),
-    border-radius 300ms cubic-bezier(0.4, 0, 0.2, 1),
+    width 320ms cubic-bezier(0.4, 0, 0.2, 1),
+    height 320ms cubic-bezier(0.4, 0, 0.2, 1),
+    border-radius 320ms cubic-bezier(0.4, 0, 0.2, 1),
+    transform 320ms cubic-bezier(0.4, 0, 0.2, 1),
     opacity 90ms ease;
 }
-/* Contents wait for the shape. Independent axes mean the panel starts at 14%
-   height, so anything visible before the vertical scale is nearly home arrives
-   squashed and rubbers out — which is what still felt wrong after the shape
-   itself was fixed. At 190ms the vertical scale is ~93%. */
-#islandPanel.morph-run > * { transition: opacity 130ms ease 190ms; }
-#islandPanel { transform-origin: 50% 0; }
+/* Contents come in early now — nothing squashes them any more, they are simply
+   uncovered as the box grows. */
+#islandPanel.morph-run > * { transition: opacity 160ms ease 60ms; }
 
 [data-theme="private"] #islandPanel { border: 1px dashed var(--text-dim); }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1177,6 +1177,23 @@ body[data-mode="palette"] #backdrop {
    uncovered as the box grows. */
 #islandPanel.morph-run > * { transition: opacity 160ms ease 60ms; }
 
+/* Closing: the same movement in reverse, quicker — exits that match their
+   entrance in length feel slow. The panel stops taking clicks the moment it
+   starts leaving, so the page underneath is live again immediately even though
+   the overlay view is still on screen for another fifth of a second. */
+#islandPanel.retracting {
+  pointer-events: none;
+  transition:
+    width 200ms cubic-bezier(0.4, 0, 1, 1),
+    height 200ms cubic-bezier(0.4, 0, 1, 1),
+    border-radius 200ms cubic-bezier(0.4, 0, 1, 1),
+    transform 200ms cubic-bezier(0.4, 0, 1, 1),
+    opacity 200ms ease 60ms;
+}
+#islandPanel.retracting { opacity: 0; }
+#islandPanel.retracting > * { opacity: 0; transition: opacity 90ms ease; }
+body[data-mode=""] #backdrop, #backdrop[hidden] { animation: none; }
+
 [data-theme="private"] #islandPanel { border: 1px dashed var(--text-dim); }
 
 .panel-row {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1144,17 +1144,21 @@ body[data-mode="palette"] #backdrop { background: rgba(14, 14, 14, 0.18); }
    Contents stay invisible through the first half, so the squash a uniform
    scale puts on them never reaches the screen. */
 #islandPanel.morph-start {
-  transform: translate(var(--morph-x, 0), var(--morph-y, 0)) scale(var(--morph-scale, 1));
+  transform:
+    translate(var(--morph-x, 0), var(--morph-y, 0))
+    scale(var(--morph-sx, 1), var(--morph-sy, 1));
   border-radius: 999px;
   transition: none;
 }
 #islandPanel.morph-start > * { opacity: 0; }
+/* Steadier than the DS's snappy curve: that one front-loads so hard the whole
+   movement was over inside 60ms, which reads as a flash rather than a morph. */
 #islandPanel.morph-run {
   transition:
-    transform 260ms cubic-bezier(0.32, 0.72, 0, 1),
-    border-radius 260ms cubic-bezier(0.32, 0.72, 0, 1);
+    transform 300ms cubic-bezier(0.4, 0, 0.2, 1),
+    border-radius 300ms cubic-bezier(0.4, 0, 0.2, 1);
 }
-#islandPanel.morph-run > * { transition: opacity 140ms ease 110ms; }
+#islandPanel.morph-run > * { transition: opacity 150ms ease 130ms; }
 #islandPanel { transform-origin: 50% 0; }
 
 [data-theme="private"] #islandPanel { border: 1px dashed var(--text-dim); }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1136,6 +1136,27 @@ body[data-mode="palette"] #backdrop { background: rgba(14, 14, 14, 0.18); }
   box-shadow: var(--shadow-popover);
   padding: 10px 12px 8px;
 }
+/* Opening: the panel grows out of the resting pill rather than appearing.
+   The two are separate views, so overlay.js is handed the pill's box and sets
+   --morph-* from it; 'morph-start' is the pill-shaped state and 'morph-run'
+   carries it home. Corners travel 999px → the panel radius, which is what
+   stops the pill's capsule ends peeking out from behind a square panel.
+   Contents stay invisible through the first half, so the squash a uniform
+   scale puts on them never reaches the screen. */
+#islandPanel.morph-start {
+  transform: translate(var(--morph-x, 0), var(--morph-y, 0)) scale(var(--morph-scale, 1));
+  border-radius: 999px;
+  transition: none;
+}
+#islandPanel.morph-start > * { opacity: 0; }
+#islandPanel.morph-run {
+  transition:
+    transform 260ms cubic-bezier(0.32, 0.72, 0, 1),
+    border-radius 260ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+#islandPanel.morph-run > * { transition: opacity 140ms ease 110ms; }
+#islandPanel { transform-origin: 50% 0; }
+
 [data-theme="private"] #islandPanel { border: 1px dashed var(--text-dim); }
 
 .panel-row {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1100,8 +1100,15 @@ body.overlay-body { background: transparent; }
 }
 #backdrop[hidden] { display: none; }
 /* The summoned palette dims the page behind it; the in-place panel keeps
-   a transparent backdrop that still catches click-outside-to-dismiss. */
-body[data-mode="palette"] #backdrop { background: rgba(14, 14, 14, 0.18); }
+   a transparent backdrop that still catches click-outside-to-dismiss.
+   The dim FADES with the panel's growth — snapping to full darkness in one
+   frame front-ran the movement and read as a hard cut, which was most of why
+   opening felt abrupt even once the panel's shape was right. */
+body[data-mode="palette"] #backdrop {
+  background: rgba(14, 14, 14, 0.18);
+  animation: backdrop-in 300ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+@keyframes backdrop-in { from { background: rgba(14, 14, 14, 0); } }
 
 #panelAnchor {
   position: fixed;
@@ -1147,18 +1154,27 @@ body[data-mode="palette"] #backdrop { background: rgba(14, 14, 14, 0.18); }
   transform:
     translate(var(--morph-x, 0), var(--morph-y, 0))
     scale(var(--morph-sx, 1), var(--morph-sy, 1));
-  border-radius: 999px;
+  /* Elliptical on purpose — see the note in overlay.js. This renders as the
+     pill's own capsule corner once the non-uniform scale is applied. */
+  border-radius: var(--morph-rx, 999px) / var(--morph-ry, 999px);
   transition: none;
 }
 #islandPanel.morph-start > * { opacity: 0; }
 /* Steadier than the DS's snappy curve: that one front-loads so hard the whole
    movement was over inside 60ms, which reads as a flash rather than a morph. */
+#islandPanel.morph-start { opacity: 0; }
 #islandPanel.morph-run {
+  opacity: 1;
   transition:
     transform 300ms cubic-bezier(0.4, 0, 0.2, 1),
-    border-radius 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    border-radius 300ms cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 90ms ease;
 }
-#islandPanel.morph-run > * { transition: opacity 150ms ease 130ms; }
+/* Contents wait for the shape. Independent axes mean the panel starts at 14%
+   height, so anything visible before the vertical scale is nearly home arrives
+   squashed and rubbers out — which is what still felt wrong after the shape
+   itself was fixed. At 190ms the vertical scale is ~93%. */
+#islandPanel.morph-run > * { transition: opacity 130ms ease 190ms; }
 #islandPanel { transform-origin: 50% 0; }
 
 [data-theme="private"] #islandPanel { border: 1px dashed var(--text-dim); }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -685,9 +685,35 @@ body.mac .vertical-tabs-toolbar {
   background: var(--surface-raised);
   border: 1px solid var(--border);
   border-radius: 999px;
-  box-shadow: var(--shadow-pill);
   white-space: nowrap;
   cursor: pointer;
+
+  /* Proximity. --island-k is how close the cursor is (0 far, 1 arrived) and
+     --island-lean is which side it's on (-1 to 1); main measures both and sets
+     them from renderer.js. The pill leans toward you, rises, and grows.
+
+     THE RISE IS LOAD-BEARING, not decoration. The shadow below fades to
+     nothing exactly at the strip's bottom edge — there is no headroom at all
+     (see the --shadow-pill note in tokens/layout.css). Scaling would clip it
+     twice: the box grows downward AND the shadow stretches with it. The rise
+     out-runs both, so the shadow's bottom edge actually pulls UP as you
+     approach. Shrink the rise or grow the scale and the shadow starts getting
+     sliced again — test/unit/island-proximity.test.js fails if you do.
+
+     The shadow deepens by DARKNESS only; its offset, blur and spread never
+     change. Growing its size is what would clip, and a denser shadow reads as
+     "closer to the surface" anyway. */
+  transform-origin: 50% 0%;
+  transform:
+    translateX(calc(6px * var(--island-lean, 0)))
+    translateY(calc(-3.5px * var(--island-k, 0)))
+    scale(calc(1 + 0.045 * var(--island-k, 0)));
+  box-shadow:
+    var(--shadow-pill),
+    0 2px 16px -3px rgba(14, 14, 14, calc(0.07 * var(--island-k, 0)));
+  transition:
+    transform 220ms cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 220ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Dot clusters: one cluster per tab group (group order), ungrouped tabs
@@ -1809,5 +1835,7 @@ body:not(.mac) #permissionBar { right: 118px; } /* clear the window controls */
   .island-row.tab-row .row-tag,
   .island-row.tab-row .row-remote-pin { transition: none; }
   .pill-download .dl-wave { animation: none; }
+  /* The proximity reaction is entirely decorative — off, not just instant. */
+  #islandPill { transform: none; transition: none; box-shadow: var(--shadow-pill); }
   #strip { transition: none; }
 }

--- a/test/unit/island-proximity.test.js
+++ b/test/unit/island-proximity.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  RANGE,
+  smoothstep,
+  distanceToRect,
+  closeness,
+  lean,
+  shadowClearanceAtFullCloseness,
+  fitsInsideStrip,
+  SCALE_AT_1,
+  RISE_AT_1,
+} = require('../../src/main/island-proximity');
+
+// The resting pill as it actually renders, measured in the running chrome:
+// top 11.5, bottom 50.28 inside a 64px strip, with the shadow fading to white
+// exactly at 64. See the --shadow-pill note in tokens/layout.css.
+const PILL = { x: 466, y: 11.5, width: 348, height: 38.78 };
+const SHADOW_REACH = 13.72;
+const STRIP_H = 64;
+
+test('closeness is 0 beyond the range and 1 on the pill', () => {
+  assert.equal(closeness({ x: 640, y: PILL.y + PILL.height + RANGE }, PILL), 0);
+  assert.equal(closeness({ x: 640, y: PILL.y + PILL.height + RANGE + 400 }, PILL), 0);
+  assert.equal(closeness({ x: 640, y: PILL.y + 5 }, PILL), 1);
+});
+
+test('closeness rises as the cursor approaches, with no step at the edge', () => {
+  const at = (d) => closeness({ x: 640, y: PILL.y + PILL.height + d }, PILL);
+  const samples = [250, 200, 150, 100, 50, 10, 0].map(at);
+  for (let i = 1; i < samples.length; i++) {
+    assert.ok(samples[i] > samples[i - 1], `closeness should grow: ${samples}`);
+  }
+  // smoothstep flattens at both ends, so the first step off the edge is tiny —
+  // that is what stops the effect switching on visibly.
+  assert.ok(at(249) < 0.001, `just inside the range should be imperceptible, got ${at(249)}`);
+  assert.ok(at(1) > 0.999, `all but touching should be ~1, got ${at(1)}`);
+});
+
+test('distance is measured to the pill box, not its centre', () => {
+  // A cursor beside the pill's left edge is close, even though the pill is wide.
+  const besideEdge = { x: PILL.x - 20, y: PILL.y + 10 };
+  assert.equal(distanceToRect(besideEdge, PILL), 20);
+  // Inside the box is zero.
+  assert.equal(distanceToRect({ x: 640, y: 20 }, PILL), 0);
+});
+
+test('smoothstep is clamped and symmetric about its midpoint', () => {
+  assert.equal(smoothstep(-1), 0);
+  assert.equal(smoothstep(0), 0);
+  assert.equal(smoothstep(1), 1);
+  assert.equal(smoothstep(2), 1);
+  assert.equal(smoothstep(0.5), 0.5);
+  assert.ok(Math.abs((smoothstep(0.25) + smoothstep(0.75)) - 1) < 1e-9);
+});
+
+test('lean points toward the cursor and is gated by closeness', () => {
+  const k = 1;
+  const left = lean({ x: PILL.x - 100, y: PILL.y }, PILL, k);
+  const right = lean({ x: PILL.x + PILL.width + 100, y: PILL.y }, PILL, k);
+  assert.ok(left < 0, 'cursor to the left should lean left');
+  assert.ok(right > 0, 'cursor to the right should lean right');
+  assert.ok(Math.abs(left) <= 1 && Math.abs(right) <= 1, 'lean stays in -1..1');
+  // Dead centre, no lean.
+  assert.ok(Math.abs(lean({ x: PILL.x + PILL.width / 2, y: PILL.y }, PILL, k)) < 1e-9);
+  // Far away, no lean even though the cursor is off to one side.
+  assert.equal(lean({ x: PILL.x - 100, y: PILL.y }, PILL, 0), 0);
+});
+
+// ---------------------------------------------------------------------------
+// The one that matters. This is a guard, not a description: the pill's shadow
+// has ZERO headroom at rest, so if someone shrinks the rise or grows the scale
+// the shadow starts getting sliced at the strip's edge — the exact bug fixed in
+// PR #93, twice. The numbers here mirror styles.css.
+// ---------------------------------------------------------------------------
+
+test('the rise out-runs the scale, so the shadow never reaches the strip edge', () => {
+  const clearance = shadowClearanceAtFullCloseness({
+    pillHeight: PILL.height,
+    shadowReach: SHADOW_REACH,
+  });
+  assert.ok(clearance > 0,
+    `the shadow would clip at full closeness by ${(-clearance).toFixed(2)}px — ` +
+    `the rise (${RISE_AT_1}px) must exceed ${((PILL.height + SHADOW_REACH) * SCALE_AT_1).toFixed(2)}px`);
+
+  // And state where the shadow actually lands, so a regression reads clearly.
+  const shadowBottom = PILL.y + PILL.height + SHADOW_REACH - clearance;
+  assert.ok(shadowBottom <= STRIP_H,
+    `shadow bottom ${shadowBottom.toFixed(2)} must stay inside the ${STRIP_H}px strip`);
+});
+
+test('every term is linear in closeness, so k=1 is the worst case', () => {
+  // Half closeness = half the growth and half the rise, so clearance halves too.
+  const full = shadowClearanceAtFullCloseness({ pillHeight: PILL.height, shadowReach: SHADOW_REACH });
+  const half = shadowClearanceAtFullCloseness({
+    pillHeight: PILL.height, shadowReach: SHADOW_REACH,
+    scaleAt1: SCALE_AT_1 / 2, riseAt1: RISE_AT_1 / 2,
+  });
+  assert.ok(Math.abs(half - full / 2) < 1e-9,
+    'clearance must scale linearly with closeness — otherwise k=1 is not the worst case');
+});
+
+test('fitsInsideStrip rejects the shapes that broke before', () => {
+  const base = { pillHeight: PILL.height, shadowReach: SHADOW_REACH };
+  // No rise at all — the original variant C, which overshot badly.
+  assert.equal(fitsInsideStrip({ ...base, riseAt1: 0 }), false);
+  // A rise that only pays for the box and forgets the shadow stretches too.
+  assert.equal(fitsInsideStrip({ ...base, riseAt1: PILL.height * SCALE_AT_1 }), false);
+  // What we ship.
+  assert.equal(fitsInsideStrip(base), true);
+});

--- a/test/unit/tab-menu-items.test.js
+++ b/test/unit/tab-menu-items.test.js
@@ -1,0 +1,85 @@
+'use strict';
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+// tabMenuItems lives in main.js, which cannot be required in a unit test. Same
+// approach as settings-fanout-reload.test.js: lift the function's real source
+// and run it in a sandbox, so this asserts the shipped code, not a copy.
+const mainSource = fs.readFileSync(path.join(__dirname, '../../src/main/main.js'), 'utf8');
+const fnSource = mainSource.match(/function tabMenuItems\(\) \{[\s\S]*?\n\}/)?.[0];
+
+test('the tab-menu builder is still present in main.js', () => {
+  assert.ok(fnSource, 'tabMenuItems not found — update this test with it');
+});
+
+/**
+ * Run the real function against a controllable world.
+ * `slotIds` is what clusterSlots() reports; `tabsById` is what actually exists.
+ * The gap between the two is the whole point — see the regression test below.
+ */
+function run({ slotIds, tabsById, groups = [], activeTabId = null }) {
+  const tabs = new Map(Object.entries(tabsById).map(([k, v]) => [Number(k), v]));
+  const sandbox = {
+    clusterSlots: () => [{ tabIds: slotIds }],
+    tabs,
+    rt: () => ({ groups, activeTabId }),
+    primaryRuntime: {},
+    bindWindowRuntime: (_r, fn) => fn,
+    setActiveTab: () => {},
+    escapeMenuLabel: (l) => l,
+    URL,
+  };
+  vm.runInNewContext(`${fnSource}\nthis.__fn = tabMenuItems;`, sandbox);
+  return sandbox.__fn();
+}
+
+const tab = (over = {}) => ({ title: 'The Verge', url: 'https://theverge.com/', private: false, groupId: null, ...over });
+
+test('builds one item per open tab, in slot order', () => {
+  const items = run({ slotIds: [1, 2], tabsById: { 1: tab(), 2: tab({ title: 'News', url: 'https://news.example/' }) } });
+  assert.equal(items.length, 2);
+  assert.equal(items[0].label, 'The Verge — theverge.com');
+  assert.equal(items[1].label, 'News — news.example');
+});
+
+test('private tabs are left out entirely', () => {
+  const items = run({ slotIds: [1, 2], tabsById: { 1: tab(), 2: tab({ title: 'Secret', private: true }) } });
+  assert.equal(items.length, 1);
+  assert.equal(items[0].label, 'The Verge — theverge.com');
+});
+
+test("a tab's group name is appended when it has one", () => {
+  const items = run({
+    slotIds: [1], tabsById: { 1: tab({ groupId: 'g1' }) }, groups: [{ id: 'g1', name: 'work' }],
+  });
+  assert.equal(items[0].label, 'The Verge — theverge.com (work)');
+});
+
+// ---------------------------------------------------------------------------
+// REGRESSION — hard crash of the whole main process, shipped in 1.0.10.
+//
+// The menu rebuild is debounced by 100ms. Close a tab and the rebuild fires
+// afterwards, by which time clusterSlots() can still name an id that `tabs` no
+// longer holds. The filter tolerated that (`tabs.get(id)?.private` — a missing
+// tab is "not private", so its id passes through) but the very next line did
+// `tab.groupId` on undefined and took the app down.
+//
+// Same shape as the settings-fanout crash fixed in #88: a deferred action
+// outliving the tab it was scheduled for.
+// ---------------------------------------------------------------------------
+
+test('a tab that closed before the debounced rebuild does not crash the menu', () => {
+  const items = run({
+    slotIds: [1, 999, 2],                       // 999 closed while the rebuild was pending
+    tabsById: { 1: tab(), 2: tab({ title: 'News', url: 'https://news.example/' }) },
+  });
+  assert.equal(items.length, 2, 'the stale id should be dropped, not rendered');
+  assert.deepEqual(items.map((i) => i.label), ['The Verge — theverge.com', 'News — news.example']);
+});
+
+test('a rebuild after every tab closed produces an empty menu, not a crash', () => {
+  assert.deepEqual(run({ slotIds: [7, 8], tabsById: {} }), []);
+});


### PR DESCRIPTION
Motion for the island, for 1.1.0. Two effects, plus the roadmap change that makes room for them.

> **Stacked on #94.** The first commit is that crash fix, so it can merge on its own without waiting for this. Rebase after it lands.

## 1. The resting pill senses the cursor

Move toward the island and it leans your way, rises, and grows — full strength as you arrive, easing back as you leave. Nothing switches on: the reaction follows distance continuously on a smoothstep, so neither end of the range has an edge you can feel. It starts reacting at 250px.

**The measuring happens in main, which is the only place it can.** The cursor spends most of its life over the page, and the page is a different `WebContentsView` from the one the pill lives in — the chrome document never sees those moves. Both views report their input events to main, so main watches the whole window and hands the renderer one number.

What crosses the IPC boundary is that number and a lean direction, rounded to three decimals, only when it changes, at most once a frame. Beyond 250px main sends a single zero and goes quiet. Nothing runs while another app has focus, or while the panel is open and the pill is hidden.

### The rise is load-bearing, not decoration

The pill's shadow fades to nothing *exactly* at the strip's bottom edge — zero headroom, by construction (see #93). Scaling would clip it twice over: the box grows downward and the shadow stretches with it.

The rise out-runs both. Work it through and the shadow's bottom edge lands at **64 − 1.1 × closeness** — at rest exactly where it is today, and pulling further *up* the closer you get. It cannot clip at any distance, and that is a property of the numbers rather than something I spot-checked.

`island-proximity.test.js` guards precisely that. It fails if the rise ever stops out-running the scale, and it rejects the two shapes tried and discarded during design: no rise at all, and a rise that pays for the box but forgets the shadow stretches too. The shadow therefore deepens by **darkness only** — offset, blur and spread never change.

## 2. The panel grows out of the pill, and retracts back into it

The pill and panel are separate views, so one becoming the other is an illusion. Main hands the overlay the pill's box — it already tracks it for the proximity effect — and the panel starts life matching it, then travels to full size. Closing reverses it.

**It animates real width and height, not a transform scale.** This took three attempts and every wrong turn is worth recording:

| Attempt | Result |
|---|---|
| Uniform scale | Width about right, height 5× too tall — a blank blob that expanded |
| Independent scaleX/scaleY | Correct start shape, but a round corner under an uneven scale renders as an **ellipse**, and contents arrived squashed |
| Pre-compensating the radius | Still wrong: the radius interpolates linearly and the scale doesn't, so they drift apart mid-movement and the corner balloons |

The panel's corner is 18px and the pill's about 19px. They are nearly identical, so the corner should barely move — **any** visible radius change was an artefact of scaling. With real width and height it measures 19.4 → 19.3 → 18.7 → 18.2 → 18.0 across the whole movement.

Animating size also means contents are *uncovered* rather than squashed, so they no longer rubber out on the way in.

The cost is layout per frame instead of a compositor-only transform. For one small panel in its own view that is not a real cost, and the shape being right is the entire point.

### Closing

Main used to detach the overlay view the instant the mode cleared, leaving nothing to animate. It now sends the close first, holds the view 200ms, then detaches. Only the pixels linger — focus and island state hand over immediately, and the panel drops `pointer-events` as it starts leaving so the page is clickable straight away.

Two races handled and verified: reopening mid-retraction cancels the pending detach (tested at 60ms), and the timer re-checks `overlayMode` so it can never remove a view that has legitimately come back.

## 3. M2 and M3 deferred

1.1.0 is M1 plus the island work. The two architecture milestones are unstarted and would hold it hostage. Nothing about their specs is retracted.

Recorded because M1 was scoped as a foundation *for M2 to build on*, and now ships in a release containing no M2 — inert by design, but the second runtime arrives later than the plan assumed.

## Bugs found on the way

- **`onOverlayHide` dropped its payload entirely.** The preload listener took no arguments, so nothing sent with an overlay-hide ever reached the renderer. Predates this work.
- **`openInternalPage` re-queried the tab map after calling `setActiveTab`**, unguarded — safe only because that call happens not to mutate `tabs`. Same unstated assumption that caused #94.

## Verification

`test:unit` **408/408** (8 new) · `substrate:check` **4/4** · `test:acceptance:desktop` **64/64, 425/425**

Measured in the running app rather than reasoned about: proximity reaching the renderer from a move over the *page*, the morph's box and corner sampled through the movement, the retraction's size, opacity and click-through, and the reopen race.

## Not included

Press feedback, tab switching, the shield popover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
