### PR TITLE
Give a finished download a completion and a resting state

### DIFF
--- a/src/main/downloads.js
+++ b/src/main/downloads.js
@@ -15,6 +15,9 @@ const active = new Map();
 /** A download finished as `completed` and hasn't been looked at yet — drives
  * the pill's contextual downloads button. Cleared by acknowledgeDownloads(). */
 let hasRecent = false;
+// In-memory only, like hasRecent: a fresh launch must not replay the pulse for
+// a download that finished in a previous session.
+let lastCompletedAt = null;
 
 /** @type {(() => void) | null} notify the chrome UI that something changed */
 let onChanged = null;
@@ -68,7 +71,14 @@ function setupDownloads(session, notifyChanged) {
         d.items.unshift(record);
         if (d.items.length > MAX_PERSISTED) d.items.length = MAX_PERSISTED;
       });
-      if (state === 'completed') hasRecent = true;
+      if (state === 'completed') {
+        hasRecent = true;
+        // The pill's completion pulse keys off this changing, not off `active`
+        // reaching 0: cancelling a download after an earlier one finished also
+        // empties `active` while hasRecent is still true, and that must not
+        // read as "your download landed".
+        lastCompletedAt = record.finishedAt;
+      }
       broadcast();
     });
 
@@ -118,7 +128,7 @@ function downloadsActivity() {
     receivedBytes += record.receivedBytes;
     totalBytes += record.totalBytes;
   }
