### PR TITLE
Release Blanc 1.1.0

### DIFF
--- a/docs/press/release-notes/v1.1.0.md
+++ b/docs/press/release-notes/v1.1.0.md
@@ -1,0 +1,23 @@
+# Blanc 1.1.0
+
+## Added
+
+- The island now senses your cursor. Move toward it and it leans your way, rises slightly, and grows — reaching full strength as you arrive and easing back as you leave. It follows how close you are rather than switching on at a threshold, so there's no edge you can feel, and it stays completely still while another app has focus or the panel is already open.
+- Opening the command bar is now a movement rather than a cut. The panel grows out of the resting island — starting at its exact size and shape, corners rounding out as it expands — and shrinks back into it when you dismiss. The page underneath stays clickable the moment you press Escape; only the picture takes a moment to leave.
+- If you have "reduce motion" turned on in your system settings, both of these are off entirely rather than shortened.
+
+## Changed
+
+- The island has been rebuilt against the Blanc design system. The resting pill drops the group name it was repeating — group identity already reads from the dots and the ⌘L panel — and gains a close button in its action cluster. The address field is a capsule, tab rows drop their domain column so the title has room, and the panel's dismiss control is now a downward chevron that points the way the panel travels.
+- Ad and tracker blocking is now called Blanc Blocker throughout, and its icon is a shield cut by the diagonal from Blanc's own mark. The count sits on the shield's shoulder instead of floating beside it.
+- The Blanc mark is heavier across every icon — the Dock, the taskbar, and the favicon on Blanc's own pages. The previous drawing was too fine to survive being scaled down, and broke up at small sizes.
+- Every keyboard shortcut in the interface renders in the system font. JetBrains Mono draws ⌘, ⇧, ⌥ and ⎋ malformed, which was most visible on the start page.
+
+## Fixed
+
+- Fixed a crash that could quit Blanc when a tab was closed a moment before the application menu rebuilt itself. The rebuild is deliberately delayed to batch up rapid changes, and it could still be handed a tab that had just gone.
+- The island's shadow no longer gets sliced off where the chrome meets the page. The refreshed shadow was deeper than the band had room for, leaving a faint straight line under the island. The find bar had the same problem against its own edge.
+
+## Other platforms
+
+All three platforms are built from the same `v1.1.0` source tag and published with one SHA-256 manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.0.10",
+      "version": "1.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@1password/sdk": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -4,7 +4,7 @@ import BrandMark from '../components/BrandMark.astro';
 import PressIslandDemo from '../components/PressIslandDemo.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 
-const VERSION = '1.0.10';
+const VERSION = '1.1.0';
 const TAG = `v${VERSION}`;
 const RELEASE_BASE = 'https://github.com/bnfy/blanc/releases';
 const RELEASE_URL = `${RELEASE_BASE}/tag/${TAG}`;

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.0.10');
+  assert.equal(packageVersion, '1.1.0');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
Release PR for **Blanc 1.1.0**, per the `releasing-blanc` runbook step 1 — one commit carrying the version bump, the checked-in release notes, and both version pins the press verification gate enforces.

| | |
|---|---|
| `package.json` + lock | 1.0.10 → **1.1.0** |
| `docs/press/release-notes/v1.1.0.md` | new; shipped verbatim as the GitHub release body |
| `site/src/pages/press.astro` | `const VERSION = '1.1.0'` |
| `test/unit/press-kit.test.js` | `assert.equal(packageVersion, '1.1.0')` |

## What 1.1.0 contains

- **M1 — window-runtime foundation.** Shipped inert in 1.0.10 for real-world soak; this is the release it was scoped for.
- **The island refresh** — the ten design-system checklist items (#92) and the four revisions that followed review (#93).
- **Island motion** (#95) — the resting pill reacting to the cursor, and the panel growing out of it and retracting back.
- **The heavier brand mark** (#96) — every icon, the site, and the design system.
- **Two crash fixes** — the settings-fanout reload (#88, already in 1.0.10) and the menu rebuild (#94).

**M2 and M3 are deferred** to a release after this one; recorded in the 1.1 roadmap.

## Electron stays at 43.3.0

It tracks Chromium stable and can't be swapped out of a running app, so bumping it is its own change with its own soak — not something to fold into a release commit.

## Pre-flight

The three failure modes the runbook names as first-attempt killers were checked before this branch existed:

- **press-kit pin** — both pins bumped here, in the release commit itself
- **npm audit** (`--omit=dev --audit-level=high`) — 0 vulnerabilities
- **site deps** — present, and the site builds

`test:unit` **408/408** · `substrate:check` **4/4**

The full `release:verify:press` gate runs inside `scripts/release.sh` after this merges.

## After this merges

Run from a checkout whose HEAD is exactly `origin/main`:

```
BLANC_RELEASE_MODE=stable BLANC_RELEASE_PLATFORMS=mac,windows,linux BLANC_MAC_ARCHES=arm64 npm run release
```

Then record the changelog and deploy the site, each as their own step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
