### PR TITLE
Preserve high-quality website favicons

### DIFF
--- a/src/main/favicon-policy.js
+++ b/src/main/favicon-policy.js
@@ -101,43 +101,131 @@ async function updateFaviconFromPage(
   return true;
 }
 
-/** Read only the page's declared icon URLs, in document order. This is a
- * compatibility fallback for pages where Chromium never emits its event; it
- * deliberately does no size ranking or touch-icon guessing. */
-async function declaredPageFavicons(webContents) {
+function declaredFaviconCandidate(raw) {
+  const candidate = typeof raw === 'string' ? { href: raw, rel: 'icon' } : raw;
+  if (!candidate || typeof candidate.href !== 'string' || candidate.href.length > 2048) return null;
+  if (!/^(https?:|data:image\/)/i.test(candidate.href)) return null;
+  return {
+    href: candidate.href,
+    rel: typeof candidate.rel === 'string' ? candidate.rel.slice(0, 100) : '',
+    sizes: typeof candidate.sizes === 'string' ? candidate.sizes.slice(0, 100) : '',
+    type: typeof candidate.type === 'string' ? candidate.type.slice(0, 100).toLowerCase() : '',
+  };
+}
+
+function declaredFaviconSize(sizes) {
+  let largest = 0;
+  for (const match of String(sizes).matchAll(/(\d+)[x×](\d+)/gi)) {
+    const width = Number(match[1]);
+    const height = Number(match[2]);
+    if (width === height && width > largest) largest = width;
+  }
+  return largest;
+}
+
+/** Prefer an explicit vector, then a regular icon with enough source pixels
+ * for the 32px Retina raster. Document order breaks equal-quality ties. The
+ * generic `sizes="any"` hint is not proof that an ICO is scalable — Blanc's
+ * own site exposed exactly that mistake — so only an SVG URL/MIME earns the
+ * vector score. */
+function pickBestDeclaredFavicon(rawCandidates) {
+  let best = null;
+  let bestScore = -1;
+  for (const raw of Array.isArray(rawCandidates) ? rawCandidates.slice(0, 20) : []) {
+    const candidate = declaredFaviconCandidate(raw);
+    if (!candidate) continue;
+    const vector = candidate.type === 'image/svg+xml' ||
+      /(?:\.svg(?:[?#]|$)|^data:image\/svg\+xml[;,])/i.test(candidate.href);
+    const size = declaredFaviconSize(candidate.sizes);
+    const appleTouch = /(?:^|\s)apple-touch-icon(?:\s|$)/i.test(candidate.rel);
+    let score;
+    if (vector) score = 1_000_000;
+    else if (size >= 32) score = 100_000 + (10_000 - Math.abs(size - 64)) - (appleTouch ? 500 : 0);
+    else if (size > 0) score = size;
+    else if (candidate.type === 'image/png' || /\.png(?:[?#]|$)/i.test(candidate.href)) score = 1_000;
+    else if (/\.ico(?:[?#]|$)/i.test(candidate.href)) score = 100;
+    else score = 500;
+    if (score > bestScore) {
+      best = candidate.href;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+/** Read the page's bounded declared icon metadata. This powers both the
+ * no-event availability fallback and a later quality refinement. */
+async function declaredPageFaviconCandidates(webContents) {
   try {
-    const sources = await webContents.executeJavaScript(`
-      Array.from(document.querySelectorAll('link[rel~="icon"]'))
+    const candidates = await webContents.executeJavaScript(`
+      Array.from(document.querySelectorAll('link[rel~="icon"], link[rel~="apple-touch-icon"]'))
         .slice(0, 20)
-        .map((link) => link.href)
+        .map((link) => ({
+          href: link.href,
+          rel: link.rel,
+          sizes: link.getAttribute('sizes') || '',
+          type: link.getAttribute('type') || ''
+        }))
     `, true);
-    return Array.isArray(sources) ? sources.slice(0, 20) : [];
+    return Array.isArray(candidates)
+      ? candidates.slice(0, 20).map(declaredFaviconCandidate).filter(Boolean)
+      : [];
   } catch {
     return [];
   }
 }
 
-/** Some long-running pages never make Chromium emit page-favicon-updated.
- * At DOM readiness, use their declared icons when no event has already
- * supplied pixels or started an attempt. */
+/** Read only ordinary `rel=icon` URLs, in document order, for callers that
+ * need the availability list rather than touch-icon quality metadata. */
+async function declaredPageFavicons(webContents) {
+  const candidates = await declaredPageFaviconCandidates(webContents);
+  return candidates
+    .filter(({ rel }) => /(?:^|\s)icon(?:\s|$)/i.test(rel))
+    .map(({ href }) => href);
+}
+
+/** At DOM readiness, fill pages whose Chromium event never arrived and refine
+ * an already-working low-resolution choice. Availability remains fail-safe:
+ * the best declared candidate is tried first, then original document order,
+ * while setTabFavicon preserves existing pixels when an upgrade fails. */
 async function updateFaviconAfterDomReady(tab, webContents, deps) {
-  if (!tab || tab.favicon) return false;
+  if (!tab) return false;
   // Chromium can emit page-favicon-updated just before dom-ready. Let that
   // bounded attempt finish; if transient load pressure made it fail, the
   // declared-link path below becomes one clean retry instead of standing down
   // forever because faviconSource happened to be non-null at this instant.
   const pending = tab.faviconPending;
   if (pending) await pending.catch(() => false);
-  if (tab.favicon || tab.faviconSource) return false;
+  // A source with no pixels and no tracked promise is still an in-flight or
+  // externally-owned attempt. Do not compete with it.
+  if (!tab.favicon && tab.faviconSource) return false;
   const urlAtStart = tab.url;
-  const favicons = await declaredPageFavicons(webContents);
-  if (tab.url !== urlAtStart || tab.favicon || tab.faviconSource) return false;
+  const faviconAtStart = tab.favicon;
+  const sourceAtStart = tab.faviconSource ?? null;
+  const candidates = await declaredPageFaviconCandidates(webContents);
+  if (
+    tab.url !== urlAtStart ||
+    tab.favicon !== faviconAtStart ||
+    (tab.faviconSource ?? null) !== sourceAtStart
+  ) return false;
+  if (tab.favicon) {
+    const best = pickBestDeclaredFavicon(candidates);
+    if (!best || best === tab.faviconSource) return false;
+    return deps.setTabFavicon(tab, best);
+  }
+  const preferred = pickBestDeclaredFavicon(candidates);
+  const favicons = candidates
+    .filter(({ rel }) => /(?:^|\s)icon(?:\s|$)/i.test(rel))
+    .map(({ href }) => href);
+  if (preferred) favicons.unshift(preferred);
   return updateFaviconFromPage(tab, favicons, deps);
 }
 
 module.exports = {
+  declaredPageFaviconCandidates,
   declaredPageFavicons,
   pageFaviconSources,
+  pickBestDeclaredFavicon,
   resolvedFavicon,
   shouldClearFaviconOnNavigate,
   updateFaviconAfterDomReady,

--- a/src/main/favicon-policy.js
+++ b/src/main/favicon-policy.js
@@ -129,18 +129,25 @@ function declaredFaviconSize(sizes) {
  * own site exposed exactly that mistake — so only an SVG URL/MIME earns the
  * vector score. */
 function pickBestDeclaredFavicon(rawCandidates) {
+  const candidates = (Array.isArray(rawCandidates) ? rawCandidates.slice(0, 20) : [])
+    .map(declaredFaviconCandidate)
+    .filter(Boolean);
+  // Apple touch icons are home-screen artwork and frequently have a different
+  // crop or background from the site's desktop mark. They remain a useful
+  // availability fallback, but must never displace an ordinary rel=icon.
+  const ordinary = candidates.filter(({ rel }) => !rel || /(?:^|\s)icon(?:\s|$)/i.test(rel));
+  const eligible = ordinary.length
+    ? ordinary
+    : candidates.filter(({ rel }) => /(?:^|\s)apple-touch-icon(?:\s|$)/i.test(rel));
   let best = null;
   let bestScore = -1;
-  for (const raw of Array.isArray(rawCandidates) ? rawCandidates.slice(0, 20) : []) {
-    const candidate = declaredFaviconCandidate(raw);
-    if (!candidate) continue;
+  for (const candidate of eligible) {
     const vector = candidate.type === 'image/svg+xml' ||
       /(?:\.svg(?:[?#]|$)|^data:image\/svg\+xml[;,])/i.test(candidate.href);
     const size = declaredFaviconSize(candidate.sizes);
-    const appleTouch = /(?:^|\s)apple-touch-icon(?:\s|$)/i.test(candidate.rel);
     let score;
     if (vector) score = 1_000_000;
-    else if (size >= 32) score = 100_000 + (10_000 - Math.abs(size - 64)) - (appleTouch ? 500 : 0);
+    else if (size >= 32) score = 100_000 + (10_000 - Math.abs(size - 64));
     else if (size > 0) score = size;
     else if (candidate.type === 'image/png' || /\.png(?:[?#]|$)/i.test(candidate.href)) score = 1_000;
     else if (/\.ico(?:[?#]|$)/i.test(candidate.href)) score = 100;

--- a/src/main/tab-view.js
+++ b/src/main/tab-view.js
@@ -154,6 +154,11 @@ function wireTabView(tab, view, { owner, adopted }) {
   }));
   wc.on('page-favicon-updated', boundToTab((_e, favicons) => {
     if (tab.sleeping || tab.view?.webContents !== wc) return;
+    // During the initial load, Chromium can report its default ICO after the
+    // document-ready SVG refinement. Once loading has stopped, however, a
+    // favicon event is page-owned live state (for example an unread badge) and
+    // must win rather than being reset to the document's original declaration.
+    const refineInitialFavicon = tab.isLoading;
     const pending = updateFaviconFromPage(tab, favicons, { setTabFavicon })
       .catch(() => false);
     tab.faviconPending = pending;
@@ -161,9 +166,10 @@ function wireTabView(tab, view, { owner, adopted }) {
       if (tab.faviconPending !== pending) return;
       tab.faviconPending = null;
       if (tab.sleeping || tab.view?.webContents !== wc) return;
-      // DOM readiness can precede Chromium's favicon event. If that late event
-      // superseded an SVG/Retina refinement with its smaller default choice,
-      // run the declared quality pass once more after the event settles.
+      if (!refineInitialFavicon) return;
+      // DOM readiness can precede Chromium's initial favicon event. If that
+      // event superseded an SVG/Retina refinement with a smaller default
+      // choice, run the declared quality pass once more after it settles.
       updateFaviconAfterDomReady(tab, wc, { setTabFavicon })
         .catch(() => {});
     });

--- a/src/main/tab-view.js
+++ b/src/main/tab-view.js
@@ -158,7 +158,14 @@ function wireTabView(tab, view, { owner, adopted }) {
       .catch(() => false);
     tab.faviconPending = pending;
     pending.finally(() => {
-      if (tab.faviconPending === pending) tab.faviconPending = null;
+      if (tab.faviconPending !== pending) return;
+      tab.faviconPending = null;
+      if (tab.sleeping || tab.view?.webContents !== wc) return;
+      // DOM readiness can precede Chromium's favicon event. If that late event
+      // superseded an SVG/Retina refinement with its smaller default choice,
+      // run the declared quality pass once more after the event settles.
+      updateFaviconAfterDomReady(tab, wc, { setTabFavicon })
+        .catch(() => {});
     });
   }));
   wc.on('dom-ready', boundToTab(() => {

--- a/test/desktop/packaged-live-favicons-smoke.mjs
+++ b/test/desktop/packaged-live-favicons-smoke.mjs
@@ -90,10 +90,11 @@ const requestedNames = new Set(
   String(process.env.BLANC_FAVICON_SITES ?? '')
     .split(',').map((name) => name.trim().toLowerCase()).filter(Boolean)
 );
-const sites = requestedNames.size
+const brandOnly = process.env.BLANC_FAVICON_BRAND_ONLY === '1';
+const sites = brandOnly ? [] : requestedNames.size
   ? matrixSites.filter(({ name }) => requestedNames.has(name.toLowerCase()))
   : matrixSites;
-if (sites.length === 0) {
+if (sites.length === 0 && !brandOnly) {
   throw new Error(`BLANC_FAVICON_SITES matched no sites: ${[...requestedNames].join(', ')}`);
 }
 
@@ -213,11 +214,74 @@ const runBatch = async (batch, batchIndex) => {
   }
 };
 
+// Availability alone is not enough for Blanc's own mark: the site declares a
+// small multi-frame ICO before its SVG, which is the exact ordering that made
+// 1.2.3 stop at soft, upscaled pixels. Compare the chrome payload with a fresh
+// Chromium raster of the declared vector so this first-party quality contract
+// stays deterministic even if the PNG encoder changes in a future Electron.
+const runBrandQualityCanary = async () => {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-brand-favicon-'));
+  fs.writeFileSync(path.join(userDataDir, 'settings.json'), JSON.stringify({
+    adblockEnabled: false,
+    onboardingVersion: 1,
+    searchSuggestions: false,
+    usagePing: false,
+  }, null, 2));
+
+  let app;
+  try {
+    app = await launchPackagedOverCdp({
+      executablePath,
+      args: [`--user-data-dir=${userDataDir}`, 'https://blancbrowser.com/changelog'],
+      env: { ...process.env, BLANC_TEST: '0' },
+    });
+    const deadline = Date.now() + 30_000;
+    let expected = null;
+    let actual = null;
+    let matched = false;
+    while (Date.now() < deadline && !matched) {
+      const page = app.pages().find((candidate) => matchesHost(candidate.url(), 'blancbrowser.com'));
+      const chrome = app.pages().find((candidate) => candidate.url() === 'blanc-chrome://index/');
+      if (page && !expected) {
+        expected = await page.evaluate(() => new Promise((resolve) => {
+          const img = new Image();
+          img.onload = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = 32;
+            canvas.height = 32;
+            canvas.getContext('2d').drawImage(img, 0, 0, 32, 32);
+            resolve(canvas.toDataURL('image/png'));
+          };
+          img.onerror = () => resolve(null);
+          img.src = '/favicon.svg';
+        }));
+      }
+      const state = chrome ? await chrome.evaluate(() => window.browserAPI.getAllTabs()) : null;
+      actual = state?.tabs?.find((tab) => matchesHost(tab.url, 'blancbrowser.com'))?.favicon ?? null;
+      matched = !!expected && actual === expected;
+      if (!matched) await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    assert.ok(expected?.startsWith('data:image/png;base64,'), 'Blanc SVG should rasterize in Chromium');
+    assert.equal(actual, expected, 'Blanc chrome favicon must use the declared SVG pixels');
+    const bytes = Buffer.from(actual.split(',')[1], 'base64');
+    assert.equal(bytes.readUInt32BE(16), 32, 'Blanc favicon width');
+    assert.equal(bytes.readUInt32BE(20), 32, 'Blanc favicon height');
+    return { name: 'Blanc first-party quality canary', pngBytes: bytes.length };
+  } finally {
+    if (app) await app.close();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+};
+
 const proof = [];
 for (const [batchIndex, batch] of batches.entries()) {
   proof.push(...await runBatch(batch, batchIndex));
 }
+const ranBrandCanary = brandOnly ||
+  ((!matrixName || matrixName === 'primary') && requestedNames.size === 0);
+if (ranBrandCanary) proof.push(await runBrandQualityCanary());
 console.log(JSON.stringify(proof, null, 2));
 console.log(
-  `packaged-live-favicons-smoke OK: ${matrixName || 'all'} matrix, ${sites.length} sites in ${batches.length} cold batches`
+  `packaged-live-favicons-smoke OK: ${matrixName || 'all'} matrix, ${sites.length} sites in ${batches.length} cold batches` +
+  (ranBrandCanary ? ' + Blanc vector-quality canary' : '')
 );

--- a/test/unit/favicon-policy.test.js
+++ b/test/unit/favicon-policy.test.js
@@ -3,6 +3,7 @@ const test = require('node:test');
 
 const {
   pageFaviconSources,
+  pickBestDeclaredFavicon,
   declaredPageFavicons,
   resolvedFavicon,
   shouldClearFaviconOnNavigate,
@@ -105,6 +106,89 @@ test('a superseded page event stops before trying another candidate', async () =
     { setTabFavicon: async (_tab, source) => { calls.push(source); return false; } }
   );
   assert.deepEqual(calls, ['https://x.com/favicon.ico']);
+});
+
+test('prefers Blanc’s declared SVG over an earlier ICO mislabeled as sizes=any', () => {
+  assert.equal(pickBestDeclaredFavicon([
+    {
+      href: 'https://blancbrowser.com/favicon.ico',
+      rel: 'icon',
+      sizes: 'any',
+      type: '',
+    },
+    {
+      href: 'https://blancbrowser.com/favicon.svg',
+      rel: 'icon',
+      sizes: '',
+      type: 'image/svg+xml',
+    },
+    {
+      href: 'https://blancbrowser.com/favicon-32x32.png',
+      rel: 'icon',
+      sizes: '32x32',
+      type: 'image/png',
+    },
+  ]), 'https://blancbrowser.com/favicon.svg');
+});
+
+test('prefers a declared Retina-sized icon over a 16px icon', () => {
+  assert.equal(pickBestDeclaredFavicon([
+    { href: 'https://example.com/16.png', rel: 'icon', sizes: '16x16', type: 'image/png' },
+    { href: 'https://example.com/64.png', rel: 'icon', sizes: '64x64', type: 'image/png' },
+  ]), 'https://example.com/64.png');
+});
+
+test('document-ready refines a working low-resolution favicon without blanking first', async () => {
+  const working = 'data:image/png;base64,working';
+  const tab = {
+    id: 'blanc',
+    url: 'https://blancbrowser.com/changelog',
+    favicon: working,
+    faviconSource: 'https://blancbrowser.com/favicon.ico',
+  };
+  const calls = [];
+  await updateFaviconAfterDomReady(tab, {
+    executeJavaScript: async () => [
+      { href: 'https://blancbrowser.com/favicon.ico', rel: 'icon', sizes: 'any', type: '' },
+      { href: 'https://blancbrowser.com/favicon.svg', rel: 'icon', sizes: '', type: 'image/svg+xml' },
+    ],
+  }, {
+    setTabFavicon: async (record, source) => {
+      calls.push({ source, faviconAtCall: record.favicon });
+      record.faviconSource = source;
+      record.favicon = 'data:image/png;base64,sharp';
+      return true;
+    },
+  });
+  assert.deepEqual(calls, [{
+    source: 'https://blancbrowser.com/favicon.svg',
+    faviconAtCall: working,
+  }]);
+});
+
+test('document-ready tries Blanc’s best declared icon before lower-resolution fallbacks', async () => {
+  const tab = {
+    id: 'blanc',
+    url: 'https://blancbrowser.com/changelog',
+    favicon: null,
+    faviconSource: null,
+  };
+  const calls = [];
+  await updateFaviconAfterDomReady(tab, {
+    executeJavaScript: async () => [
+      { href: 'https://blancbrowser.com/favicon.ico', rel: 'icon', sizes: 'any', type: '' },
+      { href: 'https://blancbrowser.com/favicon.svg', rel: 'icon', sizes: '', type: 'image/svg+xml' },
+      { href: 'https://blancbrowser.com/favicon-32x32.png', rel: 'icon', sizes: '32x32', type: 'image/png' },
+    ],
+  }, {
+    setTabFavicon: async (record, source) => {
+      calls.push(source);
+      record.faviconSource = source;
+      record.favicon = 'data:image/png;base64,working';
+      return true;
+    },
+  });
+  assert.deepEqual(calls, ['https://blancbrowser.com/favicon.svg']);
 });
 
 test('document-ready supplies the declared favicon when Chromium emitted no icon event', async () => {

--- a/test/unit/favicon-policy.test.js
+++ b/test/unit/favicon-policy.test.js
@@ -138,6 +138,16 @@ test('prefers a declared Retina-sized icon over a 16px icon', () => {
   ]), 'https://example.com/64.png');
 });
 
+test('uses an Apple touch icon only when the page declares no ordinary favicon', () => {
+  assert.equal(pickBestDeclaredFavicon([
+    { href: 'https://example.com/favicon-16.png', rel: 'icon', sizes: '16x16', type: 'image/png' },
+    { href: 'https://example.com/apple-touch-icon.png', rel: 'apple-touch-icon', sizes: '180x180', type: 'image/png' },
+  ]), 'https://example.com/favicon-16.png');
+  assert.equal(pickBestDeclaredFavicon([
+    { href: 'https://example.com/apple-touch-icon.png', rel: 'apple-touch-icon', sizes: '180x180', type: 'image/png' },
+  ]), 'https://example.com/apple-touch-icon.png');
+});
+
 test('document-ready refines a working low-resolution favicon without blanking first', async () => {
   const working = 'data:image/png;base64,working';
   const tab = {

--- a/test/unit/tab-view.test.js
+++ b/test/unit/tab-view.test.js
@@ -124,6 +124,13 @@ test('document-ready has a favicon fallback when Chromium emits no favicon event
   assert.match(wireSource, /wc\.on\('dom-ready',[\s\S]*?updateFaviconAfterDomReady/);
 });
 
+test('a late Chromium favicon event is followed by the declared quality pass', () => {
+  const start = wireSource.indexOf("wc.on('page-favicon-updated'");
+  const end = wireSource.indexOf("wc.on('dom-ready'", start);
+  const listener = wireSource.slice(start, end);
+  assert.match(listener, /pending\.finally\([\s\S]*?updateFaviconAfterDomReady/);
+});
+
 for (const required of [
   'installChromeShortcuts',
   'watchCursorFor',

--- a/test/unit/tab-view.test.js
+++ b/test/unit/tab-view.test.js
@@ -131,6 +131,14 @@ test('a late Chromium favicon event is followed by the declared quality pass', (
   assert.match(listener, /pending\.finally\([\s\S]*?updateFaviconAfterDomReady/);
 });
 
+test('a favicon event after initial load keeps its dynamic favicon', () => {
+  const start = wireSource.indexOf("wc.on('page-favicon-updated'");
+  const end = wireSource.indexOf("wc.on('dom-ready'", start);
+  const listener = wireSource.slice(start, end);
+  assert.match(listener, /const refineInitialFavicon = tab\.isLoading;/);
+  assert.match(listener, /if \(!refineInitialFavicon\) return;/);
+});
+
 for (const required of [
   'installChromeShortcuts',
   'watchCursorFor',


### PR DESCRIPTION
## Summary

- Prefer declared SVG/Retina desktop favicons over low-resolution ICOs.
- Preserve live favicon changes after the initial document load.
- Treat Apple touch icons as a fallback only when no ordinary favicon is declared.
- Add a packaged Blanc SVG quality canary and focused regression coverage.

## Root cause

Blancbrowser.com declares a multi-frame ICO before its SVG. Chromium could emit the ICO after document readiness, replacing the sharper SVG with soft upscaled pixels.

## Validation

- `npm run test:unit` — 717 passing
- `npm run substrate:check` — passing
- Signed macOS unpacked build completed and passed strict code-signature verification

The packaged first-party canary compares the tab payload to Chromium's 32px raster of Blanc's declared SVG.