### PR TITLE
Release Blanc 1.2.2

### DIFF
--- a/docs/press/release-notes/v1.2.2.md
+++ b/docs/press/release-notes/v1.2.2.md
@@ -1,0 +1,11 @@
+# Blanc 1.2.2
+
+## Fixed
+
+- Website icons load again. Blanc still checks every resolved address before connecting, while allowing the connection to fall back across the approved IPv4 and IPv6 addresses when the first one is unavailable.
+- Sites that check microphone or camera permission before asking can now show their recording flow normally. An undecided permission truthfully reports `prompt`; choosing Allow or Block updates retained permission status objects and fires their standard change event. Blanc continues to refuse access until you explicitly allow it.
+- Tabs restored from Blanc 1.1.1 or earlier no longer appear as identical “New Tab” rows when the older session file has no saved titles. Blanc derives a useful title from each website’s address until the page is opened and supplies its real title.
+
+## Other platforms
+
+All three platforms are built from the same `v1.2.2` source tag and published with one SHA-256 manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",
@@ -25,6 +25,7 @@
     "test:dns-smoke": "node test/desktop/dns-smoke.mjs",
     "test:packaged:first-run": "node test/desktop/packaged-first-run-smoke.mjs",
     "test:packaged:migration": "node test/desktop/packaged-migration-smoke.mjs",
+    "test:packaged:regressions": "node test/desktop/release-regressions-smoke.mjs",
     "bench:memory": "node bench/memory/run.js",
     "release:security": "npm audit --omit=dev --audit-level=high",
     "release:verify:press": "npm run substrate:check && npm run icons:windows:check && npm run test:unit && npm run test:acceptance:dry && npm run test:acceptance:desktop && npm run test:oauth:desktop && npm run test:dns-smoke && npm run release:security && npm run site:build",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -6,7 +6,7 @@ import MemoryChart from '../components/MemoryChart.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 import releaseData from '../data/releases.json';
 
