### PR TITLE
Release Blanc 1.2.1

### DIFF
--- a/docs/press/release-notes/v1.2.1.md
+++ b/docs/press/release-notes/v1.2.1.md
@@ -1,4 +1,4 @@
-# Blanc 1.2.0
+# Blanc 1.2.1
 
 ## Added
 
@@ -21,4 +21,4 @@
 
 ## Other platforms
 
-All three platforms are built from the same `v1.2.0` source tag and published with one SHA-256 manifest.
+All three platforms are built from the same `v1.2.1` source tag and published with one SHA-256 manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -6,7 +6,7 @@ import MemoryChart from '../components/MemoryChart.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 import releaseData from '../data/releases.json';
 
-const VERSION = '1.2.0';
+const VERSION = '1.2.1';
 const TAG = `v${VERSION}`;
 /* Wherever this page states a version and a date together, the date is that
    version's own ship date — read from the generated changelog data rather than

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.2.0');
+  assert.equal(packageVersion, '1.2.1');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
## Why 1.2.1 and not 1.2.0

The 1.2.0 run cleared every gate — press verification, notarized mac build,
fuse verification, first-run smoke, migration from v0.22.0, and both native CI
jobs — then aborted at Sigstore signing: `cosign` fell back to keyless device
flow and the code expired before it was entered.

`scripts/release.sh` treats released *and staged* versions as immutable ("a
failed draft remains evidence of that attempt; fix forward with a new
rc.N/version rather than overwriting"), so the `v1.2.0` tag and its unpublished
draft stay put. Nothing from 1.2.0 was ever published.

## Contents

Identical to the 1.2.0 attempt — Quiet Tabs, the mic/camera capture indicator,
the relocated permission prompt, and the fixes. Only the version strings move.

- `version` → `1.2.1` in `package.json` + `package-lock.json`
- `docs/press/release-notes/v1.2.0.md` → `v1.2.1.md` (heading and tag reference updated)
- `press.astro` `VERSION` pin and the `press-kit.test.js` assertion

## Test plan

- [x] 671 unit tests pass
- [x] `npm audit --omit=dev` clean

## Run note

The release must be run from an interactive terminal so `cosign` opens a
browser for the OIDC flow instead of falling back to the 5-minute device code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)