### PR TITLE
fix: derive quiet restored-tab titles from the URL host when meta is absent

### DIFF
--- a/src/main/session-restore.js
+++ b/src/main/session-restore.js
@@ -8,18 +8,34 @@
  *          meta?: {title: string, favicon: string|null}[], activeIndex?: number}} saved
  * @param {(url: string) => boolean} shouldDrop
  */
+// Files written before the meta column (≤1.1.1), and rollbacks that dropped
+// it, carry no saved title — and restored tabs are born quiet, so nothing
+// repaints the label until first wake. A real site's host ("blancbrowser.com",
+// www-stripped like the panel's own url labels) keeps rows distinguishable;
+// non-web urls (blanc://newtab) stay blank and render as "New Tab". Favicons
+// are never fabricated here.
+function hostTitle(url) {
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return '';
+    return u.host.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+}
+
 function filterRestoredSession({ urls = [], groupIds = [], pinned = [], meta = [], activeIndex = 0 } = {}, shouldDrop) {
   const survivors = [];
   for (const [i, url] of urls.entries()) {
     if (shouldDrop(url)) continue;
+    // Quiet Tabs (spec §10.1). A missing or blank saved title falls back to
+    // the host, never to a label belonging to a different tab.
+    const saved = meta[i] ?? { title: '', favicon: null };
     survivors.push({
       url,
       groupId: groupIds[i] ?? null,
       pinned: !!pinned[i],
-      // Quiet Tabs (spec §10.1). Files written before the meta column, and
-      // rollbacks that dropped it, restore with a blank label rather than
-      // one belonging to a different tab.
-      meta: meta[i] ?? { title: '', favicon: null },
+      meta: saved.title ? saved : { ...saved, title: hostTitle(url) },
       originalIndex: i,
     });
   }

--- a/test/unit/session-restore.test.js
+++ b/test/unit/session-restore.test.js
@@ -58,7 +58,7 @@ test('active survives a shift left', () => {
   }, drop);
   assert.deepEqual(out, {
     urls: ['https://a/'], groupIds: ['g1'], pinned: [true],
-    meta: [{ title: '', favicon: null }], activeIndex: 0,
+    meta: [{ title: 'a', favicon: null }], activeIndex: 0,
   });
 });
 
@@ -73,8 +73,53 @@ test('missing metadata arrays and out-of-range activeIndex are tolerated', () =>
   const out = filterRestoredSession({ urls: ['https://a/'], activeIndex: 99 }, drop);
   assert.deepEqual(out, {
     urls: ['https://a/'], groupIds: [null], pinned: [false],
-    meta: [{ title: '', favicon: null }], activeIndex: 0,
+    meta: [{ title: 'a', favicon: null }], activeIndex: 0,
   });
+});
+
+// A v1.1.1 session.json has urls but no meta column. Restored tabs are born
+// quiet, so without a derived label every row reads "New Tab" until first
+// wake — reported after the 1.2.1 update as "my tabs are gone".
+test('missing meta on a real site derives the row title from the host', () => {
+  const out = filterRestoredSession({
+    urls: ['https://www.blancbrowser.com/changelog/'],
+    activeIndex: 0,
+  }, drop);
+  assert.deepEqual(out.meta, [{ title: 'blancbrowser.com', favicon: null }]);
+});
+
+test('empty meta title on a real site also derives from the host', () => {
+  const out = filterRestoredSession({
+    urls: ['https://news.ycombinator.com/item?id=1'],
+    meta: [{ title: '', favicon: null }],
+    activeIndex: 0,
+  }, drop);
+  assert.deepEqual(out.meta, [{ title: 'news.ycombinator.com', favicon: null }]);
+});
+
+test('a saved real title is never overwritten by the host', () => {
+  const out = filterRestoredSession({
+    urls: ['https://example.com/'],
+    meta: [{ title: 'Example Domain', favicon: 'https://example.com/i.png' }],
+    activeIndex: 0,
+  }, drop);
+  assert.deepEqual(out.meta, [{ title: 'Example Domain', favicon: 'https://example.com/i.png' }]);
+});
+
+test('a genuinely blank tab keeps its empty title (renders as New Tab)', () => {
+  const out = filterRestoredSession({
+    urls: ['blanc://newtab/'],
+    activeIndex: 0,
+  }, drop);
+  assert.deepEqual(out.meta, [{ title: '', favicon: null }]);
+});
+
+test('an unparsable url without meta stays untitled rather than throwing', () => {
+  const out = filterRestoredSession({
+    urls: ['not a url'],
+    activeIndex: 0,
+  }, drop);
+  assert.deepEqual(out.meta, [{ title: '', favicon: null }]);
 });
 
 test('restoreTargetId skips holes at and after the saved index', () => {


### PR DESCRIPTION
## Summary

A session.json written by v1.1.1 has `windows[0].urls` but no parallel `meta` column, and 1.2.x restores every tab quiet — so an upgrading user's whole ⌘L list rendered as identical "New Tab" rows until first wake. Reported after the 1.2.1 update as "my tabs are gone" (the URL list was intact).

`filterRestoredSession` now fills a missing or blank saved title with the entry's http(s) host (www-stripped, matching the panel's own url labels), so rows are distinguishable before first wake:

- Real saved titles are never overwritten
- Favicons are never fabricated
- `blanc://newtab` (and any non-web/unparsable url) stays blank and still renders as the literal "New Tab"

No main.js change — the restore path already feeds `cleaned.meta[i].title` into `createTab`.

## Test plan

- 5 new unit tests over `filterRestoredSession` (v1.1.1-style file without meta, blank meta title, preserved real title, blank newtab, unparsable url), written first and watched fail
- 2 existing tests encoding the old blank fallback updated in the same commit
- `npm run test:unit`: 676/676 pass; `npm run substrate:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)