### PR TITLE
Render synced favicons sharply on Retina displays

### DIFF
--- a/docs/superpowers/specs/2026-07-21-tab-sync-design.md
+++ b/docs/superpowers/specs/2026-07-21-tab-sync-design.md
@@ -68,13 +68,15 @@ seconds, and stay under 256 KB. Redirects are disabled, and localhost,
 literal targets are rejected before fetch so capture cannot become a new LAN
 probe. A PNG source is decoded natively after a cheap header/dimension guard;
 other formats (ICO — usually BMP-framed — SVG, GIF, …), which `nativeImage`
-cannot decode, are drawn into a 16×16 canvas inside a locked-down, detached
+cannot decode, are drawn into a 32×32 canvas inside a locked-down, detached
 `WebContentsView` (`icon-raster.js`) — an SVG loaded via `<img>` runs no scripts
 and fetches no external resources, so untrusted vectors stay inert, and the
 renderer only ever sees inert `data:` bytes, never a live URL. Either path
-rasterizes to a 16×16 PNG; only a bounded `data:image/png;base64,...` value
-with a valid PNG signature/IHDR and 16×16 dimensions can enter the sidecar or
-renderer projection. Receiving
+rasterizes to a 32×32 PNG so 14–16 CSS-pixel UI slots stay sharp on 2×
+displays. Only a bounded `data:image/png;base64,...` value with a valid PNG
+signature/IHDR and supported square dimensions can enter the sidecar or
+renderer projection; receivers also accept the original 16×16 records during
+mixed-version rollout. Receiving
 chrome never contacts a remote tab's site merely to draw the list. The
 sidecar has its own 256 KB plaintext budget and discards cosmetic icon records
 before its limit; it can never evict a tab or device from the primary session

--- a/src/main/icon-raster.js
+++ b/src/main/icon-raster.js
@@ -1,5 +1,6 @@
-// Rasterize arbitrary favicon bytes into a fixed 16x16 PNG using Chromium's own
-// image decoders. `nativeImage.createFromBuffer` only decodes PNG/JPEG, so ICO
+// Rasterize arbitrary favicon bytes into a fixed Retina-sized PNG using
+// Chromium's own image decoders. `nativeImage.createFromBuffer` only decodes
+// PNG/JPEG, so ICO
 // (BMP-framed), SVG, GIF, WEBP, and friends — the majority of real favicons —
 // cannot be rendered that way and never synced. This draws the bytes into a
 // canvas inside a locked-down, detached WebContentsView instead.
@@ -8,12 +9,12 @@
 // the SSRF/cookie/redirect guards in tabicons.js), never a live URL — so this
 // view makes no network requests of its own. An SVG loaded through `<img>`
 // additionally runs no scripts and fetches no external resources, keeping
-// untrusted vector sources inert. The output is re-validated as a bounded 16x16
-// PNG by the caller (`validIconData`) before it can enter the sidecar.
+// untrusted vector sources inert. The output is re-validated as a bounded
+// square PNG by the caller (`validIconData`) before it can enter the sidecar.
 
 const { WebContentsView } = require('electron');
+const { ICON_SIZE } = require('./tabicons-model');
 
-const ICON_SIZE = 16;
 const RASTER_TIMEOUT_MS = 3000;
 
 let view = null;
@@ -76,7 +77,7 @@ function drawInPage(dataUrl, size, timeoutMs) {
   });
 }
 
