### PR TITLE
Release Blanc 1.5.0

### DIFF
--- a/docs/press/release-notes/v1.5.0.md
+++ b/docs/press/release-notes/v1.5.0.md
@@ -1,0 +1,34 @@
+# Blanc 1.5.0
+
+## Added
+
+- Reopen Closed Tab now gives the tab back rather than reopening its address. For thirty seconds after you close a tab, `Cmd/Ctrl+Shift+T` returns the page itself — the same view, with no reload, keeping scroll position, half-typed form text, video position, and pages that only exist because you submitted a form. After that window it restores from a snapshot instead: the address, the back and forward history, scroll position, group, pin, mute, and the tab's original place in the order.
+- Closing a group is one step to undo. `/close-group` used to cost one keypress per tab to reverse; the whole group now comes back together, with its name, its members in their original order, its pins, and its position among your other groups.
+- The command panel lists what you recently closed. Open it with `Cmd/Ctrl+L` and the last few closed tabs sit below your open ones, each reopening on click, so you can pick the one you meant instead of pressing `Cmd/Ctrl+Shift+T` repeatedly. A group entry shows how many tabs it holds.
+- `/reopen` joins the slash commands as another way to reach the same thing.
+- A new tab now shows where to type. The resting island reads "Search or type a URL" with a band of light washing through the words, and typing anywhere on a blank tab opens the island with what you typed already entered. A `/` chip beside the prompt opens the command list.
+- The start page offers three layouts, and first run walks through setup: theme, default browser, importing Favorites from another browser, and your privacy choices.
+
+## Privacy and compatibility
+
+- Private tabs are excluded from all of this, exactly as before. They are never recorded as closed tabs, never held, and never reopenable.
+- A tab held for reopening is silenced and frozen the moment you close it. It cannot open windows, cannot navigate, and is refused every permission it asks for — including ones you previously granted that site — so a closed tab can never quietly acquire your microphone or camera. Tabs using the microphone or camera are never held at all; closing one ends its access immediately.
+- Pages reached by submitting a form are restored exactly for the thirty-second window and then re-fetched as an ordinary page load. Blanc never silently resubmits a form, so a payment or a submission cannot be replayed by reopening a tab.
+- Nothing about closed tabs is written to disk, session restore, Profile Sync, telemetry, or crash reports. The list lives in memory and ends with the app.
+- Reduced motion is honored on the new-tab prompt: the wash is replaced by a stronger resting ink rather than simply being removed.
+
+## Fixed
+
+- Answering a permission prompt after closing its tab no longer grants or remembers that permission. Previously a prompt left open outlived the tab, and a late "Allow" saved a decision for a page that no longer existed — affecting every future visit to that site.
+- macOS raises one "change your default browser?" dialog instead of two.
+- Onboarding buttons stay readable on hover.
+
+## Release verification
+
+- The source gate includes 807 unit tests and 114 runnable desktop acceptance scenarios with 688 steps, covering closed-tab tier selection, the held-tab permission firewall, group-close undo, and the new-tab prompt. Packaged verification exercises first run, release regressions, live favicon compatibility, and migration from public Stable v1.4.0.
+- Audio stopping when a held tab is closed, and the macOS microphone indicator clearing on close, were confirmed by hand on real hardware; the microphone result was independently corroborated against the operating system's own audio-device state.
+- `SHA256SUMS` is authenticated with a Sigstore bundle whose expected certificate identity is `anthony@bnfy.me` and whose expected OIDC issuer is `https://github.com/login/oauth`.
+
+## Other platforms
+
+macOS Apple Silicon, signed Windows, and Linux are built from the same `v1.5.0` source tag and published with one signed SHA-256 manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -6,7 +6,7 @@ import MemoryChart from '../components/MemoryChart.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 import releaseData from '../data/releases.json';
 
