### PR TITLE
Fix favicon compatibility and background autoplay

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:packaged:first-run": "node test/desktop/packaged-first-run-smoke.mjs",
     "test:packaged:migration": "node test/desktop/packaged-migration-smoke.mjs",
     "test:packaged:regressions": "node test/desktop/release-regressions-smoke.mjs",
+    "test:packaged:favicons-live": "node test/desktop/packaged-live-favicons-smoke.mjs",
     "bench:memory": "node bench/memory/run.js",
     "release:security": "npm audit --omit=dev --audit-level=high",
     "release:verify:press": "npm run substrate:check && npm run icons:windows:check && npm run test:unit && npm run test:acceptance:dry && npm run test:acceptance:desktop && npm run test:oauth:desktop && npm run test:dns-smoke && npm run release:security && npm run site:build",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -231,6 +231,20 @@ echo "==> Smoke-testing the signed packaged first-run experience"
 BLANC_PACKAGED_EXECUTABLE="$PWD/dist/$NATIVE_MAC_DIR/Blanc.app/Contents/MacOS/Blanc" \
   npm run test:packaged:first-run
 
+echo "==> Smoke-testing packaged release regressions"
+BLANC_PACKAGED_EXECUTABLE="$PWD/dist/$NATIVE_MAC_DIR/Blanc.app/Contents/MacOS/Blanc" \
+  npm run test:packaged:regressions
+
+echo "==> Checking live favicon compatibility — primary 25-site matrix"
+BLANC_FAVICON_MATRIX=primary \
+  BLANC_PACKAGED_EXECUTABLE="$PWD/dist/$NATIVE_MAC_DIR/Blanc.app/Contents/MacOS/Blanc" \
+  npm run test:packaged:favicons-live
+
+echo "==> Checking live favicon compatibility — additional 25-site matrix"
+BLANC_FAVICON_MATRIX=additional \
+  BLANC_PACKAGED_EXECUTABLE="$PWD/dist/$NATIVE_MAC_DIR/Blanc.app/Contents/MacOS/Blanc" \
+  npm run test:packaged:favicons-live
+
 echo "==> Verifying migration from public Stable v$MIGRATION_BASE_VERSION"
 MIGRATION_DIR="$(mktemp -d)"
 cleanup_migration() { rm -rf "$MIGRATION_DIR"; }

--- a/src/main/favicon-network.js
+++ b/src/main/favicon-network.js
@@ -6,7 +6,16 @@ const https = require('node:https');
 const net = require('node:net');
 
 const MAX_BYTES = 256 * 1024;
+const MAX_REDIRECTS = 5;
 const TIMEOUT_MS = 3000;
+const FAVICON_REQUEST_HEADERS = Object.freeze({
+  Accept: 'image/png,image/*;q=0.8',
+  'Cache-Control': 'no-store',
+  // Several public CDNs reject HTTP/1.1 requests unless the identity has the
+  // ordinary browser shape. Keep it static and generic: no Blanc/Electron
+  // version fingerprint, cookies, referrer, or page/session state.
+  'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',
+});
 
 // Keep families separate: adding the IPv4-mapped IPv6 range to a shared
 // BlockList makes Node treat every IPv4 address as matching that IPv6 rule.
@@ -92,10 +101,21 @@ function isPinnedRemote(target, remote) {
   return target.addresses.some(({ address }) => address === remote);
 }
 
