### PR TITLE
Copy decision: the /sleep hint wording

### DIFF
--- a/copy/generated/SlashCommands.strings
+++ b/copy/generated/SlashCommands.strings
@@ -10,7 +10,7 @@
 "slash_close" = "Close this tab";
 "slash_pin" = "Pin or unpin this tab";
 "slash_mute" = "Mute or unmute this tab";
-"slash_sleep" = "Put background tabs to sleep and free their memory";
+"slash_sleep" = "Quiet background tabs and free their memory";
 "slash_group" = "Type a space, then a group name — e.g. \"work\"";
 "slash_ungroup" = "Take this tab out of its group";
 "slash_close_group" = "Close every tab in this group";

--- a/copy/generated/slash_commands.xml
+++ b/copy/generated/slash_commands.xml
@@ -11,7 +11,7 @@
     <string name="slash_close">Close this tab</string>
     <string name="slash_pin">Pin or unpin this tab</string>
     <string name="slash_mute">Mute or unmute this tab</string>
-    <string name="slash_sleep">Put background tabs to sleep and free their memory</string>
+    <string name="slash_sleep">Quiet background tabs and free their memory</string>
     <string name="slash_group">Type a space, then a group name — e.g. \"work\"</string>
     <string name="slash_ungroup">Take this tab out of its group</string>
     <string name="slash_close_group">Close every tab in this group</string>

--- a/copy/slash-commands.json
+++ b/copy/slash-commands.json
@@ -17,7 +17,7 @@
     { "command": "/close", "hint": "Close this tab" },
     { "command": "/pin", "hint": "Pin or unpin this tab" },
     { "command": "/mute", "hint": "Mute or unmute this tab" },
