### PR TITLE
Release Blanc 1.2.3

### DIFF
--- a/docs/press/release-notes/v1.2.3.md
+++ b/docs/press/release-notes/v1.2.3.md
@@ -1,0 +1,15 @@
+# Blanc 1.2.3
+
+## Fixed
+
+- Website icons now load reliably across a much broader range of sites, including pages whose icon redirects, CDN behavior, request requirements, or mislabeled image types previously left a gray placeholder. Blanc keeps a working icon when a later candidate fails and still checks every resolved address before connecting.
+- Synced tab icons continue to use the sanitized pixels captured by the source device. Receiving devices do not contact the website again, and this release does not change the synced-icon format.
+- Tabs opened in the background as part of a multi-link handoff can no longer start playing sound unexpectedly. Media that first starts while a tab is hidden stays silent until you reveal that tab; media you started in the foreground continues normally when you switch away.
+
+## Release verification
+
+Blanc now checks two non-overlapping 25-site favicon matrices against the signed packaged candidate before creating an immutable release tag.
+
+## Other platforms
+
+All three platforms are built from the same `v1.2.3` source tag and published with one SHA-256 manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -6,7 +6,7 @@ import MemoryChart from '../components/MemoryChart.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 import releaseData from '../data/releases.json';
 
-const VERSION = '1.2.2';
+const VERSION = '1.2.3';
 const TAG = `v${VERSION}`;
 /* Wherever this page states a version and a date together, the date is that
    version's own ship date — read from the generated changelog data rather than

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.2.2');
+  assert.equal(packageVersion, '1.2.3');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
## Release

Prepare Blanc 1.2.3 from the favicon compatibility and background-autoplay fixes merged in #135.

## Changes

- bump `package.json` and the lockfile to 1.2.3
- pin the public press surface to 1.2.3
- add checked-in 1.2.3 release notes
- keep Electron at 43.4.0, which is still the current published stable

## Verification

- `npm run test:unit`: 710/710
- `npm run site:build`
- the signed 1.2.3 publisher will rerun the full press gate, signed packaged regressions, both 25-site favicon matrices, migration from 1.2.2, native platform builds, manifest verification, and smoke downloads before publication