-/** Draw a bounded image `data:` URL down to a 16x16 PNG data URL, or null. */
+/** Draw a bounded image `data:` URL to the synced PNG size, or null. */
 async function rasterize(dataUrl, signal) {
   if (typeof dataUrl !== 'string' || signal?.aborted) return null;
   try {

--- a/src/main/tabicons-model.js
+++ b/src/main/tabicons-model.js
@@ -8,8 +8,15 @@ const HEARTBEAT_MS = 24 * 60 * 60 * 1000;
 const BUDGET_BYTES = 256 * 1024;
 const MAX_ICONS = 500;
 const MAX_URL = 2048;
-const MAX_ICON_DATA = 4096;
-const ICON_SIZE = 16;
+// Publish enough source pixels for the largest 16 CSS-pixel favicon slot on a
+// 2x display. Keep accepting the original 16x16 records so mixed-version
+// devices and already-synced caches continue to render during rollout.
+const LEGACY_ICON_SIZE = 16;
+const ICON_SIZE = 32;
+const ICON_SIZES = new Set([LEGACY_ICON_SIZE, ICON_SIZE]);
+// A high-entropy 32x32 RGBA PNG can exceed the old 4 KiB data-URL ceiling.
+// The independent 256 KiB account budget below still bounds aggregate data.
+const MAX_ICON_DATA = 8192;
 const MAX_SOURCE_BYTES = 256 * 1024;
 const MAX_SOURCE_DIMENSION = 1024;
 const MAX_SOURCE_PIXELS = 512 * 512;
@@ -41,8 +48,8 @@ function validIconData(data) {
     bytes.length < 24 ||
     !bytes.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE) ||
     bytes.subarray(12, 16).toString('ascii') !== 'IHDR' ||
-    bytes.readUInt32BE(16) !== ICON_SIZE ||
-    bytes.readUInt32BE(20) !== ICON_SIZE
+    bytes.readUInt32BE(16) !== bytes.readUInt32BE(20) ||
+    !ICON_SIZES.has(bytes.readUInt32BE(16))
   ) return null;
   return data;
 }
