### PR TITLE
Release Blanc 1.2.0

### DIFF
--- a/docs/press/release-notes/v1.2.0.md
+++ b/docs/press/release-notes/v1.2.0.md
@@ -3,13 +3,21 @@
 ## Added
 
 - Blanc now gives back the memory of tabs you have not opened in a while. A tab left alone past the delay you choose hands its page back to the system; it keeps its place in the Island, the rail, and the switcher, and reloads when you come back to it. Choose the delay — off, 30 minutes, 1 hour, or 6 hours — under Settings → General → Quiet inactive tabs. It is set to an hour to begin with, and the choice stays on this device.
-- A quiet tab is marked wherever tabs are drawn: a smaller dot in the Island, a `quiet` tag on its row in the ⌘L panel, a marker in the vertical rail, and `· quiet` in the Quick Switcher. Screen readers hear the same word.
+- A quiet tab says so where you pick tabs: its row dims in the ⌘L panel and the vertical rail, and carries the word `quiet`. Screen readers hear the same word. The dim alone would not do — after a relaunch every restored tab is quiet, and a uniformly dim list reads as styling rather than as a state.
 - Blanc leaves a tab alone when quieting it would cost you something: anything playing or that has played sound, anything muted or pinned, a page with something typed into it or a checkbox you ticked, a page that asks before you leave, a result of a form you submitted, a tab waiting on a permission prompt, a window it opened or was opened by, and a page you have scrolled deep into. The new `/sleep` command quiets every eligible background tab straight away — it skips the waiting and nothing else, and it works even with the delay set to off.
 - Reopening Blanc is quicker. Restored tabs come back quiet with their titles and site icons already in place, and only the tab you were last using loads.
+- You can now see when a site is using your microphone or camera. While any tab or pop-out window is recording, a red microphone or camera mark appears in the Island; clicking it lists every site currently listening or watching, and each one has a stop button. Blanc knows a site started recording because it granted the permission itself, so the mark cannot be suppressed by the page — and if a site's own recording ends in a way Blanc cannot observe, the mark stays up rather than going quietly dark. A tab that is recording is never quieted.
 
 ## Changed
 
-- Turning the delay off stops Blanc quieting anything new. Tabs that are already quiet stay as they are and come back normally when you open them — switching the setting off never throws away what a quiet tab needs to return.
+- Turning the quiet delay off stops Blanc quieting anything new. Tabs that are already quiet stay as they are and come back normally when you open them — switching the setting off never throws away what a quiet tab needs to return.
+- Permission requests now appear along the bottom of the page instead of beside the Island, where they crowded it, and a request for your microphone or camera shows which one it is asking for.
+
+## Fixed
+
+- Pinned tabs that belong to no group stay visible in the ⌘L panel.
+- Opening Settings, History, or Downloads while a page is still loading no longer risks a crash.
+- Site icons synced from your other devices are drawn sharply on high-resolution displays.
 
 ## Other platforms
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -6,7 +6,7 @@ import MemoryChart from '../components/MemoryChart.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 import releaseData from '../data/releases.json';
 
-const VERSION = '1.1.1';
+const VERSION = '1.2.0';
 const TAG = `v${VERSION}`;
 /* Wherever this page states a version and a date together, the date is that
    version's own ship date — read from the generated changelog data rather than

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.1.1');
+  assert.equal(packageVersion, '1.2.0');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
## Summary

- Bumps `version` to `1.2.0` in `package.json` + `package-lock.json`
- Updates the press-page `VERSION` pin and the `press-kit.test.js` assertion
- Ships the rewritten release notes covering Quiet Tabs, capture indicator, bottom-center permission prompt, and bug fixes

## Test plan

- [x] 671 unit tests pass
- [x] 92 acceptance scenarios resolve (dry-run)
- [x] `substrate:check` passes
- [x] `npm audit --omit=dev` clean
- [x] Electron devDep is current (43.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)