### PR TITLE
Point F37-1 at the wash instead of the deleted caret

### DIFF
--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -553,10 +553,19 @@ function install(refs) {
         const label = document.getElementById('pillDomain');
         const chip = document.getElementById('pillSlash');
         if (!label) return null;
+        // The caret is gone (fbc8270): the prompt now carries its own motion,
+        // a bright band washing through the glyphs. Report the mechanism that
+        // actually ships in each branch — the animation plus whether the
+        // gradient is painting the text — so the guard can't be satisfied by
+        // deleting the affordance.
+        const cs = getComputedStyle(label);
+        const fill = cs.webkitTextFillColor || cs.color;
         return {
           text: label.textContent,
           placeholder: label.classList.contains('placeholder'),
-          caret: !!label.querySelector('.pill-caret'),
+          animation: cs.animationName,
+          gradientPainted: /rgba\\(0, 0, 0, 0\\)|transparent/.test(fill),
+          reducedMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
           chipHidden: chip ? !!chip.hidden : null,
           chipLabel: chip ? chip.textContent : null,
         };

--- a/test/desktop/steps/blank-tab-affordance.steps.js
+++ b/test/desktop/steps/blank-tab-affordance.steps.js
@@ -67,8 +67,23 @@ Then('the island shows the typing prompt', async function () {
   const pill = await this.call('pillPlaceholderState');
   assert.ok(pill, 'the pill label was not found in the chrome document');
   assert.ok(pill.placeholder, 'the pill label is not in placeholder mode');
-  assert.ok(pill.caret, 'the pill shows no caret');
   assert.strictEqual(pill.text, 'Search or type a URL');
+  // What makes the prompt read as a field rather than a label is its motion:
+  // a bright band washing through the glyphs, painted by a gradient clipped
+  // to the text. Under reduced motion that is deliberately traded for a
+  // stronger resting ink instead (styles.css). Assert whichever branch this
+  // environment is actually in, so neither can be quietly deleted.
+  if (pill.reducedMotion) {
+    assert.strictEqual(pill.animation, 'none',
+      'reduced motion must not animate the prompt');
+    assert.strictEqual(pill.gradientPainted, false,
+      'the reduced-motion prompt must paint real ink, not a clipped gradient');
+  } else {
+    assert.strictEqual(pill.animation, 'pill-placeholder-wash',
+      'the prompt is not running the wash that signals a typing field');
+    assert.strictEqual(pill.gradientPainted, true,
+      'the wash must paint through the glyphs (text fill is transparent)');
+  }
 });
 
 Then('the island shows the commands chip', async function () {


### PR DESCRIPTION
`F37-1` ("The blank-tab island invites typing") has failed on `main` since **fbc8270**. The app is correct — the guard went stale.

## Root cause

fbc8270 replaced the blank-tab caret with a prompt that carries its own motion. Its own commit message says it plainly: *"The caret is gone entirely."* That commit updated `test/unit/blank-tab-pill.test.js` — which now asserts "nothing of the caret survives" — but the **acceptance** step still asserted a `.pill-caret` element:

```js
assert.ok(pill.caret, 'the pill shows no caret');
```

`pillPlaceholderState` reported `caret: !!label.querySelector('.pill-caret')`, which has been permanently `false` since the element was deleted. So the failure was a dead probe, not a regression — exactly the class of thing the repo's guard-test rule exists to prevent.

## The fix

Rather than deleting the assertion (which would leave the affordance unguarded), the step now asserts the mechanism that actually ships — and does it **per branch**, because `styles.css` deliberately has two:

- **Default:** `animation-name` is `pill-placeholder-wash` and the text fill is transparent, so the gradient paints through the glyphs.
- **`prefers-reduced-motion: reduce`:** no animation, real ink instead — the deliberate trade the stylesheet documents ("no caret remains to say 'field' without motion, so the prompt cannot simply fall back to `--text-dim`").

The hook reports `animation`, `gradientPainted`, and `reducedMotion`; the step picks the branch the environment is actually in. Asserting the specific branch rather than "either is acceptable" is what keeps the guard from being satisfied by deleting the affordance outright.

## Verification

**Positive control** — with the `animation: pill-placeholder-wash` rule removed from `styles.css`, the scenario fails with *"the prompt is not running the wash that signals a typing field"*, then passes again on restore. The guard has teeth.

- Acceptance: **114/114** (was 113/114 — this was the only red scenario)
- Unit: 807/807
- `substrate:check`: 4/4 OK

No production code changed; the diff is the test hook's probe and the step definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)