@@ -95,7 +102,8 @@ function sourcePngFromDataUrl(source) {
 // take the renderer-canvas path (icon-raster.js) instead of the native PNG
 // guard above. The model's job for these is only to confirm an image MIME type
 // and bound the payload; Chromium's own <img> decoder does the parsing, and the
-// canvas output is re-validated as a 16x16 PNG before it can be stored.
+// canvas output is re-validated as a supported square PNG before it can be
+// stored (32x32 for new captures, plus legacy 16x16 records on receive).
 const IMAGE_MEDIA_TYPE = /^image\/[a-z0-9][a-z0-9.+-]*$/;
 // A base64 image data URL can't exceed this many chars for MAX_SOURCE_BYTES of
 // bytes; percent-encoded inline SVG favicons stay well under it too.
@@ -360,6 +368,7 @@ module.exports = {
   MAX_ICONS,
   MAX_URL,
   MAX_ICON_DATA,
+  LEGACY_ICON_SIZE,
   ICON_SIZE,
   MAX_SOURCE_BYTES,
   MAX_SOURCE_DIMENSION,

--- a/test/unit/tabicons-model.test.js
+++ b/test/unit/tabicons-model.test.js
@@ -7,16 +7,26 @@ const NOW = 1_800_000_000_000;
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;
 const PNG_A = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGElEQVR42mNgGAWjYBSMglEwCkbBqAABBgAE/wABeV0FzgAAAABJRU5ErkJggg==';
+const pngAtSize = (source, size) => {
+  const bytes = Buffer.from(source.split(',')[1], 'base64');
+  bytes.writeUInt32BE(size, 16);
+  bytes.writeUInt32BE(size, 20);
+  return `${m.PNG_DATA_PREFIX}${bytes.toString('base64')}`;
+};
+const PNG_2X = pngAtSize(PNG_A, m.ICON_SIZE);
 const pngBBytes = Buffer.from(PNG_A.split(',')[1], 'base64');
 pngBBytes[pngBBytes.length - 1] ^= 1;
 const PNG_B = `data:image/png;base64,${pngBBytes.toString('base64')}`;
 const icon = (over = {}) => ({ url: 'https://a.example/', data: PNG_A, ...over });
 const entry = (over = {}) => ({ updatedAt: NOW - HOUR, icons: [icon()], ...over });
 
-test('validIconData accepts only bounded, structurally identified PNG data URLs', () => {
+test('validIconData accepts Retina and legacy PNG records but rejects other dimensions', () => {
   const fakePng = `data:image/png;base64,${Buffer.from('<svg/>').toString('base64')}`;
   const oversized = `${PNG_A}${'A'.repeat(m.MAX_ICON_DATA)}`;
-  assert.equal(m.validIconData(PNG_A), PNG_A);
+  assert.equal(m.validIconData(PNG_2X), PNG_2X, 'new captures retain 2x backing pixels');
+  assert.equal(m.validIconData(PNG_A), PNG_A, 'deployed 16x16 records remain compatible');
+  assert.equal(m.validIconData(pngAtSize(PNG_A, 24)), null);
+  assert.equal(m.validIconData(pngAtSize(PNG_A, 64)), null);
   assert.equal(m.validIconData('https://a.example/icon.png'), null);
   assert.equal(m.validIconData('data:image/svg+xml,<svg/>'), null);
   assert.equal(m.validIconData(fakePng), null, 'MIME label alone cannot smuggle another format');

--- a/test/unit/tabicons.test.js
+++ b/test/unit/tabicons.test.js
@@ -4,15 +4,23 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const PNG_DATA = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGElEQVR42mNgGAWjYBSMglEwCkbBqAABBgAE/wABeV0FzgAAAABJRU5ErkJggg==';
+const LEGACY_PNG_DATA = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGElEQVR42mNgGAWjYBSMglEwCkbBqAABBgAE/wABeV0FzgAAAABJRU5ErkJggg==';
+const pngBytes = Buffer.from(LEGACY_PNG_DATA.split(',')[1], 'base64');
+pngBytes.writeUInt32BE(32, 16);
+pngBytes.writeUInt32BE(32, 20);
+const PNG_DATA = `data:image/png;base64,${pngBytes.toString('base64')}`;
 const PNG_BYTES = Buffer.from(PNG_DATA.split(',')[1], 'base64');
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-tabicons-'));
 const requests = [];
 let decodeCount = 0;
+let lastResizeOptions = null;
 
 const image = {
   isEmpty: () => false,
-  resize: () => image,
+  resize: (options) => {
+    lastResizeOptions = options;
+    return image;
+  },
   toPNG: () => PNG_BYTES,
 };
 const electronId = require.resolve('electron');
@@ -69,6 +77,7 @@ test('capture rasterizes on the source device without cookies or a referrer', as
   assert.equal(requests[0].options.credentials, 'omit');
   assert.equal(requests[0].options.referrerPolicy, 'no-referrer');
   assert.equal(requests[0].options.redirect, 'error');
+  assert.deepEqual(lastResizeOptions, { width: 32, height: 32, quality: 'best' });
 
   const payload = tabicons.exportForSync(ctx);
   assert.deepEqual(payload.devices['device-a'].icons, [{
@@ -171,7 +180,7 @@ test('non-PNG favicons rasterize through the renderer seam and store the result'
   }
 });
 
-test('a rasterizer result that is not a bounded 16x16 PNG is discarded', async () => {
+test('a rasterizer result that is not a bounded supported-size PNG is discarded', async () => {
   tabicons.setRasterizer(async () => 'data:image/svg+xml,<svg/>'); // not a PNG data URL
   try {
     const tab = {


### PR DESCRIPTION
## What changed

- Publish synced tab favicons as 32×32 PNGs for 2× display backing pixels.
- Continue accepting deployed 16×16 records during mixed-version rollout.
- Raise the per-icon data-URL ceiling for worst-case 32×32 PNGs while preserving the existing 256 KiB aggregate sidecar budget.
- Share the output-size constant between native and renderer rasterization paths.

## Why

Synced favicons were always downsampled to 16×16 before upload. Blanc renders them in 14–16 CSS-pixel slots, so macOS Retina displays had to enlarge those records across roughly twice as many physical pixels, making remote-tab icons visibly softer than local favicons.

Existing cached 16×16 icons remain valid and are replaced opportunistically as source devices recapture and sync them.

## Validation

- `node --test test/unit/*.test.js`
- 482 tests passed
- `git diff --check`