-const VERSION = '1.4.0';
+const VERSION = '1.5.0';
 const TAG = `v${VERSION}`;
 /* Wherever this page states a version and a date together, the date is that
    version's own ship date — read from the generated changelog data rather than

--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -553,10 +553,19 @@ function install(refs) {
         const label = document.getElementById('pillDomain');
         const chip = document.getElementById('pillSlash');
         if (!label) return null;
+        // The caret is gone (fbc8270): the prompt now carries its own motion,
+        // a bright band washing through the glyphs. Report the mechanism that
+        // actually ships in each branch — the animation plus whether the
+        // gradient is painting the text — so the guard can't be satisfied by
+        // deleting the affordance.
+        const cs = getComputedStyle(label);
+        const fill = cs.webkitTextFillColor || cs.color;
         return {
           text: label.textContent,
           placeholder: label.classList.contains('placeholder'),
-          caret: !!label.querySelector('.pill-caret'),
+          animation: cs.animationName,
+          gradientPainted: /rgba\\(0, 0, 0, 0\\)|transparent/.test(fill),
+          reducedMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
           chipHidden: chip ? !!chip.hidden : null,
           chipLabel: chip ? chip.textContent : null,
         };

--- a/test/desktop/steps/blank-tab-affordance.steps.js
+++ b/test/desktop/steps/blank-tab-affordance.steps.js
@@ -67,8 +67,23 @@ Then('the island shows the typing prompt', async function () {
   const pill = await this.call('pillPlaceholderState');
   assert.ok(pill, 'the pill label was not found in the chrome document');
   assert.ok(pill.placeholder, 'the pill label is not in placeholder mode');
-  assert.ok(pill.caret, 'the pill shows no caret');
   assert.strictEqual(pill.text, 'Search or type a URL');
+  // What makes the prompt read as a field rather than a label is its motion:
+  // a bright band washing through the glyphs, painted by a gradient clipped
+  // to the text. Under reduced motion that is deliberately traded for a
+  // stronger resting ink instead (styles.css). Assert whichever branch this
+  // environment is actually in, so neither can be quietly deleted.
+  if (pill.reducedMotion) {
+    assert.strictEqual(pill.animation, 'none',
+      'reduced motion must not animate the prompt');
+    assert.strictEqual(pill.gradientPainted, false,
+      'the reduced-motion prompt must paint real ink, not a clipped gradient');
+  } else {
+    assert.strictEqual(pill.animation, 'pill-placeholder-wash',
+      'the prompt is not running the wash that signals a typing field');
+    assert.strictEqual(pill.gradientPainted, true,
+      'the wash must paint through the glyphs (text fill is transparent)');
+  }
 });
 
 Then('the island shows the commands chip', async function () {

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.4.0');
+  assert.equal(packageVersion, '1.5.0');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
Release PR for **Blanc 1.5.0**, covering the 14 commits on `main` since `v1.4.0`.

Contents, in one commit per the runbook: the `version` bump in `package.json` + `package-lock.json`, the checked-in notes at `docs/press/release-notes/v1.5.0.md`, and both press version pins (`site/src/pages/press.astro` `VERSION`, `test/unit/press-kit.test.js`).

## What ships

- **Reopen Closed Tab holds the tab** (#144). For 30s after ⌘W, ⌘⇧T returns the *same view* — no reload, scroll and form state and POST-derived pages intact — then degrades to a snapshot restore (address, back/forward, scroll, group, pin, mute, slot). Group closes undo in one step. The command panel lists recent closes; `/reopen` added.
- **Permission-prompt fix** (#142). A prompt answered after its tab closed no longer grants *or persists* the decision — that bug affected every future visit to the site.
- **Blank tab shows where to type** (#141, fbc8270, #143) and **start page layouts + first-run onboarding** (#140).
- Fixes: one macOS default-browser dialog instead of two; onboarding button hover legibility.

## Pre-flight (the runbook's known first-attempt killers, checked early)

| Gate | Result |
|---|---|
| `npm run test:unit` | 807/807 with the new pins |
| `npm audit --omit=dev --audit-level=high` | 0 vulnerabilities |
| `npm --prefix site ci` + `npm run site:build` | 17 pages built (site deps were absent in this worktree — installed) |
| Acceptance (pre-bump, on `main`) | 114/114 |

**`electron` deliberately not bumped**, staying at `^43.4.0` — same as v1.4.0, which shipped two days ago. Chromium can't be swapped out of a running app, so a mid-week engine change adds risk this release doesn't need.

Once merged, the release runs from a checkout at exactly `origin/main`:

```
BLANC_RELEASE_MODE=stable BLANC_RELEASE_PLATFORMS=mac,windows,linux BLANC_MAC_ARCHES=arm64 npm run release
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)