-  return { active: active.size, hasRecent, receivedBytes, totalBytes };
+  return { active: active.size, hasRecent, receivedBytes, totalBytes, lastCompletedAt };
 }
 
 module.exports = {

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -156,13 +156,68 @@
   under.append(underGlyph);
   downloadsBtn.append(span('dl-glass'), vessel, under);
 
+  // The download-complete sequence, per the design handoff's PORT-CHECKLIST:
+  // the waves still at a full vessel, a check pops out of a solid accent disc
+  // for ~3s, and then the vessel stays *held full* until the downloads page is
+  // opened — it does not fall back to the idle glyph. Without this the level,
+  // being derived from in-flight bytes, dropped to zero the instant `active`
+  // emptied, so finishing a download drained the vessel.
+  const DL_CHECK_MS = 3000;
+  let lastCompletionSeen = null;
+  let checkTimer = null;
+
+  // A check knocked out of the disc: the disc paints --accent and sets its own
+  // color to --surface-raised, so the stroke reads as a hole in it.
+  const doneDisc = span('dl-done-disc');
+  const checkGlyph = svgEl('svg', { viewBox: '0 0 16 16', 'aria-hidden': 'true' });
+  checkGlyph.append(svgEl('path', { d: 'M3.5 8.5l3 3 6-6.5' }));
+  doneDisc.append(checkGlyph);
+  downloadsBtn.append(doneDisc);
+
   function renderDownloads() {
-    const { active, hasRecent, receivedBytes, totalBytes } = downloadState;
+    const { active, hasRecent, receivedBytes, totalBytes, lastCompletedAt } = downloadState;
     downloadsBtn.hidden = !(active > 0 || hasRecent);
     downloadsBtn.classList.toggle('active', active > 0);
-    const pct = active > 0 && totalBytes > 0 ? Math.min(1, receivedBytes / totalBytes) : 0;
+
+    // Keyed off the timestamp changing rather than `active` falling to 0, so a
+    // cancelled download never borrows the finished one's celebration. No
+    // first-observation guard is needed or wanted: main holds lastCompletedAt
+    // in memory and starts every launch at null, so any value at all belongs to
+    // this session — suppressing the first would cost every session its first
+    // completion, which is the common case of exactly one.
+    if (lastCompletedAt && lastCompletedAt !== lastCompletionSeen) {
+      lastCompletionSeen = lastCompletedAt;
+      // A download still running behind this one keeps the vessel live; the
+      // check belongs to the moment the last of them lands.
+      if (active === 0) {
+        clearTimeout(checkTimer);
+        downloadsBtn.classList.add('dl-check');
+        checkTimer = setTimeout(() => {
+          checkTimer = null;
+          downloadsBtn.classList.remove('dl-check');
+        }, DL_CHECK_MS);
+      }
+    }
+
+    // Held full is the resting state for an unacknowledged completed download,
+    // so it keys off hasRecent rather than a timer — main clears that when the
+    // downloads page opens, which is exactly step 4 of the sequence.
+    const heldFull = hasRecent && active === 0;
+    downloadsBtn.classList.toggle('dl-done', heldFull);
+    if (!heldFull && checkTimer) {
+      clearTimeout(checkTimer);
+      checkTimer = null;
+      downloadsBtn.classList.remove('dl-check');
+    }
+
+    const pct = heldFull
+      ? 1
+      : active > 0 && totalBytes > 0 ? Math.min(1, receivedBytes / totalBytes) : 0;
     downloadsBtn.style.setProperty('--dl-progress', String(pct));
-    downloadsBtn.title = active > 0 ? `Downloading — ${active} active` : 'Downloads';
+
+    downloadsBtn.title = active > 0
+      ? `Downloading — ${active} active`
+      : heldFull ? 'Download complete — open Downloads' : 'Downloads';
   }
   renderDownloads();
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -787,7 +787,42 @@ body.mac .vertical-tabs-toolbar {
    equivalent rule to fight. */
 .pill-download .dl-wave { position: absolute; left: -100%; width: 300%; height: 2.4px; bottom: calc(100% - 1.2px); fill: var(--accent); stroke: none; animation: dl-drift 2.4s linear infinite; }
 .pill-download .dl-wave.w2 { left: -88%; opacity: 0.5; animation-duration: 3.9s; animation-direction: reverse; }
-.pill-download.active > svg, .pill-download .dl-under svg { width: 9.5px; height: 9.5px; }
+.pill-download.active > svg,
+.pill-download.dl-done > svg,
+.pill-download .dl-under svg { width: 9.5px; height: 9.5px; }
+/* Download-complete sequence (design handoff PORT-CHECKLIST, added 2026-08-09):
+   the waves still over ~400ms at a full vessel, a check pops out of a solid
+   accent disc for ~3s, and the vessel then stays held full until the downloads
+   page is opened. .dl-done repeats .active's colour and glyph size because the
+   download is no longer active by then — without it the glyph snaps back to
+   full size against a still-full vessel. */
+.pill-download.dl-done { color: var(--accent); }
+.pill-download.dl-done .dl-wave,
+.pill-download.dl-done .dl-wave.w2 {
+  animation-play-state: paused;
+  opacity: 0;
+  transition: opacity 400ms ease;
+}
+.dl-done-disc {
+  position: absolute; inset: 4.5px; border-radius: 50%;
+  background: var(--accent);
+  display: none; align-items: center; justify-content: center;
+  color: var(--surface-raised);
+  pointer-events: none;
+  animation: dl-pop 240ms cubic-bezier(0.2, 0.9, 0.3, 1.4);
+}
+.pill-download.dl-check .dl-done-disc { display: flex; }
+/* Scoped and explicit for the same reason the waves are: `.pill-btn svg` sizes
+   and strokes every glyph in the cluster and would otherwise win. */
+.pill-download .dl-done-disc svg {
+  width: 9px; height: 9px;
+  fill: none; stroke: currentColor; stroke-width: 1.8;
+  stroke-linecap: round; stroke-linejoin: round;
+}
+@keyframes dl-pop {
+  0% { transform: scale(0.6); opacity: 0; }
+  100% { transform: scale(1); opacity: 1; }
+}
 .dl-under { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: var(--surface-raised); clip-path: inset(calc(100% - var(--dl-progress, 0) * 100% + 1.2px) 0 0 0); transition: clip-path 300ms cubic-bezier(0.4, 0, 0.2, 1); pointer-events: none; }
 @keyframes dl-drift { to { transform: translateX(-16.6667%); } }
 
@@ -1898,6 +1933,12 @@ body:not(.mac) #permissionBar { right: 118px; } /* clear the window controls */
   .island-row.tab-row .row-tag,
   .island-row.tab-row .row-remote-pin { transition: none; }
   .pill-download .dl-wave { animation: none; }
+  /* The completion state still reads without its pulse: the vessel is full and
+     the glyph inverted for the same beat, so the information survives while the
+     decoration goes. */
+  /* The completion still reads without the pop: the check, the full vessel and
+     the inverted glyph all remain. */
+  .dl-done-disc { animation: none; }
   /* The proximity reaction is entirely decorative — off, not just instant. */
   #islandPill { transform: none; transition: none; box-shadow: var(--shadow-pill); }
   #strip { transition: none; }


### PR DESCRIPTION
Implements the **download-complete sequence** from the design handoff's `PORT-CHECKLIST.md` (added 2026-08-09) — the last `OPEN` item on that checklist. The checklist has been updated to PORTED in the Design System.

## The bug underneath

The vessel's level is derived from **in-flight** bytes. The moment the last download finished and `active` emptied, the level dropped to zero — so completing a download visibly *drained* the glass, the opposite of what the metaphor promises at the one moment it should pay off. A second later the button was indistinguishable from nothing having happened.

## The sequence

1. Waves still (~400ms) at a full vessel
2. **Check phase (~3s)** — a check knocked out of a solid accent disc: `.dl-done-disc` inset 4.5px, bg `--accent`, colour `--surface-raised`, `dl-pop` 240ms `cubic-bezier(0.2, 0.9, 0.3, 1.4)`; check `M3.5 8.5l3 3 6-6.5` at 9×9, stroke 1.8, round caps
3. **At rest** — vessel **held full** (`--dl-progress: 1`, `.dl-under` inverted glyph, waves stilled) until Downloads is opened
4. Opening Downloads clears it via the existing `hasRecent`, and the button returns to its idle glyph
5. Tooltip through 2–3: "Download complete — open Downloads"

`prefers-reduced-motion` drops only the pop — the check, the full vessel and the inverted glyph all still read.

## The one design decision worth reviewing

**The trigger is a timestamp, not an empty active set.** `active` also reaches 0 when a download is *cancelled*, and `hasRecent` may still be true from an earlier completion — so keying off that combination makes a cancel wear the celebration. [downloads.js](src/main/downloads.js) gained `lastCompletedAt`, set only on `state === 'completed'`, and the sequence fires when it changes. It's in-memory like `hasRecent`, so a relaunch can't replay a previous session's completion.

Selectors stay `.pill-download` / `.dl-*` rather than the DS's `.bw-*`, which the checklist explicitly notes.

## Verification

Driven as real downloads through the real chrome, in two configurations — including **no `Content-Length`**, where `totalBytes` stays 0 so the vessel never fills during transfer and completion is the only thing that ever puts liquid in it:

| Spec step | Observed |
|---|---|
| Check phase | `dl-check`, disc `display:flex`, `dl-pop`, path `M3.5 8.5l3 3 6-6.5` |
| Waves still | opacity 0.83 → 0 |
| Held full at rest | 3.6s later: `dl-done`, `--dl-progress: 1`, fluid 13.0px |
| Tooltip | "Download complete — open Downloads" |

468 unit tests pass; `substrate:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)