-const VERSION = '1.2.1';
+const VERSION = '1.2.2';
 const TAG = `v${VERSION}`;
 /* Wherever this page states a version and a date together, the date is that
    version's own ship date — read from the generated changelog data rather than

--- a/test/desktop/release-regressions-smoke.mjs
+++ b/test/desktop/release-regressions-smoke.mjs
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { launchPackagedOverCdp } from './support/packaged-cdp.mjs';
+
+const defaultExecutable = process.platform === 'darwin'
+  ? path.resolve('dist/mac-arm64/Blanc.app/Contents/MacOS/Blanc')
+  : null;
+const executablePath = process.env.BLANC_PACKAGED_EXECUTABLE || defaultExecutable;
+if (!executablePath || !fs.existsSync(executablePath)) {
+  throw new Error(
+    'Packaged Blanc executable not found. Set BLANC_PACKAGED_EXECUTABLE or build dist/mac-arm64 first.'
+  );
+}
+
+const poll = async (read, predicate, message, timeoutMs = 30_000) => {
+  const deadline = Date.now() + timeoutMs;
+  let value;
+  while (Date.now() < deadline) {
+    value = await read();
+    if (predicate(value)) return value;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.fail(`${message}; last value: ${JSON.stringify(value)}`);
+};
+
+const server = http.createServer((request, response) => {
+  response.setHeader('Content-Type', 'text/html; charset=utf-8');
+  if (request.url === '/favicon') {
+    response.end(`<!doctype html>
+      <title>Favicon probe</title>
+      <link rel="icon" type="image/png" href="https://blancbrowser.com/favicon-32x32.png">
+      <main>favicon probe</main>`);
+    return;
+  }
+  if (request.url === '/mic') {
+    response.end(`<!doctype html>
+      <title>Microphone probe</title>
+      <button id="ask" type="button">Ask for microphone</button>
+      <script>
+        globalThis.__requestState = 'idle';
+        document.getElementById('ask').addEventListener('click', async () => {
+          globalThis.__requestState = 'pending';
+          try {
+            globalThis.__stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            globalThis.__requestState = 'granted';
+          } catch (error) {
+            globalThis.__requestState = 'rejected:' + error.name;
+          }
+        });
+      </script>`);
+    return;
+  }
+  response.statusCode = 404;
+  response.end('not found');
+});
+
+await new Promise((resolve, reject) => {
+  server.once('error', reject);
+  server.listen(0, '127.0.0.1', resolve);
+});
+const address = server.address();
+const origin = `http://127.0.0.1:${address.port}`;
+
+const baseSettings = {
+  adblockEnabled: false,
+  onboardingVersion: 1,
+  searchSuggestions: false,
+  usagePing: false,
+};
+
+const withPackagedApp = async ({ label, launchArgs = [], prepare }, run) => {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), `blanc-${label}-`));
+  let app;
+  try {
+    fs.writeFileSync(
+      path.join(userDataDir, 'settings.json'),
+      JSON.stringify(baseSettings, null, 2)
+    );
+    await prepare?.(userDataDir);
+    app = await launchPackagedOverCdp({
+      executablePath,
+      args: [`--user-data-dir=${userDataDir}`, ...launchArgs],
+      env: { ...process.env, BLANC_TEST: '0' },
+    });
+    await run(app);
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+};
+
+const readTabState = async (app) => {
+  const chrome = app.pages().find((page) => page.url() === 'blanc-chrome://index/');
+  if (!chrome) return null;
+  return chrome.evaluate(() => window.browserAPI.getAllTabs());
+};
+
+try {
+  await withPackagedApp({
+    label: 'release-regressions-restore-favicon',
+    prepare: async (userDataDir) => {
+      fs.writeFileSync(
+        path.join(userDataDir, 'session.json'),
+        JSON.stringify({
+          urls: ['https://example.com/', `${origin}/favicon`],
+          activeIndex: 1,
+        }, null, 2)
+      );
+    },
+  }, async (app) => {
+    const restored = await poll(
+      () => readTabState(app),
+      (state) => state?.tabs?.some((tab) => tab.url === 'https://example.com/')
+        && state.tabs.some((tab) => tab.url === `${origin}/favicon`),
+      'packaged candidate did not restore the legacy session'
+    );
+    const quiet = restored.tabs.find((tab) => tab.url === 'https://example.com/');
+    assert.equal(quiet.asleep, true, 'inactive legacy tab should restore quiet');
+    assert.equal(quiet.title, 'example.com', 'missing legacy title should derive from the host');
+    assert.notEqual(quiet.title, 'New Tab');
+
+    const faviconTab = await poll(
+      () => readTabState(app).then((state) =>
+        state?.tabs?.find((tab) => tab.url === `${origin}/favicon`) ?? null),
+      (tab) => tab?.favicon?.startsWith('data:image/png;base64,'),
+      'packaged candidate did not sanitize the live remote favicon into PNG bytes',
+      45_000
+    );
+    const faviconBytes = Buffer.from(faviconTab.favicon.split(',')[1], 'base64');
+    assert.equal(faviconBytes.subarray(1, 4).toString('ascii'), 'PNG');
+    assert.ok(faviconBytes.length > 100, 'sanitized favicon should contain real image bytes');
+  });
+
+  await withPackagedApp({
+    label: 'release-regressions-microphone',
+    launchArgs: ['--use-fake-device-for-media-stream', `${origin}/mic`],
+  }, async (app) => {
+    const micPage = await poll(
+      () => Promise.resolve(app.pages().find((page) => page.url() === `${origin}/mic`) ?? null),
+      Boolean,
+      'packaged candidate did not open the microphone probe'
+    );
+
+    const initial = await micPage.evaluate(async () => {
+      const status = await navigator.permissions.query({ name: 'microphone' });
+      globalThis.__heldPermissionStatus = status;
+      globalThis.__permissionChanges = [];
+      status.addEventListener('change', (event) => {
+        globalThis.__permissionChanges.push({
+          state: status.state,
+          eventIsEvent: event instanceof Event,
+          targetIsStatus: event.target === status,
+        });
+      });
+      const stateDescriptor = Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(status),
+        'state'
+      );
+      return {
+        state: status.state,
+        isEventTarget: status instanceof EventTarget,
+        stateHasSetter: typeof stateDescriptor?.set === 'function',
+      };
+    });
+    assert.deepEqual(initial, {
+      state: 'prompt',
+      isEventTarget: true,
+      stateHasSetter: false,
+    });
+
+    await micPage.locator('#ask').click();
+    const permissionPage = await poll(
+      () => Promise.resolve(
+        app.pages().find((page) => page.url() === 'blanc-chrome://permission/') ?? null
+      ),
+      Boolean,
+      'Blanc did not show its microphone permission prompt'
+    );
+    await permissionPage.locator('#permAllowBtn').click();
+
+    const granted = await poll(
+      () => micPage.evaluate(async () => ({
+        requestState: globalThis.__requestState,
+        heldState: globalThis.__heldPermissionStatus?.state,
+        changes: globalThis.__permissionChanges,
+        canonical: await navigator.permissions.query({ name: 'microphone' })
+          === globalThis.__heldPermissionStatus,
+        liveTracks: globalThis.__stream?.getAudioTracks()
+          .filter((track) => track.readyState === 'live').length ?? 0,
+      })),
+      (state) => state.requestState === 'granted'
+        && state.heldState === 'granted'
+        && state.changes?.some((change) => change.state === 'granted')
+        && state.canonical === true
+        && state.liveTracks > 0,
+      'microphone permission did not become a live granted status and stream',
+      45_000
+    );
+    assert.deepEqual(granted.changes.at(-1), {
+      state: 'granted',
+      eventIsEvent: true,
+      targetIsStatus: true,
+    });
+    await micPage.evaluate(() => {
+      globalThis.__stream?.getTracks().forEach((track) => track.stop());
+    });
+  });
+
+  console.log(`release-regressions-smoke OK: ${executablePath}`);
+} finally {
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.2.1');
+  assert.equal(packageVersion, '1.2.2');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
## Summary

- bump Blanc from 1.2.1 to 1.2.2 across package, lockfile, press, and release-note guards
- document the restored-tab title, remote favicon, and microphone/camera preflight fixes
- add a repeatable packaged regression smoke for the three reported symptoms

## Signed candidate proof

Built the unpacked candidate with `npm run dist:dir`. The Developer ID/provisioning-profile preflight passed, Electron packaged 1.2.2, and the final bundle passed code-signature, designated-requirement, entitlement, and embedded-profile verification.

`npm run test:packaged:regressions` launches the packaged binary with disposable profiles and proves:

- a pre-meta legacy `session.json` restores an inactive tab as quiet with host-derived title `example.com`, not “New Tab”
- a live remote favicon becomes a sanitized PNG data URL containing real image bytes
- microphone preflight starts at `prompt`; Blanc's real bottom permission bar appears; Allow updates the retained status to `granted`, fires a genuine change `Event`, and yields a live fake-device audio track

## Broader verification

`npm run release:verify:press` passed:

- substrate and Windows icon freshness
- 688 unit assertions
- 92 desktop acceptance scenarios / 560 steps
- desktop OAuth compatibility
- DNS smoke
- production dependency audit: 0 vulnerabilities
- Astro production site build

Electron remains at the current stable 43.4.0.

## Release boundary

This PR prepares and verifies the source only. It does **not** run the immutable release script, create `v1.2.2`, publish GitHub artifacts, or deploy the post-release changelog.