### PR TITLE
Drive slash commands through the palette and stabilize desktop acceptance

### DIFF
--- a/src/main/test-call-bridge.js
+++ b/src/main/test-call-bridge.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * Install the acceptance-only, idempotent call surface used across Playwright's
+ * inspector boundary. Chromium can report `Promise was collected` after the
+ * method already ran but before its reply arrived; retaining the promise here
+ * and retrying the SAME id returns that original result without repeating a
+ * mutation.
+ */
+function installTestCallBridge(target, methods, { maxEntries = 4096 } = {}) {
+  const calls = new Map();
+
+  target.__blancCall = (id, method, args) => {
+    if (calls.has(id)) return calls.get(id).promise;
+    if (!Number.isSafeInteger(id) || id < 1) return Promise.reject(new Error('invalid test call id'));
+    if (typeof method !== 'string' || typeof methods[method] !== 'function') {
+      return Promise.reject(new Error(`unknown test method: ${String(method)}`));
+    }
+    if (!Array.isArray(args)) return Promise.reject(new Error('test call args must be an array'));
+
+    while (calls.size >= maxEntries) calls.delete(calls.keys().next().value);
+    const promise = Promise.resolve().then(() => methods[method](...args));
+    calls.set(id, { method, promise });
+    return promise;
+  };
+
+  return target.__blancCall;
+}
+
+module.exports = { installTestCallBridge };

--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -15,6 +15,7 @@ const { app, Menu, clipboard } = require('electron');
 const { buildAddressMenu } = require('./address-menu-model');
 const { blockableHostname } = require('./adblock-exceptions');
 const { syncSnapshot } = require('./session-snapshot');
+const { installTestCallBridge } = require('./test-call-bridge');
 const {
   runAddressMenuItem,
   readAddressFieldText,
@@ -982,6 +983,7 @@ function install(refs) {
       if (typeof fn === 'function') globalThis.__blanc[key] = bindRoot(fn);
     }
   }
+  installTestCallBridge(globalThis, globalThis.__blanc);
 }
 
 module.exports = { install };

--- a/test/desktop/README.md
+++ b/test/desktop/README.md
@@ -12,10 +12,13 @@ bindings later; only the step definitions here are desktop-specific.
   (`_electron.launch`) starts the packaged app once per run.
 - **Bridge:** a tiny, env-guarded main-process surface (`src/main/test-hook.js`,
   installed only when `BLANC_TEST=1`) exposes real state readers and actions on
-  `globalThis.__blanc`. Steps call into it via `electronApp.evaluate()`, which
-  runs in the Electron **main process** — so the scenarios drive the actual
+  `globalThis.__blanc`. Steps call it through the idempotent
+  `globalThis.__blancCall` wrapper via `electronApp.evaluate()`, which runs in
+  the Electron **main process** — so the scenarios drive the actual
   `tabs`/`groups` state and the real settings/history/bookmarks stores, not a
-  reimplementation.
+  reimplementation. Each call carries an id: if Chromium's inspector loses a
+  completed reply, the harness can request that same result without replaying
+  a mutating action.
 - **Offline & isolated:** `BLANC_TEST` also skips the network ad-engine build so
   the app launches with no internet, and each run uses a throwaway
   `--user-data-dir` so no prior session/history/settings leaks in. Tab URLs load
@@ -29,6 +32,7 @@ test/desktop/
   cucumber.mjs            profiles (runnable / dry / default)
   support/
     world.js             the `this` in steps: call()/state()/waitForState()/fixtureUrl()
+    test-hook-call.js    call ids + one safe retry for a lost inspector reply
     hooks.js             launch app + fixtures (BeforeAll), reset (Before), teardown
     fixtures-server.js   local pages so tab URLs load offline
     context.js           state shared across hooks/world/steps