-function readIconBytes(source, { signal, lookup } = {}) {
-  return new Promise(async (resolve) => {
-    const target = await resolvePinnedTarget(source, lookup);
-    if (!target || signal?.aborted) return resolve(null);
+function redirectSource(source, statusCode, location) {
+  if (![301, 302, 303, 307, 308].includes(statusCode) || typeof location !== 'string') return null;
+  try {
+    const next = new URL(location, source);
+    if (!['http:', 'https:'].includes(next.protocol) || next.username || next.password) return null;
+    return next.href;
+  } catch {
+    return null;
+  }
+}
+
+async function readIconBytesOnce(source, { signal, lookup } = {}) {
+  const target = await resolvePinnedTarget(source, lookup);
+  if (!target || signal?.aborted) return null;
+  return new Promise((resolve) => {
     const client = target.url.protocol === 'https:' ? https : http;
     const options = {
       protocol: target.url.protocol,
@@ -105,10 +125,7 @@ function readIconBytes(source, { signal, lookup } = {}) {
       method: 'GET',
       agent: false,
       signal,
-      headers: {
-        Accept: 'image/png,image/*;q=0.8',
-        'Cache-Control': 'no-store',
-      },
+      headers: FAVICON_REQUEST_HEADERS,
       lookup: pinnedLookup(target),
       ...(target.url.protocol === 'https:' ? { servername: target.url.hostname } : {}),
     };
@@ -119,43 +136,79 @@ function readIconBytes(source, { signal, lookup } = {}) {
       settled = true;
       resolve(value);
     };
-    const request = client.request(options, (response) => {
-      const remote = cleanAddress(response.socket?.remoteAddress);
-      const remoteFamily = net.isIP(remote);
-      if (
-        response.statusCode !== 200 ||
-        !remote ||
-        !isPublicAddress(remote, remoteFamily) ||
-        !isPinnedRemote(target, remote)
-      ) {
-        response.resume();
-        return done(null);
-      }
-      const contentType = String(response.headers['content-type'] ?? '')
-        .split(';', 1)[0].trim().toLowerCase();
-      if (!/^image\/[a-z0-9][a-z0-9.+-]*$/.test(contentType)) {
-        response.resume();
-        return done(null);
-      }
-      const declared = Number(response.headers['content-length']);
-      if (Number.isFinite(declared) && declared > MAX_BYTES) {
-        response.resume();
-        return done(null);
-      }
-      const chunks = [];
-      let total = 0;
-      response.on('data', (chunk) => {
-        total += chunk.length;
-        if (total > MAX_BYTES) response.destroy(new Error('favicon too large'));
-        else chunks.push(chunk);
+    let request;
+    try {
+      request = client.request(options, (response) => {
+        const remote = cleanAddress(response.socket?.remoteAddress);
+        const remoteFamily = net.isIP(remote);
+        if (
+          !remote ||
+          !isPublicAddress(remote, remoteFamily) ||
+          !isPinnedRemote(target, remote)
+        ) {
+          response.resume();
+          return done(null);
+        }
+        const redirect = redirectSource(target.url.href, response.statusCode, response.headers.location);
+        if (redirect) {
+          response.resume();
+          return done({ redirect });
+        }
+        if (response.statusCode !== 200) {
+          response.resume();
+          return done(null);
+        }
+        const contentType = String(response.headers['content-type'] ?? '')
+          .split(';', 1)[0].trim().toLowerCase();
+        if (!/^image\/[a-z0-9][a-z0-9.+-]*$/.test(contentType)) {
+          response.resume();
+          return done(null);
+        }
+        const declared = Number(response.headers['content-length']);
+        if (Number.isFinite(declared) && declared > MAX_BYTES) {
+          response.resume();
+          return done(null);
+        }
+        const chunks = [];
+        let total = 0;
+        response.on('data', (chunk) => {
+          total += chunk.length;
+          if (total > MAX_BYTES) response.destroy(new Error('favicon too large'));
+          else chunks.push(chunk);
+        });
+        response.on('end', () => done({ contentType, bytes: Buffer.concat(chunks, total) }));
+        response.on('error', () => done(null));
       });
-      response.on('end', () => done({ contentType, bytes: Buffer.concat(chunks, total) }));
-      response.on('error', () => done(null));
-    });
+    } catch {
+      return done(null);
+    }
     request.setTimeout(TIMEOUT_MS, () => request.destroy(new Error('favicon timeout')));
     request.on('error', () => done(null));
     request.end();
   });
 }
 
-module.exports = { MAX_BYTES, isPublicAddress, resolvePinnedTarget, pinnedLookup, readIconBytes };
+async function readIconBytes(source, options = {}) {
+  let current = source;
+  const seen = new Set();
+  for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+    if (seen.has(current)) return null;
+    seen.add(current);
+    const result = await readIconBytesOnce(current, options);
+    if (!result) return null;
+    if (!result.redirect) return result;
+    if (redirects === MAX_REDIRECTS) return null;
+    current = result.redirect;
+  }
+  return null;
+}
+
+module.exports = {
+  FAVICON_REQUEST_HEADERS,
+  MAX_BYTES,
+  isPublicAddress,
+  redirectSource,
+  resolvePinnedTarget,
+  pinnedLookup,
+  readIconBytes,
+};

--- a/src/main/favicon-policy.js
+++ b/src/main/favicon-policy.js
@@ -4,9 +4,9 @@
 // and rely on Chromium re-firing `page-favicon-updated` to restore it. That
 // event is NOT guaranteed: Chromium skips it on a same-origin navigation whose
 // favicon is unchanged/already cached (e.g. apple.com/ -> apple.com/mac/). For a
-// site with no declared `<link rel="icon">` (favicon.ico-only), `upgradeFavicon`
-// has nothing to restore from either, so the icon is cleared and never comes
-// back — a permanent gray box in the pill and the panel rows.
+// site with no declared `<link rel="icon">` (favicon.ico-only), there may be no
+// later event to restore it, so the icon is cleared and never comes back — a
+// permanent gray box in the pill and the panel rows.
 //
 // Fix: only clear on a genuine CROSS-ORIGIN navigation. Cross-origin reliably
 // re-fires `page-favicon-updated`; same-origin keeps the (correct) current icon
@@ -49,4 +49,97 @@ function shouldClearFaviconOnNavigate(fromUrl, toUrl) {
   return from !== to; // same web origin keeps; cross-origin clears
 }
 
-module.exports = { shouldClearFaviconOnNavigate };
+/**
+ * Resolve an asynchronous favicon attempt without letting a failed cosmetic
+ * upgrade erase pixels that were already proven safe. A null candidate is an
+ * explicit navigation/page clear; a non-null candidate that failed to fetch
+ * or decode keeps the currently displayed icon.
+ */
+function resolvedFavicon(current, candidate, sanitized) {
+  if (!candidate) return null;
+  return sanitized || current || null;
+}
+
+/** Keep the supplied page order, then add the conventional same-origin icon
+ * as one boring compatibility fallback. No sharpness ranking: basic
+ * availability matters more than guessing which touch asset looks best at
+ * 14 CSS pixels. */
+function pageFaviconSources(pageUrl, favicons) {
+  const sources = [];
+  const seen = new Set();
+  for (const source of Array.isArray(favicons) ? favicons.slice(0, 20) : []) {
+    if (typeof source !== 'string' || source.length > 2048) continue;
+    if (!/^(https?:|data:image\/)/i.test(source) || seen.has(source)) continue;
+    seen.add(source);
+    sources.push(source);
+  }
+  try {
+    const page = new URL(pageUrl);
+    if (page.protocol === 'http:' || page.protocol === 'https:') {
+      const fallback = new URL('/favicon.ico', page.origin).href;
+      if (!seen.has(fallback)) sources.push(fallback);
+    }
+  } catch {
+    // No conventional fallback for an opaque or malformed page URL.
+  }
+  return sources;
+}
+
+/** Try Chromium's choices in order, then the single conventional fallback. */
+async function updateFaviconFromPage(
+  tab,
+  favicons,
+  { setTabFavicon }
+) {
+  const sources = pageFaviconSources(tab?.url, favicons);
+  if (sources.length === 0) return setTabFavicon(tab, null);
+  for (const source of sources) {
+    const current = await setTabFavicon(tab, source);
+    if (current === false) return false;
+    if (tab.favicon && tab.faviconSource === source) return true;
+  }
+  return true;
+}
+
+/** Read only the page's declared icon URLs, in document order. This is a
+ * compatibility fallback for pages where Chromium never emits its event; it
+ * deliberately does no size ranking or touch-icon guessing. */
+async function declaredPageFavicons(webContents) {
+  try {
+    const sources = await webContents.executeJavaScript(`
+      Array.from(document.querySelectorAll('link[rel~="icon"]'))
+        .slice(0, 20)
+        .map((link) => link.href)
+    `, true);
+    return Array.isArray(sources) ? sources.slice(0, 20) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Some long-running pages never make Chromium emit page-favicon-updated.
+ * At DOM readiness, use their declared icons when no event has already
+ * supplied pixels or started an attempt. */
+async function updateFaviconAfterDomReady(tab, webContents, deps) {
+  if (!tab || tab.favicon) return false;
+  // Chromium can emit page-favicon-updated just before dom-ready. Let that
+  // bounded attempt finish; if transient load pressure made it fail, the
+  // declared-link path below becomes one clean retry instead of standing down
+  // forever because faviconSource happened to be non-null at this instant.
+  const pending = tab.faviconPending;
+  if (pending) await pending.catch(() => false);
+  if (tab.favicon || tab.faviconSource) return false;
+  const urlAtStart = tab.url;
+  const favicons = await declaredPageFavicons(webContents);
+  if (tab.url !== urlAtStart || tab.favicon || tab.faviconSource) return false;
+  return updateFaviconFromPage(tab, favicons, deps);
+}
+
+module.exports = {
+  declaredPageFavicons,
+  pageFaviconSources,
+  resolvedFavicon,
+  shouldClearFaviconOnNavigate,
+  updateFaviconAfterDomReady,
+  updateFaviconFromPage,
+};

--- a/src/main/favicon-sanitizer.js
+++ b/src/main/favicon-sanitizer.js
@@ -6,6 +6,7 @@ const model = require('./tabicons-model');
 const { readIconBytes } = require('./favicon-network');
 
 const MAX_CACHE = 512;
+const SESSION_FETCH_TIMEOUT_MS = 5000;
 const cache = new Map();
 
 function pngData(image) {
@@ -15,12 +16,87 @@ function pngData(image) {
   return model.validIconData(`data:image/png;base64,${resized.toPNG().toString('base64')}`);
 }
 
-async function sanitizeUncached(source, signal) {
+async function sanitizeFetched(contentType, bytes, signal) {
+  if (!bytes || signal?.aborted) return null;
+  // Trust the validated byte signature over a stale/mistaken server label.
+  // Google, for example, serves real PNG bytes as image/x-icon.
+  const png = model.validSourcePngBytes(bytes);
+  if (png) return pngData(nativeImage.createFromBuffer(png));
+  if (contentType === 'image/png') return null;
+  const dataUrl = model.imageSourceToDataUrl(contentType, bytes);
+  return dataUrl ? model.validIconData(await iconRaster.rasterize(dataUrl, signal)) : null;
+}
+
+async function readBoundedResponse(response) {
+  const declared = Number(response.headers?.get?.('content-length'));
+  if (Number.isFinite(declared) && declared > model.MAX_SOURCE_BYTES) return null;
+  if (!response.body?.getReader) {
+    const bytes = Buffer.from(await response.arrayBuffer());
+    return bytes.length <= model.MAX_SOURCE_BYTES ? bytes : null;
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = Buffer.from(value);
+      total += chunk.length;
+      if (total > model.MAX_SOURCE_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(chunk);
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+  return Buffer.concat(chunks, total);
+}
+
+async function readSameOriginSessionIcon(source, pageUrl, browsingSession, signal) {
+  if (!browsingSession?.fetch) return null;
+  let page;
+  let current;
+  try {
+    page = new URL(pageUrl);
+    current = new URL(source);
+  } catch {
+    return null;
+  }
+  if (!['http:', 'https:'].includes(page.protocol) || current.origin !== page.origin) return null;
+
+  const timeoutController = new AbortController();
+  const timeout = setTimeout(() => timeoutController.abort(), SESSION_FETCH_TIMEOUT_MS);
+  const requestSignal = signal
+    ? AbortSignal.any([signal, timeoutController.signal])
+    : timeoutController.signal;
+  try {
+    const response = await browsingSession.fetch(current.href, {
+      credentials: 'omit',
+      referrerPolicy: 'no-referrer',
+      redirect: 'error',
+      signal: requestSignal,
+    });
+    if (!response.ok || requestSignal.aborted) return null;
+    if (response.url && new URL(response.url).origin !== page.origin) return null;
+    const contentType = response.headers?.get?.('content-type')
+      ?.split(';', 1)[0]?.trim()?.toLowerCase();
+    if (!model.isImageMediaType(contentType)) return null;
+    const bytes = await readBoundedResponse(response);
+    return requestSignal.aborted || !bytes ? null : { contentType, bytes };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function sanitizeUncached(source, signal, { browsingSession, pageUrl } = {}) {
   if (signal?.aborted || typeof source !== 'string') return null;
   const alreadySafe = model.validIconData(source);
   if (alreadySafe) return alreadySafe;
-  let contentType;
-  let bytes;
   if (source.toLowerCase().startsWith('data:image/')) {
     const bounded = model.boundedImageDataUrl(source);
     if (!bounded) return null;
@@ -30,18 +106,20 @@ async function sanitizeUncached(source, signal) {
     }
     return model.validIconData(await iconRaster.rasterize(bounded, signal));
   }
-  const fetched = await readIconBytes(source, { signal });
-  if (!fetched || signal?.aborted) return null;
-  ({ contentType, bytes } = fetched);
-  if (contentType === 'image/png') {
-    const png = model.validSourcePngBytes(bytes);
-    return png ? pngData(nativeImage.createFromBuffer(png)) : null;
-  }
-  const dataUrl = model.imageSourceToDataUrl(contentType, bytes);
-  return dataUrl ? model.validIconData(await iconRaster.rasterize(dataUrl, signal)) : null;
+  let fetched = await readIconBytes(source, { signal });
+  let sanitized = fetched
+    ? await sanitizeFetched(fetched.contentType, fetched.bytes, signal)
+    : null;
+  if (sanitized || signal?.aborted) return sanitized;
+  fetched = await readSameOriginSessionIcon(source, pageUrl, browsingSession, signal);
+  return fetched ? sanitizeFetched(fetched.contentType, fetched.bytes, signal) : null;
 }
 
-function sanitizeFavicon(source, signal, { allowNetwork = true } = {}) {
+function sanitizeFavicon(source, signal, {
+  allowNetwork = true,
+  browsingSession,
+  pageUrl,
+} = {}) {
   if (typeof source !== 'string') return Promise.resolve(null);
   // Private tabs may reuse inline pixels supplied by their own document, but
   // Blanc must never create a second, main-process network request for them.
@@ -52,7 +130,7 @@ function sanitizeFavicon(source, signal, { allowNetwork = true } = {}) {
     cache.set(source, existing);
     return existing;
   }
-  const promise = sanitizeUncached(source, signal)
+  const promise = sanitizeUncached(source, signal, { browsingSession, pageUrl })
     .catch(() => null)
     .then((result) => {
       // Deduplicate in-flight work and cache valid pixels, but let transient

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -36,6 +36,8 @@ const tabsync = require('./tabsync');
 const tabicons = require('./tabicons');
 const iconRaster = require('./icon-raster');
 const { sanitizeFavicon } = require('./favicon-sanitizer');
+const { resolvedFavicon } = require('./favicon-policy');
+const { effectiveTabMuted, revealTabAudio } = require('./tab-audio');
 const { validFavicon } = require('./bookmark-validate');
 const { setupDownloads, downloadsActivity, acknowledgeDownloads } = require('./downloads');
 const { attachAddressMenu } = require('./address-menu');
@@ -92,7 +94,7 @@ const {
   popupPlatformMainMenu,
 } = require('./platform-main-menu');
 const { showAboutPanel } = require('./about-panel');
-const { webUrlsFromArgv } = require('./startup-urls');
+const { externalUrlActivationPlan, webUrlsFromArgv } = require('./startup-urls');
 const { isForbiddenTopLevelUrl } = require('./top-level-url-policy');
 
 const NEW_TAB_URL = 'blanc://newtab/';
@@ -205,7 +207,7 @@ if (!app.requestSingleInstanceLock()) {
   app.quit();
 } else {
   app.on('second-instance', bindWindowRuntime(primaryRuntime, (_e, commandLine) => {
-    for (const url of urlsFromArgv(commandLine)) openExternalUrl(url);
+    openExternalUrls(urlsFromArgv(commandLine));
     if (rt().window && !rt().window.isDestroyed()) {
       if (rt().window.isMinimized()) rt().window.restore();
       rt().window.focus();
@@ -317,14 +319,23 @@ function maybeSendLaunchPing() {
 // page, even when its renderer is sandboxed.
 const urlsFromArgv = webUrlsFromArgv;
 
-function openExternalUrl(url) {
+function openExternalUrl(url, { activate = true } = {}) {
   if (!externalUrlsFlushable || !hasLiveWindow()) {
     pendingExternalUrls.push(url);
     return;
   }
-  setActiveTab(createTab(url));
-  if (rt().window.isMinimized()) rt().window.restore();
-  rt().window.focus();
+  const id = createTab(url);
+  if (activate) {
+    setActiveTab(id);
+    if (rt().window.isMinimized()) rt().window.restore();
+    rt().window.focus();
+  }
+}
+
+function openExternalUrls(urls) {
+  for (const entry of externalUrlActivationPlan(urls)) {
+    openExternalUrl(entry.url, { activate: entry.activate });
+  }
 }
 
 // Protocols handed off to the OS instead of navigated — a mailto: click
@@ -369,7 +380,7 @@ function handOffToOs(url, { trusted = false } = {}) {
 
 function flushExternalUrls() {
   externalUrlsFlushable = true;
-  for (const url of pendingExternalUrls.splice(0)) openExternalUrl(url);
+  openExternalUrls(pendingExternalUrls.splice(0));
 }
 
 app.on('open-url', bindWindowRuntime(primaryRuntime, (event, url) => {
@@ -1008,7 +1019,7 @@ async function wakeTab(id, { navigateTo = null, atIndex = null } = {}) {
     if (!retained) wireTabView(tab, view, { owner, adopted: false });
     wc = view.webContents;
     tabIdByWebContentsId.set(wc.id, id);
-    wc.setAudioMuted(!!tab.muted);
+    wc.setAudioMuted(effectiveTabMuted(tab));
     wc.setWebRTCIPHandlingPolicy(webrtcPolicyFor(settings.getSettings().webrtcPolicy));
     tab.waking = true;
     generation = ++tab.wakeGeneration;
@@ -1903,7 +1914,10 @@ function serializeTabs() {
         private: tab.private,
         pinned: tab.pinned,
         muted: tab.muted,
-        audible: tab.audible,
+        // isCurrentlyAudible() describes a playing stream even when Electron
+        // has muted its output. Chrome should report sound only when it can
+        // actually reach the speakers.
+        audible: tab.audible && !(tab.muted || tab.backgroundAutoplayMuted),
         groupId: tab.groupId,
         pageBg: tab.pageBg,
         themeColor: tab.themeColor,
@@ -2348,84 +2362,41 @@ function installChromeShortcuts(webContents) {
   });
 }
 
-/** Pick the sharpest favicon from a page's declared icon links. The pill
- * renders icons at 14px CSS (28+ device px on retina), so a 16px .ico —
- * which is what `page-favicon-updated`'s first entry usually is — scales
- * up blurry. Preference: SVG, then declared sizes ≥32 (nearest 64 wins),
- * then apple-touch-icon (~180px, slightly demoted: often has a solid
- * background), then undeclared PNGs over undeclared ICOs. */
-function pickBestFavicon(candidates) {
-  let best = null;
-  let bestScore = -1;
-  for (const c of candidates) {
-    if (!c || typeof c.href !== 'string' || c.href.length > 2048) continue;
-    if (!/^(https?:|data:image\/)/i.test(c.href)) continue;
-    const sizes = typeof c.sizes === 'string' ? c.sizes.slice(0, 100) : '';
-    const appleTouch = typeof c.rel === 'string' && /apple-touch-icon/i.test(c.rel);
-    const declared = Math.max(0, ...[...sizes.matchAll(/(\d+)[x×]\d+/gi)].map((m) => Number(m[1])));
-    const size = declared || (appleTouch ? 180 : 0);
-    let score;
-    if (/\.svg(\?|#|$)/i.test(c.href) || /\bany\b/i.test(sizes)) score = 1e6;
-    else if (size >= 32) score = 100000 + (10000 - Math.abs(size - 64)) - (appleTouch ? 500 : 0);
-    else if (size === 0) score = /\.ico(\?|$)/i.test(c.href) ? 100 : 1000;
-    else score = size;
-    if (score > bestScore) {
-      bestScore = score;
-      best = c.href;
-    }
-  }
-  return best;
-}
-
-/** Asynchronously refine a tab's favicon beyond Chromium's first-listed
- * URL. Runs in the page context, so everything returned is validated in
- * pickBestFavicon before it touches chrome CSS. */
-async function upgradeFavicon(tab) {
-  const urlAtStart = tab.url;
-  try {
-    const candidates = await tab.view.webContents.executeJavaScript(
-      `[...document.querySelectorAll('link[rel~="icon"], link[rel~="apple-touch-icon"]')]
-        .slice(0, 20)
-        .map((l) => ({ href: l.href, sizes: l.getAttribute('sizes') || '', rel: l.rel }))`
-    );
-    if (!Array.isArray(candidates) || candidates.length > 20) return;
-    if (!tabs.has(tab.id) || tab.url !== urlAtStart) return; // navigated away meanwhile
-    const best = pickBestFavicon(candidates);
-    if (best && best !== tab.faviconSource) setTabFavicon(tab, best);
-  } catch {
-    /* page gone mid-query — Chromium's default pick stands */
-  }
-}
-
 /** Convert a page-controlled favicon source into inert fixed-size PNG pixels
  * before it can cross into privileged chrome or persistent stores. */
 async function setTabFavicon(tab, source) {
   const candidate = typeof source === 'string' ? source : null;
+  const previousSource = tab.faviconSource ?? null;
   const epoch = (tab.faviconEpoch ?? 0) + 1;
   tab.faviconEpoch = epoch;
   tab.faviconSource = candidate;
-  if (tab.favicon !== null) {
-    tab.favicon = null;
-    scheduleBroadcastTabs();
-  }
   if (!candidate) {
+    const changed = tab.favicon !== null;
+    tab.favicon = null;
+    if (changed) scheduleBroadcastTabs();
     if (tab.bookmarked) bookmarks.updateFavicon(tab.url, null);
-    return;
+    return true;
   }
   const urlAtStart = tab.url;
   const sanitized = await sanitizeFavicon(candidate, undefined, {
     allowNetwork: !tab.private,
+    browsingSession: liveContents(tab)?.session,
+    pageUrl: tab.url,
   });
   if (
     !tabs.has(tab.id) ||
     tab.faviconEpoch !== epoch ||
     tab.faviconSource !== candidate ||
     tab.url !== urlAtStart
-  ) return;
-  tab.favicon = sanitized;
-  if (tab.bookmarked) bookmarks.updateFavicon(tab.url, sanitized);
-  scheduleBroadcastTabs();
+  ) return false;
+  const next = resolvedFavicon(tab.favicon, candidate, sanitized);
+  if (!sanitized) tab.faviconSource = previousSource;
+  const changed = tab.favicon !== next;
+  tab.favicon = next;
+  if (sanitized && tab.bookmarked) bookmarks.updateFavicon(tab.url, sanitized);
+  if (changed) scheduleBroadcastTabs();
   if (sanitized) sync.captureTabIcon(tab).catch(() => {});
+  return true;
 }
 
 /** Most common color in a captured image, as #rrggbb (bitmap is BGRA).
@@ -2605,7 +2576,10 @@ function toggleTabMuted(id) {
   const tab = tabs.get(id);
   if (!tab) return false;
   tab.muted = !tab.muted;
-  liveContents(tab)?.setAudioMuted(tab.muted);
+  // An explicit user choice supersedes the temporary background-autoplay
+  // guard. This keeps the visible mute control truthful in both directions.
+  tab.backgroundAutoplayMuted = false;
+  liveContents(tab)?.setAudioMuted(effectiveTabMuted(tab));
   broadcastTabs();
   scheduleMenuRebuild();
   return tab.muted;
@@ -2704,7 +2678,6 @@ initTabView({
   watchCursorFor,
   isUtilityUrl,
   handOffToOs,
-  upgradeFavicon,
   setTabFavicon,
   registerPopupCaptureSurface(wc) {
     popupCaptures.set(wc.id, { record: createCaptureRecord(), wc });
@@ -2775,6 +2748,7 @@ function createTab(url = newTabUrl(), { private: isPrivate = false, groupId = nu
     private: isPrivate,
     pinned,
     muted,
+    backgroundAutoplayMuted: false,
     audible: false,
     groupId: groupId && rt().groups.some((g) => g.id === groupId) ? groupId : null,
     // Strip tint ("faux header"): the page's top-edge color, so the chrome
@@ -2857,6 +2831,10 @@ function setActiveTab(id, { focusContent = true, focusAddress = false } = {}) {
   // but a deferred activation (the window-open setImmediate) can race the
   // event — never attach or focus a dead webContents.
   if (!liveContents(next)) return;
+
+  // A tab whose media first started while hidden stays silent until the user
+  // actually reveals it. This guard is separate from the persistent user mute.
+  if (revealTabAudio(next)) liveContents(next)?.setAudioMuted(effectiveTabMuted(next));
 
   // Re-selecting the active tab is a no-op.
   if (id === rt().activeTabId) return;

--- a/src/main/startup-urls.js
+++ b/src/main/startup-urls.js
@@ -12,4 +12,14 @@ function webUrlsFromArgv(argv) {
   );
 }
 
-module.exports = { webUrlsFromArgv };
+/** Open a multi-URL handoff without pretending every intermediate tab was
+ * selected by the user. All URLs load, but only the final one becomes active. */
+function externalUrlActivationPlan(urls) {
+  if (!Array.isArray(urls)) return [];
+  return urls.map((url, index) => ({
+    url,
+    activate: index === urls.length - 1,
+  }));
+}
+
+module.exports = { externalUrlActivationPlan, webUrlsFromArgv };

--- a/src/main/tab-audio.js
+++ b/src/main/tab-audio.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// User mute and the one-time background-autoplay guard are deliberately
+// separate. The guard suppresses media that starts for the first time while a
+// tab is hidden, but it must not paint the tab as user-muted or stop audio the
+// user already started before switching tabs.
+function effectiveTabMuted(tab) {
+  return !!(tab?.muted || tab?.backgroundAutoplayMuted);
+}
+
+function noteMediaStarted(tab, isActive) {
+  if (!tab) return false;
+  const shouldGuard = !tab.usedMedia && !isActive && !tab.muted;
+  tab.usedMedia = true;
+  if (shouldGuard) tab.backgroundAutoplayMuted = true;
+  return shouldGuard;
+}
+
+function revealTabAudio(tab) {
+  if (!tab?.backgroundAutoplayMuted) return false;
+  tab.backgroundAutoplayMuted = false;
+  return true;
+}
+
+module.exports = { effectiveTabMuted, noteMediaStarted, revealTabAudio };

--- a/src/main/tab-view.js
+++ b/src/main/tab-view.js
@@ -15,7 +15,12 @@ const history = require('./history');
 const sync = require('./sync');
 const { attachContextMenu } = require('./context-menu');
 const { webrtcPolicyFor } = require('./network-privacy');
-const { shouldClearFaviconOnNavigate } = require('./favicon-policy');
+const { effectiveTabMuted, noteMediaStarted } = require('./tab-audio');
+const {
+  shouldClearFaviconOnNavigate,
+  updateFaviconAfterDomReady,
+  updateFaviconFromPage,
+} = require('./favicon-policy');
 const { blockableHostname } = require('./adblock-exceptions');
 const { isForbiddenTopLevelUrl } = require('./top-level-url-policy');
 
@@ -77,7 +82,7 @@ function initTabView(injected) {
     'currentChromeLayout', 'hideOverlay', 'hasLiveWindow',
     'reclaimAddressBarFocus', 'shouldReclaimAddressBarFocus',
     'installChromeShortcuts', 'watchCursorFor',
-    'isUtilityUrl', 'handOffToOs', 'upgradeFavicon', 'setTabFavicon',
+    'isUtilityUrl', 'handOffToOs', 'setTabFavicon',
     'isStartupGateActive', 'startupQueuedNavigations',
     'onMainFrameCommit', 'noteWakeSuppressed', 'notePopupChild',
     'registerPopupCaptureSurface', 'clearTabCaptureState',
@@ -107,7 +112,7 @@ function wireTabView(tab, view, { owner, adopted }) {
     currentChromeLayout, hideOverlay, hasLiveWindow,
     reclaimAddressBarFocus, shouldReclaimAddressBarFocus,
     installChromeShortcuts, watchCursorFor,
-    isUtilityUrl, handOffToOs, upgradeFavicon, setTabFavicon,
+    isUtilityUrl, handOffToOs, setTabFavicon,
     isStartupGateActive, startupQueuedNavigations,
     onMainFrameCommit, noteWakeSuppressed, notePopupChild,
     registerPopupCaptureSurface, clearTabCaptureState,
@@ -121,7 +126,7 @@ function wireTabView(tab, view, { owner, adopted }) {
   watchCursorFor(wc, () => currentChromeLayout().pageBounds, boundToTab);
 
   wc.setWebRTCIPHandlingPolicy(webrtcPolicyFor(settings.getSettings().webrtcPolicy));
-  if (tab.muted) wc.setAudioMuted(true);
+  if (effectiveTabMuted(tab)) wc.setAudioMuted(true);
   const syncNavState = () => {
     tab.canGoBack = wc.navigationHistory.canGoBack();
     tab.canGoForward = wc.navigationHistory.canGoForward();
@@ -139,7 +144,7 @@ function wireTabView(tab, view, { owner, adopted }) {
   // main-frame commit clears the signal.
   wc.on('media-started-playing', boundToTab(() => {
     if (tab.sleeping || tab.view?.webContents !== wc) return;
-    tab.usedMedia = true;
+    if (noteMediaStarted(tab, id === owner.activeTabId)) wc.setAudioMuted(true);
   }));
   wc.on('page-title-updated', boundToTab((_e, title) => {
     if (tab.sleeping || tab.view?.webContents !== wc) return;
@@ -149,8 +154,17 @@ function wireTabView(tab, view, { owner, adopted }) {
   }));
   wc.on('page-favicon-updated', boundToTab((_e, favicons) => {
     if (tab.sleeping || tab.view?.webContents !== wc) return;
-    setTabFavicon(tab, favicons[0] ?? null);
-    upgradeFavicon(tab);
+    const pending = updateFaviconFromPage(tab, favicons, { setTabFavicon })
+      .catch(() => false);
+    tab.faviconPending = pending;
+    pending.finally(() => {
+      if (tab.faviconPending === pending) tab.faviconPending = null;
+    });
+  }));
+  wc.on('dom-ready', boundToTab(() => {
+    if (tab.sleeping || tab.view?.webContents !== wc) return;
+    updateFaviconAfterDomReady(tab, wc, { setTabFavicon })
+      .catch(() => {});
   }));
   wc.on('did-start-loading', boundToTab(() => {
     if (tab.sleeping || tab.view?.webContents !== wc) return;

--- a/test/desktop/README.md
+++ b/test/desktop/README.md
@@ -50,10 +50,23 @@ npm run test:acceptance:dry          # dry-run: verify every runnable step resol
 
 npm run test:acceptance:desktop      # execute the runnable scenarios against the app
 xvfb-run -a npm run test:acceptance:desktop   # ...on a headless Linux/CI box
+
+npm run test:packaged:regressions    # deterministic signed-build release regressions
+npm run test:packaged:favicons-live  # both pre-tag live favicon matrices (50 unique public sites)
+BLANC_FAVICON_MATRIX=primary npm run test:packaged:favicons-live    # original 25
+BLANC_FAVICON_MATRIX=additional npm run test:packaged:favicons-live # separate 25
 ```
 
 The desktop script is plain `cucumber-js` so it works on a dev machine with a
 display (macOS); prefix `xvfb-run -a` on headless Linux.
+
+The two favicon live matrices are intentionally not PR/CI checks because third-party
+availability is outside the repository's control. The fail-closed release
+script runs both non-overlapping 25-site sets against the signed packaged
+candidate before creating the immutable source tag, alongside the deterministic
+packaged regression smoke. Each matrix runs as five cold batches of five sites:
+enough concurrency to cover background-tab behavior without turning favicon
+compatibility into an unrelated 25-homepage resource-saturation test.
 
 Google OAuth browser-compatibility coverage is intentionally separate from the
 cross-platform product scenarios here. See [`test/oauth/`](../oauth/README.md)

--- a/test/desktop/packaged-live-favicons-smoke.mjs
+++ b/test/desktop/packaged-live-favicons-smoke.mjs
@@ -1,0 +1,223 @@
+// Pre-release live compatibility canary for Blanc's favicon pipeline. This is
+// deliberately separate from CI: it depends on third-party sites, but the
+// release script runs it against the signed packaged candidate before tagging.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { launchPackagedOverCdp } from './support/packaged-cdp.mjs';
+
+const defaultExecutable = process.platform === 'darwin'
+  ? path.resolve('dist/mac-arm64/Blanc.app/Contents/MacOS/Blanc')
+  : null;
+const executablePath = process.env.BLANC_PACKAGED_EXECUTABLE || defaultExecutable;
+if (!executablePath || !fs.existsSync(executablePath)) {
+  throw new Error(
+    'Packaged Blanc executable not found. Set BLANC_PACKAGED_EXECUTABLE or build dist/mac-arm64 first.'
+  );
+}
+
+// Two independent sets spanning gated touch icons, slow CDN assets, SVG,
+// classic ICO, multi-size PNG, and sites with same-origin redirects.
+const primarySites = [
+  { name: 'X', url: 'https://x.com/', host: 'x.com' },
+  { name: 'United', url: 'https://www.united.com/', host: 'united.com' },
+  { name: 'GitHub', url: 'https://github.com/', host: 'github.com' },
+  { name: 'Apple', url: 'https://www.apple.com/', host: 'apple.com' },
+  { name: 'Google', url: 'https://www.google.com/', host: 'google.com' },
+  { name: 'Wikipedia', url: 'https://www.wikipedia.org/', host: 'wikipedia.org' },
+  { name: 'Microsoft', url: 'https://www.microsoft.com/', host: 'microsoft.com' },
+  { name: 'CNN', url: 'https://www.cnn.com/', host: 'cnn.com' },
+  { name: 'Reddit', url: 'https://www.reddit.com/', host: 'reddit.com' },
+  { name: 'Amazon', url: 'https://www.amazon.com/', host: 'amazon.com' },
+  { name: 'YouTube', url: 'https://www.youtube.com/', host: 'youtube.com' },
+  { name: 'LinkedIn', url: 'https://www.linkedin.com/', host: 'linkedin.com' },
+  { name: 'Stack Overflow', url: 'https://stackoverflow.com/', host: 'stackoverflow.com' },
+  { name: 'npm', url: 'https://www.npmjs.com/', host: 'npmjs.com' },
+  { name: 'Mozilla', url: 'https://www.mozilla.org/', host: 'mozilla.org' },
+  { name: 'Cloudflare', url: 'https://www.cloudflare.com/', host: 'cloudflare.com' },
+  { name: 'Delta', url: 'https://www.delta.com/', host: 'delta.com' },
+  { name: 'Southwest', url: 'https://www.southwest.com/', host: 'southwest.com' },
+  { name: 'Walmart', url: 'https://www.walmart.com/', host: 'walmart.com' },
+  { name: 'eBay', url: 'https://www.ebay.com/', host: 'ebay.com' },
+  { name: 'BBC', url: 'https://www.bbc.com/', host: 'bbc.com' },
+  { name: 'New York Times', url: 'https://www.nytimes.com/', host: 'nytimes.com' },
+  { name: 'ESPN', url: 'https://www.espn.com/', host: 'espn.com' },
+  { name: 'DuckDuckGo', url: 'https://duckduckgo.com/', host: 'duckduckgo.com' },
+  { name: 'Stripe', url: 'https://stripe.com/', host: 'stripe.com' },
+];
+const additionalSites = [
+  { name: 'Facebook', url: 'https://www.facebook.com/', host: 'facebook.com' },
+  { name: 'Instagram', url: 'https://www.instagram.com/', host: 'instagram.com' },
+  { name: 'TikTok', url: 'https://www.tiktok.com/', host: 'tiktok.com' },
+  { name: 'Netflix', url: 'https://www.netflix.com/', host: 'netflix.com' },
+  { name: 'Adobe', url: 'https://www.adobe.com/', host: 'adobe.com' },
+  { name: 'Salesforce', url: 'https://www.salesforce.com/', host: 'salesforce.com' },
+  { name: 'Dropbox', url: 'https://www.dropbox.com/', host: 'dropbox.com' },
+  { name: 'Zoom', url: 'https://www.zoom.com/', host: 'zoom.com' },
+  { name: 'Slack', url: 'https://slack.com/', host: 'slack.com' },
+  { name: 'Discord', url: 'https://discord.com/', host: 'discord.com' },
+  { name: 'Twitch', url: 'https://www.twitch.tv/', host: 'twitch.tv' },
+  { name: 'Pinterest', url: 'https://www.pinterest.com/', host: 'pinterest.com' },
+  { name: 'PayPal', url: 'https://www.paypal.com/', host: 'paypal.com' },
+  { name: 'Shopify', url: 'https://www.shopify.com/', host: 'shopify.com' },
+  { name: 'Target', url: 'https://www.target.com/', host: 'target.com' },
+  { name: 'Best Buy', url: 'https://www.bestbuy.com/', host: 'bestbuy.com' },
+  { name: 'Home Depot', url: 'https://www.homedepot.com/', host: 'homedepot.com' },
+  { name: 'Costco', url: 'https://www.costco.com/', host: 'costco.com' },
+  { name: 'Uber', url: 'https://www.uber.com/', host: 'uber.com' },
+  { name: 'Airbnb', url: 'https://www.airbnb.com/', host: 'airbnb.com' },
+  { name: 'Booking.com', url: 'https://www.booking.com/', host: 'booking.com' },
+  { name: 'American Airlines', url: 'https://www.aa.com/', host: 'aa.com' },
+  { name: 'Marriott', url: 'https://www.marriott.com/', host: 'marriott.com' },
+  { name: 'The Guardian', url: 'https://www.theguardian.com/', host: 'theguardian.com' },
+  { name: 'Reuters', url: 'https://www.reuters.com/', host: 'reuters.com' },
+];
+const matrices = { primary: primarySites, additional: additionalSites };
+const allSites = [...primarySites, ...additionalSites];
+assert.equal(primarySites.length, 25);
+assert.equal(additionalSites.length, 25);
+assert.equal(new Set(allSites.map(({ name }) => name.toLowerCase())).size, 50, 'favicon matrix names must be unique');
+assert.equal(new Set(allSites.map(({ host }) => host)).size, 50, 'favicon matrix hosts must be unique');
+
+const matrixName = String(process.env.BLANC_FAVICON_MATRIX ?? '').trim().toLowerCase();
+if (matrixName && !matrices[matrixName]) {
+  throw new Error(`Unknown BLANC_FAVICON_MATRIX: ${matrixName}`);
+}
+const matrixSites = matrixName ? matrices[matrixName] : allSites;
+const requestedNames = new Set(
+  String(process.env.BLANC_FAVICON_SITES ?? '')
+    .split(',').map((name) => name.trim().toLowerCase()).filter(Boolean)
+);
+const sites = requestedNames.size
+  ? matrixSites.filter(({ name }) => requestedNames.has(name.toLowerCase()))
+  : matrixSites;
+if (sites.length === 0) {
+  throw new Error(`BLANC_FAVICON_SITES matched no sites: ${[...requestedNames].join(', ')}`);
+}
+
+const matchesHost = (url, host) => {
+  try {
+    const actual = new URL(url).hostname.toLowerCase().replace(/^www\./, '');
+    return actual === host || actual.endsWith(`.${host}`);
+  } catch {
+    return false;
+  }
+};
+
+const displayUrl = (url) => {
+  try {
+    const parsed = new URL(url);
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.href;
+  } catch {
+    return '<invalid URL>';
+  }
+};
+
+const BATCH_SIZE = 5;
+const batches = [];
+for (let index = 0; index < sites.length; index += BATCH_SIZE) {
+  batches.push(sites.slice(index, index + BATCH_SIZE));
+}
+
+const runBatch = async (batch, batchIndex) => {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-live-favicons-'));
+  fs.writeFileSync(path.join(userDataDir, 'settings.json'), JSON.stringify({
+    adblockEnabled: false,
+    onboardingVersion: 1,
+    searchSuggestions: false,
+    usagePing: false,
+  }, null, 2));
+
+  let app;
+  try {
+    app = await launchPackagedOverCdp({
+      executablePath,
+      args: [`--user-data-dir=${userDataDir}`, ...batch.map(({ url }) => url)],
+      env: { ...process.env, BLANC_TEST: '0' },
+    });
+
+    const readTabs = async () => {
+      const chrome = app.pages().find((page) => page.url() === 'blanc-chrome://index/');
+      return chrome ? chrome.evaluate(() => window.browserAPI.getAllTabs()) : null;
+    };
+    const deadline = Date.now() + 90_000;
+    const passedAt = new Map();
+    let state = null;
+    while (Date.now() < deadline && passedAt.size < batch.length) {
+      state = await readTabs();
+      for (const site of batch) {
+        const tab = state?.tabs?.find((candidate) => matchesHost(candidate.url, site.host));
+        if (tab?.favicon?.startsWith('data:image/png;base64,')) passedAt.set(site.name, tab);
+      }
+      if (passedAt.size < batch.length) await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+
+    const failures = await Promise.all(batch.filter(({ name }) => !passedAt.has(name)).map(async (site) => {
+      const tab = state?.tabs?.find((candidate) => matchesHost(candidate.url, site.host));
+      const page = app.pages().find((candidate) => matchesHost(candidate.url(), site.host));
+      const rawLinks = page ? await page.evaluate(() => [...document.querySelectorAll(
+        'link[rel~="icon"], link[rel~="apple-touch-icon"]'
+      )].slice(0, 20).map((link) => ({
+        href: link.href,
+        rel: link.rel,
+        sizes: link.getAttribute('sizes') || '',
+      }))) : [];
+      const links = rawLinks.map((link) => ({ ...link, href: displayUrl(link.href) }));
+      return {
+        name: site.name,
+        requested: site.url,
+        tab: tab ? {
+          title: tab.title,
+          url: displayUrl(tab.url),
+          isLoading: tab.isLoading,
+          audible: tab.audible,
+        } : null,
+        links,
+      };
+    }));
+    assert.deepEqual(
+      failures,
+      [],
+      `live favicon failures in batch ${batchIndex + 1}: ${JSON.stringify(failures)}`
+    );
+
+    // Let Chromium's audio-state notification settle after the last favicon,
+    // then prove that no hidden live-site can make sound during the batch.
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    state = await readTabs();
+    const hiddenAudible = (state?.tabs ?? [])
+      .filter((tab) => tab.id !== state.activeTabId && tab.audible)
+      .map((tab) => ({ title: tab.title, url: displayUrl(tab.url) }));
+    assert.deepEqual(
+      hiddenAudible,
+      [],
+      `background tabs remained audible in batch ${batchIndex + 1}: ${JSON.stringify(hiddenAudible)}`
+    );
+
+    return batch.map(({ name }) => {
+      const tab = passedAt.get(name);
+      const bytes = Buffer.from(tab.favicon.split(',')[1], 'base64');
+      assert.equal(bytes.subarray(1, 4).toString('ascii'), 'PNG', name);
+      assert.equal(bytes.readUInt32BE(16), 32, `${name} width`);
+      assert.equal(bytes.readUInt32BE(20), 32, `${name} height`);
+      assert.ok(bytes.length > 100, `${name} favicon should contain real pixels`);
+      return { name, finalUrl: displayUrl(tab.url), pngBytes: bytes.length };
+    });
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+};
+
+const proof = [];
+for (const [batchIndex, batch] of batches.entries()) {
+  proof.push(...await runBatch(batch, batchIndex));
+}
+console.log(JSON.stringify(proof, null, 2));
+console.log(
+  `packaged-live-favicons-smoke OK: ${matrixName || 'all'} matrix, ${sites.length} sites in ${batches.length} cold batches`
+);

--- a/test/desktop/release-regressions-smoke.mjs
+++ b/test/desktop/release-regressions-smoke.mjs
@@ -33,6 +33,7 @@ const server = http.createServer((request, response) => {
     response.end(`<!doctype html>
       <title>Favicon probe</title>
       <link rel="icon" type="image/png" href="https://blancbrowser.com/favicon-32x32.png">
+      <link rel="apple-touch-icon" sizes="192x192" href="https://blancbrowser.com/this-icon-does-not-exist-v1.2.3.png">
       <main>favicon probe</main>`);
     return;
   }
@@ -127,7 +128,7 @@ try {
       () => readTabState(app).then((state) =>
         state?.tabs?.find((tab) => tab.url === `${origin}/favicon`) ?? null),
       (tab) => tab?.favicon?.startsWith('data:image/png;base64,'),
-      'packaged candidate did not sanitize the live remote favicon into PNG bytes',
+      'packaged candidate discarded the working favicon after its sharper candidate failed',
       45_000
     );
     const faviconBytes = Buffer.from(faviconTab.favicon.split(',')[1], 'base64');

--- a/test/unit/favicon-network.test.js
+++ b/test/unit/favicon-network.test.js
@@ -2,7 +2,27 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { isPublicAddress, resolvePinnedTarget, pinnedLookup } = require('../../src/main/favicon-network');
+const {
+  FAVICON_REQUEST_HEADERS,
+  isPublicAddress,
+  redirectSource,
+  resolvePinnedTarget,
+  pinnedLookup,
+} = require('../../src/main/favicon-network');
+
+test('favicon redirects resolve relative locations and reject non-web targets', () => {
+  assert.equal(
+    redirectSource(
+      'https://stackoverflow.com/favicon.ico',
+      301,
+      '/Content/Sites/stackoverflow/Img/favicon.ico?v=562fb39d93c8',
+    ),
+    'https://stackoverflow.com/Content/Sites/stackoverflow/Img/favicon.ico?v=562fb39d93c8',
+  );
+  assert.equal(redirectSource('https://example.com/favicon.ico', 200, '/next.ico'), null);
+  assert.equal(redirectSource('https://example.com/favicon.ico', 302, 'file:///tmp/icon.png'), null);
+  assert.equal(redirectSource('https://example.com/favicon.ico', 302, 'http://user:pass@example.com/icon.png'), null);
+});
 
 test('favicon network policy rejects local, special-use, and documentation addresses', () => {
   for (const address of [
@@ -87,4 +107,13 @@ test('chrome and internal-page CSP never permit remote favicon loads', () => {
     const img = html.match(/img-src ([^;]+)/)?.[1] ?? '';
     assert.doesNotMatch(img, /https?:/, file);
   }
+});
+
+test('the isolated reader sends a generic browser identity without cookies or referrer', () => {
+  assert.match(
+    FAVICON_REQUEST_HEADERS['User-Agent'],
+    /^Mozilla\/5\.0 \(X11; Linux x86_64\) AppleWebKit\/537\.36 \(KHTML, like Gecko\) Chrome\/\d+\.0\.0\.0 Safari\/537\.36$/,
+  );
+  assert.equal('Cookie' in FAVICON_REQUEST_HEADERS, false);
+  assert.equal('Referer' in FAVICON_REQUEST_HEADERS, false);
 });

--- a/test/unit/favicon-policy.test.js
+++ b/test/unit/favicon-policy.test.js
@@ -1,14 +1,21 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { shouldClearFaviconOnNavigate } = require('../../src/main/favicon-policy');
+const {
+  pageFaviconSources,
+  declaredPageFavicons,
+  resolvedFavicon,
+  shouldClearFaviconOnNavigate,
+  updateFaviconAfterDomReady,
+  updateFaviconFromPage,
+} = require('../../src/main/favicon-policy');
 
 // Regression guard for the recurring "favicon vanishes in the island" bug.
 // Root cause: did-navigate blanked tab.favicon on every URL change and relied on
 // Chromium re-firing page-favicon-updated to restore it — but that event does
 // NOT re-fire on a same-origin navigation whose favicon is already known
-// (apple.com/ -> apple.com/mac/), and a favicon.ico-only site has nothing for
-// upgradeFavicon to restore. Clearing must therefore be cross-origin ONLY.
+// (apple.com/ -> apple.com/mac/), and a favicon.ico-only site may have no later
+// event to restore it. Clearing must therefore be cross-origin ONLY.
 
 test('keeps favicon on a same-origin path change (the apple.com/mac regression)', () => {
   assert.equal(shouldClearFaviconOnNavigate('https://www.apple.com/', 'https://www.apple.com/mac/'), false);
@@ -34,6 +41,155 @@ test('clears favicon on a cross-subdomain navigation (different origin)', () => 
 
 test('clears favicon on a scheme change to the same host', () => {
   assert.equal(shouldClearFaviconOnNavigate('http://example.com/', 'https://example.com/'), true);
+});
+
+test('keeps the working icon when a sharper page candidate fails sanitization', () => {
+  const working = 'data:image/png;base64,working';
+  assert.equal(
+    resolvedFavicon(working, 'https://x.com/apple-touch-icon.png', null),
+    working
+  );
+  assert.equal(
+    resolvedFavicon(null, 'https://x.com/apple-touch-icon.png', null),
+    null
+  );
+  assert.equal(
+    resolvedFavicon(working, 'https://x.com/apple-touch-icon.png', 'data:image/png;base64,sharp'),
+    'data:image/png;base64,sharp'
+  );
+  assert.equal(resolvedFavicon(working, null, null), null, 'an explicit clear still clears');
+});
+
+test('uses Chromium order and appends one conventional same-origin fallback', () => {
+  assert.deepEqual(
+    pageFaviconSources('https://www.united.com/en/us', [
+      'https://www.united.com/icons/icon-72x72.png',
+      'https://www.united.com/icons/icon-72x72.png',
+      'javascript:alert(1)',
+    ]),
+    [
+      'https://www.united.com/icons/icon-72x72.png',
+      'https://www.united.com/favicon.ico',
+    ]
+  );
+});
+
+test('tries candidates in order until one produces sanitized pixels', async () => {
+  const tab = { id: 'united', url: 'https://www.united.com/en/us', favicon: null };
+  const calls = [];
+  await updateFaviconFromPage(
+    tab,
+    ['https://www.united.com/icons/icon-72x72.png'],
+    {
+      setTabFavicon: async (record, source) => {
+        calls.push(source);
+        if (source.endsWith('/favicon.ico')) {
+          record.faviconSource = source;
+          record.favicon = 'data:image/png;base64,working';
+        }
+        return true;
+      },
+    }
+  );
+  assert.deepEqual(calls, [
+    'https://www.united.com/icons/icon-72x72.png',
+    'https://www.united.com/favicon.ico',
+  ]);
+});
+
+test('a superseded page event stops before trying another candidate', async () => {
+  const calls = [];
+  await updateFaviconFromPage(
+    { id: 'x', url: 'https://x.com/', favicon: null },
+    ['https://x.com/favicon.ico'],
+    { setTabFavicon: async (_tab, source) => { calls.push(source); return false; } }
+  );
+  assert.deepEqual(calls, ['https://x.com/favicon.ico']);
+});
+
+test('document-ready supplies the declared favicon when Chromium emitted no icon event', async () => {
+  const tab = { id: 'stack-overflow', url: 'https://stackoverflow.com/questions', favicon: null };
+  const calls = [];
+  await updateFaviconAfterDomReady(tab, {
+    executeJavaScript: async () => [
+      'https://stackoverflow.com/Content/Sites/stackoverflow/Img/favicon.ico?v=562fb39d93c8',
+    ],
+  }, {
+    setTabFavicon: async (record, source) => {
+      calls.push(source);
+      record.faviconSource = source;
+      record.favicon = 'data:image/png;base64,working';
+      return true;
+    },
+  });
+  assert.deepEqual(calls, [
+    'https://stackoverflow.com/Content/Sites/stackoverflow/Img/favicon.ico?v=562fb39d93c8',
+  ]);
+});
+
+test('declared page favicon fallback is bounded and failure-safe', async () => {
+  assert.deepEqual(await declaredPageFavicons({ executeJavaScript: async () => ['https://example.com/icon.png'] }), [
+    'https://example.com/icon.png',
+  ]);
+  const bounded = await declaredPageFavicons({
+    executeJavaScript: async () => Array(30).fill('https://example.com/icon.png'),
+  });
+  assert.equal(bounded.length, 20);
+  assert.deepEqual(await declaredPageFavicons({ executeJavaScript: async () => { throw new Error('gone'); } }), []);
+});
+
+test('document-ready discards icon links if the tab navigates during the query', async () => {
+  const tab = { url: 'https://old.example/', favicon: null, faviconSource: null };
+  let calls = 0;
+  const result = await updateFaviconAfterDomReady(tab, {
+    executeJavaScript: async () => {
+      tab.url = 'https://new.example/';
+      return ['https://old.example/favicon.ico'];
+    },
+  }, { setTabFavicon: async () => { calls++; } });
+  assert.equal(result, false);
+  assert.equal(calls, 0);
+});
+
+test('document-ready does not compete with a working or in-flight favicon event', async () => {
+  let calls = 0;
+  const deps = { setTabFavicon: async () => { calls++; } };
+  const webContents = { executeJavaScript: async () => [] };
+  assert.equal(await updateFaviconAfterDomReady({
+    url: 'https://example.com/',
+    favicon: 'data:image/png;base64,working',
+    faviconSource: 'https://example.com/icon.png',
+  }, webContents, deps), false);
+  assert.equal(await updateFaviconAfterDomReady({
+    url: 'https://example.com/',
+    favicon: null,
+    faviconSource: 'https://example.com/icon.png',
+  }, webContents, deps), false);
+  assert.equal(calls, 0);
+});
+
+test('document-ready retries declared links after an in-flight page event fails', async () => {
+  const tab = {
+    url: 'https://example.com/',
+    favicon: null,
+    faviconSource: 'https://example.com/first.ico',
+  };
+  tab.faviconPending = Promise.resolve().then(() => {
+    tab.faviconSource = null;
+    return false;
+  });
+  const calls = [];
+  await updateFaviconAfterDomReady(tab, {
+    executeJavaScript: async () => ['https://example.com/retry.ico'],
+  }, {
+    setTabFavicon: async (record, source) => {
+      calls.push(source);
+      record.favicon = 'data:image/png;base64,working';
+      record.faviconSource = source;
+      return true;
+    },
+  });
+  assert.deepEqual(calls, ['https://example.com/retry.ico']);
 });
 
 test('clears when leaving or entering an internal blanc:// page', () => {

--- a/test/unit/favicon-sanitizer-cache.test.js
+++ b/test/unit/favicon-sanitizer-cache.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const LEGACY_PNG_DATA = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGElEQVR42mNgGAWjYBSMglEwCkbBqAABBgAE/wABeV0FzgAAAABJRU5ErkJggg==';
@@ -29,7 +31,11 @@ require.cache[networkId] = {
   filename: networkId,
   loaded: true,
   exports: {
-    readIconBytes: async () => {
+    readIconBytes: async (source) => {
+      if (source.includes('mislabeled')) {
+        return { contentType: 'image/x-icon', bytes: pngBytes };
+      }
+      if (source.includes('browser-fallback') || source.includes('cross-origin')) return null;
       attempts += 1;
       return attempts === 1 ? null : { contentType: 'image/png', bytes: pngBytes };
     },
@@ -48,13 +54,85 @@ test('a transient favicon failure is not cached for the process lifetime', async
 
 test('private-tab sanitization never starts a remote favicon request', async () => {
   const before = attempts;
+  let browserFetches = 0;
   assert.equal(
     await sanitizeFavicon(
       'https://private-icons.example/favicon.png',
       undefined,
-      { allowNetwork: false }
+      {
+        allowNetwork: false,
+        pageUrl: 'https://private-icons.example/',
+        browsingSession: { fetch: async () => { browserFetches++; } },
+      }
     ),
     null
   );
   assert.equal(attempts, before);
+  assert.equal(browserFetches, 0);
+});
+
+test('PNG signature wins when a server mislabels PNG bytes as an ICO', async () => {
+  assert.equal(
+    await sanitizeFavicon('https://www.gstatic.example/mislabeled-favicon.ico'),
+    PNG_DATA
+  );
+});
+
+const response = ({ status, url, contentType, location, bytes = pngBytes }) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  url,
+  headers: {
+    get: (name) => ({
+      'content-length': String(bytes.length),
+      'content-type': contentType,
+      location,
+    })[name] ?? null,
+  },
+  arrayBuffer: async () => Uint8Array.from(bytes).buffer,
+});
+
+test('same-origin browser fallback fetches the exact candidate without cookies or referrer', async () => {
+  const requests = [];
+  const browsingSession = {
+    fetch: async (url, options) => {
+      requests.push({ url, options });
+      return response({ status: 200, url, contentType: 'image/png' });
+    },
+  };
+  assert.equal(await sanitizeFavicon(
+    'https://browser-fallback.example/favicon.ico',
+    undefined,
+    { browsingSession, pageUrl: 'https://browser-fallback.example/questions' },
+  ), PNG_DATA);
+  assert.deepEqual(requests.map(({ url }) => url), ['https://browser-fallback.example/favicon.ico']);
+  for (const { options } of requests) {
+    assert.equal(options.credentials, 'omit');
+    assert.equal(options.referrerPolicy, 'no-referrer');
+    assert.equal(options.redirect, 'error');
+  }
+});
+
+test('browser fallback refuses a cross-origin candidate before requesting it', async () => {
+  const requests = [];
+  const browsingSession = {
+    fetch: async (url) => {
+      requests.push(url);
+      return response({ status: 200, url, contentType: 'image/png' });
+    },
+  };
+  assert.equal(await sanitizeFavicon(
+    'https://cdn.cross-origin.example/favicon.ico',
+    undefined,
+    { browsingSession, pageUrl: 'https://cross-origin.example/' },
+  ), null);
+  assert.deepEqual(requests, []);
+});
+
+test('main supplies only the current tab session to the same-origin fallback', () => {
+  const main = fs.readFileSync(path.join(__dirname, '../../src/main/main.js'), 'utf8');
+  const setter = main.match(/async function setTabFavicon\(tab, source\) \{[\s\S]*?\n\}/)?.[0];
+  assert.ok(setter, 'setTabFavicon not found in main.js');
+  assert.match(setter, /browsingSession:/);
+  assert.match(setter, /pageUrl: tab\.url/);
 });

--- a/test/unit/startup-urls.test.js
+++ b/test/unit/startup-urls.test.js
@@ -2,7 +2,10 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { webUrlsFromArgv } = require('../../src/main/startup-urls');
+const {
+  externalUrlActivationPlan,
+  webUrlsFromArgv,
+} = require('../../src/main/startup-urls');
 
 test('startup handoff accepts only explicit HTTP(S) URLs', () => {
   assert.deepEqual(webUrlsFromArgv([
@@ -26,4 +29,15 @@ test('startup handoff accepts only explicit HTTP(S) URLs', () => {
 test('startup handoff rejects malformed input without throwing', () => {
   assert.deepEqual(webUrlsFromArgv(null), []);
   assert.deepEqual(webUrlsFromArgv([null, 4, {}, '']), []);
+});
+
+test('multi-URL handoff loads every tab but activates only the final one', () => {
+  assert.deepEqual(externalUrlActivationPlan(['https://a.test/', 'https://b.test/']), [
+    { url: 'https://a.test/', activate: false },
+    { url: 'https://b.test/', activate: true },
+  ]);
+  assert.deepEqual(externalUrlActivationPlan(['https://only.test/']), [
+    { url: 'https://only.test/', activate: true },
+  ]);
+  assert.deepEqual(externalUrlActivationPlan(null), []);
 });

--- a/test/unit/tab-audio.test.js
+++ b/test/unit/tab-audio.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  effectiveTabMuted,
+  noteMediaStarted,
+  revealTabAudio,
+} = require('../../src/main/tab-audio');
+
+test('first media start in a background tab is guarded until that tab is revealed', () => {
+  const tab = { muted: false, usedMedia: false, backgroundAutoplayMuted: false };
+  assert.equal(noteMediaStarted(tab, false), true);
+  assert.equal(tab.usedMedia, true);
+  assert.equal(effectiveTabMuted(tab), true);
+  assert.equal(revealTabAudio(tab), true);
+  assert.equal(effectiveTabMuted(tab), false);
+});
+
+test('media started in the foreground keeps playing after a tab switch', () => {
+  const tab = { muted: false, usedMedia: false, backgroundAutoplayMuted: false };
+  assert.equal(noteMediaStarted(tab, true), false);
+  assert.equal(effectiveTabMuted(tab), false);
+  assert.equal(noteMediaStarted(tab, false), false, 'the user already visited a playing tab');
+  assert.equal(effectiveTabMuted(tab), false);
+});
+
+test('background autoplay guard never overrides an explicit user mute', () => {
+  const tab = { muted: true, usedMedia: false, backgroundAutoplayMuted: false };
+  assert.equal(noteMediaStarted(tab, false), false);
+  assert.equal(effectiveTabMuted(tab), true);
+  assert.equal(revealTabAudio(tab), false);
+  assert.equal(effectiveTabMuted(tab), true);
+});
+
+test('the temporary guard is derived into audible state but never projected as mutable state', () => {
+  const source = require('node:fs').readFileSync(
+    require('node:path').join(__dirname, '../../src/main/main.js'),
+    'utf8'
+  );
+  const serializeBody = source.slice(
+    source.indexOf('function serializeTabs()'),
+    source.indexOf('\nfunction activeShieldPopover')
+  );
+  assert.match(serializeBody, /audible: tab\.audible && !\(tab\.muted \|\| tab\.backgroundAutoplayMuted\)/);
+  assert.doesNotMatch(serializeBody, /backgroundAutoplayMuted\s*:/);
+});

--- a/test/unit/tab-view.test.js
+++ b/test/unit/tab-view.test.js
@@ -120,6 +120,10 @@ test('wireTabView is still present in tab-view.js', () => {
   assert.ok(wireSource, 'wireTabView not found in tab-view.js — update this test with it');
 });
 
+test('document-ready has a favicon fallback when Chromium emits no favicon event', () => {
+  assert.match(wireSource, /wc\.on\('dom-ready',[\s\S]*?updateFaviconAfterDomReady/);
+});
+
 for (const required of [
   'installChromeShortcuts',
   'watchCursorFor',

--- a/test/unit/tabicons.test.js
+++ b/test/unit/tabicons.test.js
@@ -88,6 +88,28 @@ test('capture rasterizes on the source device without cookies or a referrer', as
   }]);
 });
 
+test('a sanitized live fallback enters the synced sidecar without another network fetch', async () => {
+  let fetched = false;
+  const tab = {
+    url: 'https://fallback-page.example/',
+    favicon: PNG_DATA,
+    private: false,
+    view: {
+      webContents: {
+        session: { fetch: async () => { fetched = true; throw new Error('unexpected fetch'); } },
+      },
+    },
+  };
+  tabicons.setSnapshotProvider(() => ({ tabList: [tab] }));
+
+  assert.equal(await tabicons.captureTab(tab, ctx), true);
+  assert.equal(fetched, false, 'main already supplied inert PNG pixels');
+  assert.deepEqual(
+    tabicons.exportForSync(ctx).devices['device-a'].icons.find(({ url }) => url === tab.url),
+    { url: tab.url, data: PNG_DATA }
+  );
+});
+
 test('capture rejects non-image responses before decoding or serializing them', async () => {
   const before = decodeCount;
   const tab = {


### PR DESCRIPTION
## What changed

- use page favicon URLs in their declared order and keep already-sanitized pixels when a later candidate fails
- add the conventional same-origin favicon and a DOM-ready retry for pages where Chromium omits or races the favicon event
- make the pinned favicon client follow bounded, policy-checked redirects with a browser-shaped, cookie-free request
- recognize valid PNG bytes even when a server labels them as ICO, with a bounded same-origin Electron-session fallback for CDN/TLS compatibility
- suppress media that first starts in a hidden tab until that tab is revealed
- load multi-URL startup handoffs without transiently activating every intermediate tab
- add two non-overlapping 25-site signed-package favicon matrices to the pre-tag release gate

## Root cause

The 1.2.2 path treated favicon selection as a sharpness upgrade. A working icon could be replaced by a later touch asset that timed out or returned 403, leaving a gray box. The hardened Node fetcher also lacked redirect support and a browser-shaped identity, mishandled PNG bytes mislabeled as `image/x-icon`, and could not pass some same-origin CDN/TLS challenges.

The live matrix also exposed hidden TikTok/Twitch media. Multi-URL startup briefly made each new tab active, so background autoplay looked like foreground media and escaped suppression.

## Impact

X, United, Microsoft, Google, Wikipedia, Stack Overflow, and the additional CDN-heavy sites now produce sanitized 32×32 PNGs in the signed candidate. Synced icons still receive only the existing sanitized PNG sidecar; no sync/session favicon schema changed. Hidden first-start media is temporarily silenced without changing the user's persistent mute choice, and foreground-started media continues normally.

## Verification

- signed `npm run dist:dir`; app passes the designated requirement and after-sign verification
- primary live matrix: 25/25 sites
- additional live matrix: 25/25 completely different sites
- packaged deterministic favicon + microphone regressions
- `npm run test:unit`: 710/710
- `npm run substrate:check`
- `npm run test:acceptance:dry`: 92 scenarios / 560 steps resolve
