### PR TITLE
Preserve Electron listeners during tab teardown

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -897,12 +897,16 @@ async function sleepTab(id, { broadcast = true } = {}) {
 
   sleepTeardownInProgress = true;
   const wcId = wc.id;
-  // This must remove every old listener: loading/failure/crash listeners can
-  // otherwise poison tab.url or resurrect exactly the renderer being closed.
-  wc.removeAllListeners();
+  // Remove Blanc's stale-document listeners, but preserve Electron's own.
+  // Electron can deliver queued visibility work after close() destroys the
+  // native object; blanket listener removal turns that into the uncaught
+  // BrowserWindow.visibilityChanged "Object has been destroyed" exception.
+  unwireTabView(wc);
 
   let aborted = false;
   let teardownTimeout;
+  let destroyedHandler;
+  let preventUnloadHandler;
   const outcome = await new Promise((resolve) => {
     let settled = false;
     const finish = (value) => {
@@ -912,7 +916,7 @@ async function sleepTab(id, { broadcast = true } = {}) {
       }
     };
 
-    wc.once('destroyed', bindWindowRuntime(owner, () => {
+    destroyedHandler = bindWindowRuntime(owner, () => {
       tab.view = null;
       tab.asleep = true;
       tab.sleeping = false;
@@ -921,23 +925,25 @@ async function sleepTab(id, { broadcast = true } = {}) {
       tab.isLoading = false;
       tab.pageBg = null;
       tab.themeColor = null;
-      // removeAllListeners() above stripped the normal render-process-gone
-      // capture clear; the discarded document's anchors must not survive
-      // into whatever a wake later loads.
+      // unwireTabView() above removed the normal render-process-gone capture
+      // clear; the discarded document's anchors must not survive into
+      // whatever a wake later loads.
       if (tab.captureRecord) clearCaptureState({ kind: 'tab', tab, record: tab.captureRecord });
       const record = sleepSnapshots.get(id);
       if (record) record.view = null;
       tabIdByWebContentsId.delete(wcId);
       lastMainFrameMethod.delete(wcId);
       finish('quiet');
-    }));
+    });
+    wc.once('destroyed', destroyedHandler);
 
     // Polarity matters: this fires when the page objects to unload. Calling
     // preventDefault here would override that objection and destroy the tab.
-    wc.on('will-prevent-unload', () => {
+    preventUnloadHandler = () => {
       aborted = true;
       finish('aborted');
-    });
+    };
+    wc.once('will-prevent-unload', preventUnloadHandler);
 
     wc.close({ waitForBeforeUnload: true });
     // A wedged renderer must not remain permanently `sleeping`.
@@ -949,6 +955,13 @@ async function sleepTab(id, { broadcast = true } = {}) {
     sleepTeardownInProgress = false;
     if (broadcast) broadcastTabs();
     return true;
+  }
+
+  // An unload objection or timeout leaves the WebContents alive. Remove the
+  // temporary teardown observers before reinstalling the ordinary tab set.
+  if (!wc.isDestroyed()) {
+    wc.removeListener('destroyed', destroyedHandler);
+    wc.removeListener('will-prevent-unload', preventUnloadHandler);
   }
 
   // Restore the ordinary listener set after the temporary teardown pair. A
@@ -980,8 +993,13 @@ function downgradeHeldEntry(entry) {
   entry.heldAt = null;
   const wc = view?.webContents;
   if (wc && !wc.isDestroyed()) {
-    wc.removeAllListeners();
+    // The held firewall is Blanc-owned and recorded exactly. Preserve every
+    // Electron-owned listener through close() so queued visibility teardown
+    // cannot call BrowserWindow.visibilityChanged on a destroyed object.
+    removeHeldFirewall(entry, wc);
     wc.close();
+  } else {
+    entry.firewallListeners = null;
   }
   // NO rt()/broadcast here: the before-quit sweep calls this while iterating
   // every runtime OUTSIDE any bindWindowRuntime scope (acceptance mode makes

--- a/src/main/tab-view.js
+++ b/src/main/tab-view.js
@@ -126,8 +126,9 @@ const wiredListeners = new WeakMap();
 
 /** Remove exactly the listeners the last wireTabView call installed on this
  *  WebContents, leaving every Electron-owned listener (any name) intact.
- *  For KEEP-ALIVE strips only — teardown paths that destroy the contents in
- *  the same turn may keep using removeAllListeners(). */
+ *  This rule also applies immediately before close(): Electron can deliver
+ *  queued visibility/teardown work after close has destroyed the native
+ *  object, so removeAllListeners() is never safe on a managed WebContents. */
 function unwireTabView(wc) {
   for (const [event, handler] of wiredListeners.get(wc) ?? []) {
     wc.removeListener(event, handler);

--- a/test/unit/held-entry-teardown.test.js
+++ b/test/unit/held-entry-teardown.test.js
@@ -21,22 +21,30 @@ const mainSource = fs.readFileSync(path.join(__dirname, '../../src/main/main.js'
 const fnStart = mainSource.indexOf('function downgradeHeldEntry(');
 const fnEnd = mainSource.indexOf('\n}', fnStart) + 2;
 const downgradeSource = fnStart >= 0 ? mainSource.slice(fnStart, fnEnd) : null;
+const removeStart = mainSource.indexOf('function removeHeldFirewall(');
+const removeEnd = mainSource.indexOf('\n}', removeStart) + 2;
+const removeSource = removeStart >= 0 ? mainSource.slice(removeStart, removeEnd) : null;
 
 test('downgradeHeldEntry is still liftable from main.js', () => {
   assert.ok(downgradeSource, 'downgradeHeldEntry not found — update this test');
+  assert.ok(removeSource, 'removeHeldFirewall not found — update this test');
 });
 
-test('a quit-path downgrade outside any runtime binding destroys the view and throws nothing', () => {
+test('a quit-path downgrade preserves Electron listeners while destroying the view', () => {
   let closed = 0;
   let cleared = null;
+  const removed = [];
+  const firewallHandler = () => {};
   const entry = {
     holdTimer: 'timer-token',
     wcId: 41,
     heldAt: 12345,
+    firewallListeners: [['destroyed', firewallHandler]],
     view: {
       webContents: {
         isDestroyed: () => false,
-        removeAllListeners() {},
+        removeListener(event, handler) { removed.push([event, handler]); },
+        removeAllListeners() { throw new Error('must preserve Electron-owned listeners'); },
         close() { closed += 1; },
       },
     },
@@ -46,7 +54,7 @@ test('a quit-path downgrade outside any runtime binding destroys the view and th
     heldWebContents: new Set([41]),
   };
   vm.createContext(sandbox);
-  vm.runInContext(downgradeSource, sandbox);
+  vm.runInContext(`${removeSource}\n${downgradeSource}`, sandbox);
   // No rt(), hasLiveWindow, or scheduleBroadcastTabs in scope — exactly the
   // before-quit environment. A ReferenceError here is the regression.
   vm.runInContext('downgradeHeldEntry(entry);', Object.assign(sandbox, { entry }));
@@ -57,6 +65,9 @@ test('a quit-path downgrade outside any runtime binding destroys the view and th
   assert.equal(entry.heldAt, null);
   assert.equal(entry.wcId, null);
   assert.equal(sandbox.heldWebContents.size, 0, 'the registry entry must be removed');
+  assert.deepEqual(removed, [['destroyed', firewallHandler]],
+    'only the recorded Blanc firewall listener may be removed');
+  assert.equal(entry.firewallListeners, null);
 
   // Idempotent: the destroyed-handler path may call it again.
   vm.runInContext('downgradeHeldEntry(entry);', sandbox);

--- a/test/unit/tab-view.test.js
+++ b/test/unit/tab-view.test.js
@@ -124,6 +124,19 @@ test('wireTabView is still present in tab-view.js', () => {
   assert.ok(wireSource, 'wireTabView not found in tab-view.js — update this test with it');
 });
 
+test('managed WebContents teardown never strips Electron-owned listeners', () => {
+  assert.doesNotMatch(
+    `${mainSource}\n${viewSource}`,
+    /\.removeAllListeners\s*\(/,
+    'use exact wire/firewall bookkeeping; blanket removal breaks Electron visibility teardown'
+  );
+  assert.match(
+    mainSource,
+    /sleepTeardownInProgress = true;[\s\S]*?unwireTabView\(wc\);[\s\S]*?wc\.close\(/,
+    'quiet-tab teardown must unwire only Blanc listeners before close'
+  );
+});
+
 test('a queued mouse move does not calculate bounds after its window closes', () => {
   assert.ok(watchCursorForSource, 'watchCursorFor not found in main.js — update this test with it');
   let inputListener;


### PR DESCRIPTION
## What changed

- replace blanket `webContents.removeAllListeners()` in Quiet Tabs teardown with Blanc’s exact `unwireTabView()` bookkeeping
- remove only recorded held-tab firewall listeners before held-view destruction
- clean up temporary quiet-teardown observers when unload is refused or times out
- add regression coverage that fails if managed WebContents teardown strips Electron-owned listeners

## Why

Blanc 1.4.0 repeatedly surfaced an uncaught Electron main-process exception:

```
TypeError: Object has been destroyed
at BrowserWindow.visibilityChanged
```

Quiet-tab and held-tab destruction removed every WebContents listener immediately before `close()`. That also removed Electron’s internal visibility/teardown bookkeeping. A queued visibility callback could then run after the native object had been destroyed. PR #144 fixed exact listener removal for parked views but explicitly left these destruction paths on the unsafe blanket-removal shortcut.

## Impact

Idle tabs and expired reopen-closed holds can release their renderers without triggering Electron’s destroyed-object dialog. Electron-owned listeners remain intact while Blanc’s stale document listeners are still removed precisely.

## Validation

- `npm run test:unit` — 808/808 assertions pass
- `npm run test:acceptance:desktop -- --tags @F31-1` — 2/2 scenarios pass
- `npm run test:acceptance:desktop -- --tags @F31-10` — renderer release/wake scenario passes
- `npm run test:acceptance:desktop` — 114/114 scenarios, 688/688 steps pass
- `git diff --check`