--- a/test/desktop/dns-smoke.mjs
+++ b/test/desktop/dns-smoke.mjs
@@ -8,6 +8,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
+import testHookCall from './support/test-hook-call.js';
+
+const { callTestHook } = testHookCall;
 
 const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-dns-smoke-'));
 const app = await _electron.launch({
@@ -32,16 +35,16 @@ const clearDnsCache = () => app.evaluate(async ({ session }) => {
 try {
   await app.firstWindow(); // startup didn't crash (a ready-handler throw would prevent this)
 
-  assert.equal(await app.evaluate(() => globalThis.__blanc.secureDns()), 'auto', 'default secureDns should be auto');
-  assert.equal(await app.evaluate(() => globalThis.__blanc.webrtcPolicy()), 'standard', 'default webrtcPolicy should be standard');
+  assert.equal(await callTestHook(app, 'secureDns'), 'auto', 'default secureDns should be auto');
+  assert.equal(await callTestHook(app, 'webrtcPolicy'), 'standard', 'default webrtcPolicy should be standard');
 
   // Secure mode WORKS here without enableBuiltInResolver (the Linux question).
-  await app.evaluate(() => globalThis.__blanc.setSecureDns('cloudflare'));
+  await callTestHook(app, 'setSecureDns', ['cloudflare']);
   await clearDnsCache();
   assert.ok(await canResolve('example.com'), 'Cloudflare secure DoH should resolve example.com');
 
   // Strict custom FAILS CLOSED — unreachable resolver, distinct host to dodge any cache.
-  await app.evaluate(() => globalThis.__blanc.setSecureDns('custom', 'https://127.0.0.1:9/dns-query'));
+  await callTestHook(app, 'setSecureDns', ['custom', 'https://127.0.0.1:9/dns-query']);
   await clearDnsCache();
   assert.ok(!(await canResolve('cloudflare.com')), 'unreachable strict custom DoH must fail closed');
 

--- a/test/desktop/steps/extended.steps.js
+++ b/test/desktop/steps/extended.steps.js
@@ -145,7 +145,14 @@ Then('a new ungrouped tab opens on the new-tab page', async function () {
 // utility pages present as the sheet, never as tabs (utility-sheet design).
 
 Then('the find bar is shown', async function () {
-  assert.strictEqual(await this.call('overlayMode'), 'find');
+  // Typing "/find" and pressing Enter reaches main over IPC, so the mode change
+  // lands after the step returns. The old binding called the hook directly and
+  // was synchronous by accident; polling is what makes this honest either way.
+  await waitForValue(
+    () => this.call('overlayMode'),
+    (mode) => mode === 'find',
+    'overlay to enter find mode'
+  );
 });
 
 // ---------- F17-1: supporter unlock ----------

--- a/test/desktop/steps/runnable.steps.js
+++ b/test/desktop/steps/runnable.steps.js
@@ -2,6 +2,7 @@ const assert = require('node:assert');
 const { Given, When, Then } = require('@cucumber/cucumber');
 const ctx = require('./../support/context');
 const { waitForValue, openOverlaySurface } = require('./../support/poll');
+const { runSlashCommand } = require('./../support/overlay');
 
 // Step definitions for the desktop-runnable scenario set (see the `runnable`
 // profile in cucumber.mjs). Every step is intent-level and drives the app
@@ -68,15 +69,15 @@ When('I open a new tab', async function () { ctx.lastNewTabId = await this.call(
 When('I close the last tab in {string}', async function (name) { await this.call('closeTabsInGroupName', name); });
 
 When('I run the slash command {string}', async function (cmd) {
-  const [head, ...rest] = String(cmd).trim().split(/\s+/);
-  if (head === '/group') return this.call('groupActiveByName', rest.join(' '));
-  if (head === '/clear') return this.call('clearHistory');
-  if (head === '/block-ads') return this.call('toggleAdblock');
-  if (head === '/allow-ads') return this.call('allowAdsOnActive');
-  if (head === '/new') { ctx.lastNewTabId = await this.call('newTab'); return; }
-  if (head === '/downloads') return this.call('openDownloads');
-  if (head === '/find') return this.call('openFind');
-  return 'pending'; // other commands not in the runnable set yet
+  const text = String(cmd).trim();
+  const before = await this.call('state');
+  await runSlashCommand(this, text);
+  if (text.split(/\s+/)[0] === '/new') {
+    const known = new Set(before.tabs.map((tab) => tab.id));
+    await this.waitForState((s) => s.tabs.some((tab) => !known.has(tab.id)));
+    const after = await this.call('state');
+    ctx.lastNewTabId = after.tabs.map((tab) => tab.id).find((id) => !known.has(id)) ?? ctx.lastNewTabId;
+  }
 });
 
 When('I add the active page to favorites', async function () {

--- a/test/desktop/steps/vertical-tabs.steps.js
+++ b/test/desktop/steps/vertical-tabs.steps.js
@@ -588,11 +588,16 @@ Then(
 
 Then('the resting Island is centered over the website pane', async function () {
   const page = await chromePage();
-  const box = await page.locator('#islandPill').boundingBox();
-  assert.ok(box, 'resting Island should be visible');
   const expectedCenter = 248 + (this.verticalWindow.width - 248) / 2;
-  assert.ok(Math.abs(box.x + box.width / 2 - expectedCenter) <= 1,
-    `Island center ${box.x + box.width / 2} should equal website-pane center ${expectedCenter}`);
+  const measurement = await waitForValue(
+    async () => {
+      const box = await page.locator('#islandPill').boundingBox();
+      return box ? { box, center: box.x + box.width / 2, expectedCenter } : null;
+    },
+    (value) => value && Math.abs(value.center - value.expectedCenter) <= 1,
+    'resting Island to settle at the website-pane center'
+  );
+  assert.ok(measurement.box, 'resting Island should be visible');
 });
 
 When('I open a utility page', async function () {
@@ -627,7 +632,7 @@ Then('the rail remains visible and unobscured', async function () {
 
 When('I open the Island panel', async function () {
   await this.call('openPanel');
-  await waitForValue(() => this.call('overlayMode'), (mode) => mode === 'panel', 'Island panel');
+  await waitForValue(() => this.call('overlayRendererMode'), (mode) => mode === 'panel', 'Island panel renderer');
 });
 
 Then(
@@ -638,18 +643,26 @@ Then(
 );
 
 Then('the expanded Island is centered over the website pane', async function () {
-  const overlay = await this.call('overlayBounds');
-  const panel = await this.call('overlayElementRect', '#islandPanel');
-  assert.ok(panel, 'expanded Island panel should render');
-  const globalCenter = overlay.x + panel.x + panel.width / 2;
   const expectedCenter = 248 + (this.verticalWindow.width - 248) / 2;
-  assert.ok(Math.abs(globalCenter - expectedCenter) <= 1,
-    `expanded Island center ${globalCenter} should equal ${expectedCenter}`);
+  await waitForValue(
+    async () => {
+      const overlay = await this.call('overlayBounds');
+      const panel = await this.call('overlayElementRect', '#islandPanel');
+      return panel ? {
+        overlay,
+        panel,
+        center: overlay.x + panel.x + panel.width / 2,
+        expectedCenter,
+      } : null;
+    },
+    (value) => value && Math.abs(value.center - value.expectedCenter) <= 1,
+    'expanded Island to settle at the website-pane center'
+  );
 });
 
 When('I replace the panel with the command palette', async function () {
   await this.call('openPalette');
-  await waitForValue(() => this.call('overlayMode'), (mode) => mode === 'palette', 'command palette');
+  await waitForValue(() => this.call('overlayRendererMode'), (mode) => mode === 'palette', 'command palette renderer');
 });
 
 Then(
@@ -660,12 +673,21 @@ Then(
 );
 
 Then('the expanded Island remains centered over the website pane', async function () {
-  const overlay = await this.call('overlayBounds');
-  const panel = await this.call('overlayElementRect', '#islandPanel');
-  assert.ok(panel, 'palette Island should render');
-  const center = overlay.x + panel.x + panel.width / 2;
-  const expected = 248 + (this.verticalWindow.width - 248) / 2;
-  assert.ok(Math.abs(center - expected) <= 1);
+  const expectedCenter = 248 + (this.verticalWindow.width - 248) / 2;
+  await waitForValue(
+    async () => {
+      const overlay = await this.call('overlayBounds');
+      const panel = await this.call('overlayElementRect', '#islandPanel');
+      return panel ? {
+        overlay,
+        panel,
+        center: overlay.x + panel.x + panel.width / 2,
+        expectedCenter,
+      } : null;
+    },
+    (value) => value && Math.abs(value.center - value.expectedCenter) <= 1,
+    'palette Island to settle at the website-pane center'
+  );
 });
 
 Then('the page pane starts at x {int} and is {int} pixels wide', async function (x, width) {

--- a/test/desktop/steps/vertical-tabs.steps.js
+++ b/test/desktop/steps/vertical-tabs.steps.js
@@ -401,16 +401,27 @@ When('I hover the truncated vertical tab title', async function () {
 Then('the truncated title scrolls toward its hidden end', async function () {
   const page = await chromePage();
   const id = this.verticalTitleIds.longId;
-  await page.waitForFunction((tabId) => {
-    const viewport = document.querySelector(
-      `.vertical-tab-row[data-tab-id="${tabId}"] .vertical-tab-title`
-    );
-    const text = viewport?.querySelector('.vertical-tab-title-text');
-    if (!viewport?.classList.contains('scrolling') || !text) return false;
-    const transform = getComputedStyle(text).transform;
-    if (!transform || transform === 'none') return false;
-    return new DOMMatrixReadOnly(transform).m41 < -0.5;
-  }, id);
+  await waitForValue(
+    () => page.locator(
+      `.vertical-tab-row[data-tab-id="${id}"] .vertical-tab-title`
+    ).evaluate((viewport) => {
+      const text = viewport.querySelector('.vertical-tab-title-text');
+      const transform = text ? getComputedStyle(text).transform : 'none';
+      return {
+        hovered: viewport.matches(':hover'),
+        scrolling: viewport.classList.contains('scrolling'),
+        reducedMotion: matchMedia('(prefers-reduced-motion: reduce)').matches,
+        viewportWidth: viewport.clientWidth,
+        contentWidth: text?.scrollWidth ?? 0,
+        offset: viewport.style.getPropertyValue('--vertical-tab-title-offset'),
+        duration: viewport.style.getPropertyValue('--vertical-tab-title-duration'),
+        transform,
+        x: transform === 'none' ? 0 : new DOMMatrixReadOnly(transform).m41,
+      };
+    }),
+    (value) => value.hovered && value.scrolling && value.x < -0.5,
+    'truncated title hover animation to move toward its hidden end'
+  );
 });
 
 When('I move the pointer away from the vertical tab title', async function () {

--- a/test/desktop/steps/vertical-tabs.steps.js
+++ b/test/desktop/steps/vertical-tabs.steps.js
@@ -194,8 +194,24 @@ async function dragRailTo(page, targetWidth) {
   const y = Math.min(box.y + 180, box.y + box.height / 2);
   await page.mouse.move(box.x + box.width / 2, y);
   await page.mouse.down();
-  await page.mouse.move(targetWidth, y, { steps: 12 });
-  await page.mouse.up();
+  try {
+    await waitForValue(
+      () => page.evaluate(() => document.documentElement.dataset.verticalTabsResizing === 'true'),
+      Boolean,
+      'vertical-tab resize pointer capture to start'
+    );
+    // One trusted captured move tests the product's pointer path without
+    // repeatedly moving the handle out from under Playwright's synthetic
+    // pointer as each preview frame resizes the rail.
+    await page.mouse.move(targetWidth, y);
+  } finally {
+    await page.mouse.up();
+  }
+  await waitForValue(
+    () => page.evaluate(() => document.documentElement.dataset.verticalTabsResizing !== 'true'),
+    Boolean,
+    'vertical-tab resize pointer capture to finish'
+  );
 }
 
 function assertBounds(actual, expected, label) {
@@ -600,15 +616,25 @@ Then(
 Then('the resting Island is centered over the website pane', async function () {
   const page = await chromePage();
   const expectedCenter = 248 + (this.verticalWindow.width - 248) / 2;
-  const measurement = await waitForValue(
-    async () => {
-      const box = await page.locator('#islandPill').boundingBox();
-      return box ? { box, center: box.x + box.width / 2, expectedCenter } : null;
-    },
-    (value) => value && Math.abs(value.center - value.expectedCenter) <= 1,
+  await waitForValue(
+    () => page.locator('#islandPill').evaluate((pill) => {
+      const rect = pill.getBoundingClientRect();
+      const transform = getComputedStyle(pill).transform;
+      const translateX = transform === 'none' ? 0 : new DOMMatrixReadOnly(transform).m41;
+      const visualCenter = rect.left + rect.width / 2;
+      return {
+        visualCenter,
+        translateX,
+        layoutCenter: visualCenter - translateX,
+        proximity: {
+          k: Number(pill.style.getPropertyValue('--island-k')) || 0,
+          lean: Number(pill.style.getPropertyValue('--island-lean')) || 0,
+        },
+      };
+    }),
+    (value) => Math.abs(value.layoutCenter - expectedCenter) <= 1,
     'resting Island to settle at the website-pane center'
   );
-  assert.ok(measurement.box, 'resting Island should be visible');
 });
 
 When('I open a utility page', async function () {

--- a/test/desktop/support/hooks.js
+++ b/test/desktop/support/hooks.js
@@ -6,6 +6,7 @@ const { _electron } = require('playwright');
 const { BeforeAll, AfterAll, Before, setDefaultTimeout } = require('@cucumber/cucumber');
 const fixtures = require('./fixtures-server');
 const ctx = require('./context');
+const { callTestHook } = require('./test-hook-call');
 const { browserDataRoot } = require('../../../src/main/browser-data-import');
 
 // Launching Electron + first evaluate is slow; give scenarios generous headroom.
@@ -48,7 +49,7 @@ async function launchApp() {
   await electronApp.evaluate(
     () => new Promise((resolve) => {
       const t = setInterval(() => {
-        if (globalThis.__blanc) { clearInterval(t); resolve(); }
+        if (globalThis.__blancCall) { clearInterval(t); resolve(); }
       }, 50);
     })
   );
@@ -140,9 +141,7 @@ BeforeAll({ timeout: 120_000 }, async () => {
 
   // The F19 scenarios write the REAL system clipboard — save the developer's
   // clipboard now and restore it in AfterAll so a local run doesn't clobber it.
-  savedClipboard = await ctx.app
-    .evaluate(() => globalThis.__blanc.readClipboardText())
-    .catch(() => null);
+  savedClipboard = await callTestHook(ctx.app, 'readClipboardText').catch(() => null);
 });
 
 Before(async function () {
@@ -152,13 +151,12 @@ Before(async function () {
   ctx.enteredInput = null;
   ctx.addressMenuItems = null;
   ctx.addressMenuFieldText = null;
-  await ctx.app.evaluate(() => globalThis.__blanc.reset());
+  await callTestHook(ctx.app, 'reset');
 });
 
 AfterAll(async () => {
   if (ctx.app && savedClipboard !== null) {
-    await ctx.app
-      .evaluate((_electron, text) => globalThis.__blanc.setClipboardText(text), savedClipboard)
+    await callTestHook(ctx.app, 'setClipboardText', [savedClipboard])
       .catch(() => {});
   }
   if (ctx.app) await ctx.app.close();

--- a/test/desktop/support/test-hook-call.js
+++ b/test/desktop/support/test-hook-call.js
@@ -1,0 +1,25 @@
+'use strict';
+
+let nextCallId = 1;
+
+const isCollectedInspectorReply = (error) =>
+  /Execution context was destroyed/i.test(String(error?.message || error));
+
+/** Invoke one main-process test hook, retrying only the inspector reply with
+ * the same id. __blancCall owns idempotency, so a mutating hook never runs
+ * twice when Playwright loses the first response. */
+async function callTestHook(electronApp, method, args = []) {
+  const request = { id: nextCallId++, method, args };
+  const invoke = () => electronApp.evaluate(
+    (_electron, p) => globalThis.__blancCall(p.id, p.method, p.args),
+    request
+  );
+  try {
+    return await invoke();
+  } catch (error) {
+    if (!isCollectedInspectorReply(error)) throw error;
+    return invoke();
+  }
+}
+
+module.exports = { callTestHook, isCollectedInspectorReply };

--- a/test/desktop/support/world.js
+++ b/test/desktop/support/world.js
@@ -1,5 +1,6 @@
 const { setWorldConstructor } = require('@cucumber/cucumber');
 const ctx = require('./context');
+const { callTestHook } = require('./test-hook-call');
 
 // The World is the per-scenario `this` in steps. It wraps the running Electron
 // app with a generic bridge into the test hook (globalThis.__blanc) plus a few
@@ -8,10 +9,7 @@ const ctx = require('./context');
 class BlancWorld {
   /** Invoke a globalThis.__blanc method in the Electron main process. */
   async call(method, ...args) {
-    return ctx.app.evaluate(
-      (_electron, p) => globalThis.__blanc[p.m](...p.a),
-      { m: method, a: args }
-    );
+    return callTestHook(ctx.app, method, args);
   }
 
   /** Snapshot of tab/group/active state from the main process. */

--- a/test/unit/test-call-bridge.test.js
+++ b/test/unit/test-call-bridge.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { installTestCallBridge } = require('../../src/main/test-call-bridge');
+const { callTestHook } = require('../desktop/support/test-hook-call');
+
+test('a repeated call id returns the original result without repeating its mutation', async () => {
+  let mutations = 0;
+  const target = {};
+  installTestCallBridge(target, {
+    mutate(value) { mutations += 1; return { value, mutations }; },
+  });
+
+  const first = target.__blancCall(1, 'mutate', ['kept']);
+  const retry = target.__blancCall(1, 'mutate', ['ignored']);
+  assert.strictEqual(retry, first, 'the bridge must retain the exact in-flight promise');
+  assert.deepEqual(await retry, { value: 'kept', mutations: 1 });
+  assert.equal(mutations, 1);
+});
+
+test('a lost Playwright reply retries the same id and runs a mutating hook once', async () => {
+  let mutations = 0;
+  let inspectorAttempts = 0;
+  const target = {};
+  installTestCallBridge(target, {
+    newTab() { mutations += 1; return `tab-${mutations}`; },
+  });
+  const electronApp = {
+    async evaluate(_evaluator, request) {
+      inspectorAttempts += 1;
+      const result = await target.__blancCall(request.id, request.method, request.args);
+      if (inspectorAttempts === 1) {
+        throw new Error('Execution context was destroyed, most likely because of a navigation.');
+      }
+      return result;
+    },
+  };
+
+  assert.equal(await callTestHook(electronApp, 'newTab'), 'tab-1');
+  assert.equal(inspectorAttempts, 2);
+  assert.equal(mutations, 1, 'retrying the reply must not create a second tab');
+});
+
+test('permanent inspector failures are not retried', async () => {
+  let attempts = 0;
+  const electronApp = {
+    async evaluate() { attempts += 1; throw new Error('candidate process exited'); },
+  };
+  await assert.rejects(callTestHook(electronApp, 'state'), /candidate process exited/);
+  assert.equal(attempts, 1);
+});


### PR DESCRIPTION
## What changed

PR #110 now carries the complete desktop acceptance-harness fix set that grew out of the slash-command investigation:

- drives slash commands through the real palette input and Enter dispatcher instead of switching on command names and calling their effects directly
- waits for the overlay renderer, not main-process intent, before typing or measuring layout
- makes main-process test-hook calls idempotent so a lost Playwright/CDP reply can be retried without replaying mutations such as opening a tab or changing settings
- stabilizes vertical-layout coverage by measuring the Island's layout center separately from its intentional proximity lean, using one pointer-captured resize move, and reporting the complete title-hover state on timeout

The utility-sheet navigation crash fix that was originally in this local stack is **not** part of this PR; it already shipped separately in #111 and was dropped during the rebase.

## Why

The old slash-command step proved only that each underlying action worked. No test typed a command, verified that Enter selected it, exercised its parser, or confirmed that its result was perceptible. That gap let `/sleep` ship with a green suite while its changed rows remained hidden.

The investigation also separated four independent harness failures:

- main's `overlayMode` changes before the renderer has laid out the requested surface
- Chromium can execute a main-process evaluation and then lose its inspector reply as `Promise was collected`
- a raw retry is unsafe because it can repeat a mutation
- the resting Island's visual box includes an intentional proximity translation, while a many-step synthetic resize can move the handle out from under its captured pointer

Each fix targets its own boundary rather than hiding failures with Cucumber retries.

## Shipping impact

This is test infrastructure only. The new bridge is installed from `test-hook.js` under the existing `BLANC_TEST=1` development guard and is unreachable in packaged builds.

## Verification

On the exact rebased stack now on this PR:

- 622/622 unit tests
- 4/4 generated-source/substrate checks
- acceptance dry run: 91 scenarios / 555 steps resolved
- full desktop acceptance: **91/91 scenarios, 555/555 steps**, `--retry 0`
- DNS smoke: passed on macOS
- crash reports: 28 before, 28 after
- `git diff --check`: clean

The full desktop run wrote a durable Cucumber message log so a rerun could not replace the original evidence.