-    { "command": "/sleep", "hint": "Put background tabs to sleep and free their memory" },
+    { "command": "/sleep", "hint": "Quiet background tabs and free their memory" },
     { "command": "/group", "hint": "Type a space, then a group name — e.g. \"work\"", "doc": { "command": "/group <name>", "hint": "Move this tab into a group, creating it on first use" } },
     { "command": "/ungroup", "hint": "Take this tab out of its group" },
     { "command": "/close-group", "hint": "Close every tab in this group" },

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -3662,7 +3662,7 @@ const SLASH_COMMANDS = [
   ['/close', 'Close this tab'],
   ['/pin', 'Pin or unpin this tab'],
   ['/mute', 'Mute or unmute this tab'],
-  ['/sleep', 'Put background tabs to sleep and free their memory'],
+  ['/sleep', 'Quiet background tabs and free their memory'],
   ['/group <name>', 'Move this tab into a group, creating it on first use'],
   ['/ungroup', 'Take this tab out of its group'],
   ['/close-group', 'Close every tab in this group'],

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -569,7 +569,7 @@
     { cmd: '/close', hint: 'Close this tab', run: () => state.activeTabId && window.browserAPI.closeTab(state.activeTabId) },
     { cmd: '/pin', hint: 'Pin or unpin this tab', run: () => state.activeTabId && window.browserAPI.toggleTabPinned(state.activeTabId) },
     { cmd: '/mute', hint: 'Mute or unmute this tab', run: () => state.activeTabId && window.browserAPI.toggleTabMuted(state.activeTabId) },
-    { cmd: '/sleep', hint: 'Put background tabs to sleep and free their memory', run: () => window.browserAPI.sleepBackgroundTabs(), keepOverlay: true, clearInput: true, resultNotice: (quieted) => Array.isArray(quieted) && quieted.length === 0 ? 'No background tabs can be quieted right now.' : '' },
+    { cmd: '/sleep', hint: 'Quiet background tabs and free their memory', run: () => window.browserAPI.sleepBackgroundTabs(), keepOverlay: true, clearInput: true, resultNotice: (quieted) => Array.isArray(quieted) && quieted.length === 0 ? 'No background tabs can be quieted right now.' : '' },
     { cmd: '/group', hint: 'Type a space, then a group name — e.g. "work"', run: (input) => {
       const name = (input ?? '').replace(/^\/group\s*/, '').trim();
       if (name && state.activeTabId) window.browserAPI.groupTabByName(state.activeTabId, name);

--- a/src/renderer/pages/shortcuts.js
+++ b/src/renderer/pages/shortcuts.js
@@ -14,7 +14,7 @@ const SLASH_COMMANDS = [
   ['/close', 'Close this tab'],
   ['/pin', 'Pin or unpin this tab'],
   ['/mute', 'Mute or unmute this tab'],
-  ['/sleep', 'Put background tabs to sleep and free their memory'],
+  ['/sleep', 'Quiet background tabs and free their memory'],
   ['/group <name>', 'Move this tab into a group, creating it on first use'],
   ['/ungroup', 'Take this tab out of its group'],
   ['/close-group', 'Close every tab in this group'],

--- a/test/unit/sleep-command-wiring.test.js
+++ b/test/unit/sleep-command-wiring.test.js
@@ -116,7 +116,7 @@ test('/sleep sits at the same index in all four hand-synced copies', () => {
   const index = json.commands.findIndex((command) => command.command === '/sleep');
   assert.equal(index, 11, '/sleep must follow /mute and precede /group');
   const entry = json.commands[index];
-  assert.equal(entry.hint, 'Put background tabs to sleep and free their memory');
+  assert.equal(entry.hint, 'Quiet background tabs and free their memory');
   assert.equal(entry.doc, undefined);
   assert.doesNotMatch(entry.hint, /'/);
 
@@ -132,7 +132,7 @@ test('/sleep sits at the same index in all four hand-synced copies', () => {
   assert.equal(tupleIndex(mainSource), index);
 
   const line = overlay.split('\n').find((candidate) => candidate.includes("cmd: '/sleep'"));
-  assert.match(line, /hint: 'Put background tabs to sleep and free their memory'/);
+  assert.match(line, /hint: 'Quiet background tabs and free their memory'/);
   assert.match(line, /window\.browserAPI\.sleepBackgroundTabs\(\)/);
   assert.match(line, /keepOverlay: true/);
 });


### PR DESCRIPTION
**A copy decision, not a fix.** This string was deliberately locked — pinned by
a unit test *and* by the copy substrate — so changing it is a product-contract
change, not a mechanical correction. Either outcome below is valid; this PR
exists so the choice is made explicitly rather than by default.

| | |
|---|---|
| **Current (locked)** | `Put background tabs to sleep and free their memory` |
| **Proposed** | `Quiet background tabs and free their memory` |

The literal `/sleep` command token is unchanged either way. No behavior change.

## Why this is cross-platform

`copy/slash-commands.json` is the platform-neutral source of truth. It
generates `copy/generated/SlashCommands.strings` and `slash_commands.xml`,
which the future iOS and Android ports consume, and it is guarded against the
three desktop copies by `copy:check`. So this decides the wording for every
platform, present and future — not one desktop tooltip.

## The case for changing

- Every other user-visible string for the feature says **quiet**: the panel row
  label, the pill dot's accessible name (`Switch to …, quiet`), and the
  nothing-to-do notice (`No background tabs can be quieted right now.`).
  CLAUDE.md states the rule as: the fixed `/sleep` command is the only place
  the internal vocabulary surfaces.
- It puts the scope earlier in the sentence. Read as "sleep", people expect the
  command to act on the tab in front of them; it never touches the active tab,
  because discarding the renderer for the page you are looking at reclaims
  nothing. Vivaldi — the only other browser shipping this as a first-class
  manual command — names it "Hibernate Background Tabs" for that reason.
  (Observed in practice: a first-time user ran `/sleep` expecting the active
  tab to quiet.)

## The case for keeping it

- It was pinned in two places on purpose. That is a decision on record, not an
  oversight, and reversing it should clear the same bar.
- The current wording is the **only** place the product explains what `/sleep`
  means in the vocabulary of the command itself. It bridges the token and the
  concept: "sleep → quiet". Change it and `/sleep` becomes a command word that
  appears nowhere in its own description, which may cost more discoverability
  than the scope reordering gains.
- It churns the generated mobile artifacts and any downstream translation of
  them, for a string that is already accurate about scope.

## If merged — what moves, and validation

Source of truth plus its regenerated artifacts (`copy:build`, never hand-edited),
all three desktop copies (`overlay.js`, `pages/shortcuts.js`, `main.js` — they
move together or `copy:check` fails), and the two pinned assertions in
`test/unit/sleep-command-wiring.test.js`. Docs, plans, and the design spec keep
the original wording; they record what was built at the time.

- `npm run substrate:check` — all four guards green
- `npm run test:unit` — 619/619
- Rendered rather than only asserted in source — launched the app, opened the
  panel, typed `/sl`, and read the row shown to the user:

  ```
  /sleep   Quiet background tabs and free their memory ↵
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
