### PR TITLE
Settle macOS visibility before quit

### DIFF
--- a/src/main/macos-quit.js
+++ b/src/main/macos-quit.js
@@ -1,0 +1,82 @@
+function safeWindowState(window, method, fallback) {
+  try {
+    if (!window || window.isDestroyed()) return fallback;
+    return window[method]();
+  } catch {
+    return fallback;
+  }
+}
+
+function settleWindowHidden(window, schedule = setImmediate) {
+  if (!safeWindowState(window, 'isVisible', false)) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      window.removeListener?.('hide', finish);
+      window.removeListener?.('closed', finish);
+      resolve();
+    };
+
+    window.once('hide', finish);
+    window.once('closed', finish);
+    try {
+      window.hide();
+    } catch {
+      finish();
+      return;
+    }
+
+    // Some window managers update isVisible() before delivering `hide`.
+    // Re-check on the next turn so a coalesced native event cannot strand quit.
+    schedule(() => {
+      if (!safeWindowState(window, 'isVisible', false)) finish();
+    });
+  });
+}
+
+/**
+ * Electron's BrowserWindow shim listens for `hide` and immediately reads the
+ * native window again. On macOS, destroying a still-visible window can deliver
+ * that event after the native object is gone, producing the modal
+ * "Object has been destroyed" main-process exception. Pause the first quit,
+ * settle every visible window's hide event while it is still live, then retry.
+ */
+function installMacOSQuitVisibilityGate({
+  app,
+  BrowserWindow,
+  platform = process.platform,
+  schedule = setImmediate,
+} = {}) {
+  if (platform !== 'darwin') return () => {};
+
+  let settling = null;
+  let visibilitySettled = false;
+
+  const beforeQuit = (event) => {
+    const windows = BrowserWindow.getAllWindows().filter((window) =>
+      safeWindowState(window, 'isVisible', false));
+
+    if (visibilitySettled && windows.length === 0) return;
+    visibilitySettled = false;
+    event.preventDefault();
+    if (settling) return;
+
+    settling = Promise.all(windows.map((window) => settleWindowHidden(window, schedule)))
+      .then(() => {
+        visibilitySettled = true;
+        settling = null;
+        schedule(() => app.quit());
+      });
+  };
+
+  app.prependListener('before-quit', beforeQuit);
+  return () => app.removeListener('before-quit', beforeQuit);
+}
+
+module.exports = {
+  installMacOSQuitVisibilityGate,
+  settleWindowHidden,
+};

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2,6 +2,30 @@ const { app, BrowserWindow, WebContentsView, session, ipcMain, Menu, nativeTheme
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
+const { installMacOSQuitVisibilityGate } = require('./macos-quit');
+
+// Electron's default uncaught-exception path raises a native modal dialog,
+// which can leave the acceptance runner reporting green while app.close()
+// waits behind an invisible main-process failure. Test runs record the exact
+// stack in their throwaway profile instead; the parent harness turns any entry
+// into a failed scenario. Production keeps Electron's ordinary crash handling.
+if (process.env.BLANC_TEST === '1' && process.env.BLANC_TEST_UNCAUGHT_LOG) {
+  process.on('uncaughtException', (error, origin) => {
+    try {
+      fs.appendFileSync(
+        process.env.BLANC_TEST_UNCAUGHT_LOG,
+        `${origin || 'uncaughtException'}\n${error?.stack || error}\n\n`,
+        { encoding: 'utf8', mode: 0o600 }
+      );
+    } catch {}
+    // Continuing after an uncaught main-process exception is unsafe. The
+    // synchronous record above is the only cleanup this test process needs;
+    // exit without Electron's modal error dialog so the harness can report it.
+    process.exit(1);
+  });
+}
+
+installMacOSQuitVisibilityGate({ app, BrowserWindow });
 const {
   setupAdBlocker,
   attachAdBlockerToSession,

--- a/test/desktop/support/hooks.js
+++ b/test/desktop/support/hooks.js
@@ -19,6 +19,32 @@ let secureFixturesHandle;
 let secureSpkiHash = null;
 let browserHomeDir;
 let savedClipboard = null;
+let uncaughtLogPath;
+
+function mainProcessExceptionsSinceLaunch(electronApp) {
+  if (!uncaughtLogPath || !fs.existsSync(uncaughtLogPath)) return '';
+  const contents = fs.readFileSync(uncaughtLogPath, 'utf8');
+  return contents.slice(electronApp.__blancUncaughtOffset ?? 0).trim();
+}
+
+function assertNoMainProcessExceptions(electronApp) {
+  const failures = mainProcessExceptionsSinceLaunch(electronApp);
+  if (failures) throw new Error(`Electron main-process exception:\n${failures}`);
+}
+
+async function closeApp(electronApp) {
+  if (!electronApp) return;
+  try {
+    await electronApp.close();
+  } catch (error) {
+    // A fatal main-process exception may close Playwright's target before the
+    // explicit close completes. Prefer the captured application stack when it
+    // exists; otherwise preserve the original close failure.
+    assertNoMainProcessExceptions(electronApp);
+    throw error;
+  }
+  assertNoMainProcessExceptions(electronApp);
+}
 
 async function launchApp() {
   const electronApp = await _electron.launch({
@@ -42,8 +68,12 @@ async function launchApp() {
       ...process.env,
       BLANC_TEST: '1',
       BLANC_TEST_BROWSER_HOME: browserHomeDir,
+      BLANC_TEST_UNCAUGHT_LOG: uncaughtLogPath,
     },
   });
+  electronApp.__blancUncaughtOffset = fs.existsSync(uncaughtLogPath)
+    ? fs.statSync(uncaughtLogPath).size
+    : 0;
 
   // Wait for whenReady to have installed the test hook and completed the
   // blocker-gated workspace restore. Returning while persistence is still
@@ -88,6 +118,7 @@ BeforeAll({ timeout: 120_000 }, async () => {
 
   // Isolated, throwaway profile so no prior session/history/settings leaks in.
   userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-acceptance-'));
+  uncaughtLogPath = path.join(userDataDir, 'main-process-uncaught.log');
   browserHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-browser-home-'));
   const chromeRoot = browserDataRoot('chrome', {
     platform: process.platform,
@@ -141,7 +172,7 @@ BeforeAll({ timeout: 120_000 }, async () => {
   // F28-1 exercises a genuine process relaunch against this same profile,
   // rather than a renderer reload or an in-memory persistence proxy.
   ctx.relaunch = async () => {
-    if (ctx.app) await ctx.app.close();
+    if (ctx.app) await closeApp(ctx.app);
     ctx.app = await launchApp();
   };
 
@@ -151,6 +182,7 @@ BeforeAll({ timeout: 120_000 }, async () => {
 });
 
 Before(async function () {
+  if (ctx.app) assertNoMainProcessExceptions(ctx.app);
   ctx.tabByName = {};
   ctx.activeExpectedUrl = null;
   ctx.lastNewTabId = null;
@@ -161,15 +193,23 @@ Before(async function () {
 });
 
 AfterAll(async () => {
+  let closeFailure = null;
   if (ctx.app && savedClipboard !== null) {
     await callTestHook(ctx.app, 'setClipboardText', [savedClipboard])
       .catch(() => {});
   }
-  if (ctx.app) await ctx.app.close();
+  if (ctx.app) {
+    try {
+      await closeApp(ctx.app);
+    } catch (error) {
+      closeFailure = error;
+    }
+  }
   ctx.app = null;
   ctx.relaunch = null;
   if (fixturesHandle) await fixturesHandle.close();
   if (secureFixturesHandle) await secureFixturesHandle.close();
   if (userDataDir) fs.rmSync(userDataDir, { recursive: true, force: true });
   if (browserHomeDir) fs.rmSync(browserHomeDir, { recursive: true, force: true });
+  if (closeFailure) throw closeFailure;
 });

--- a/test/unit/macos-quit.test.js
+++ b/test/unit/macos-quit.test.js
@@ -1,0 +1,82 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const {
+  installMacOSQuitVisibilityGate,
+  settleWindowHidden,
+} = require('../../src/main/macos-quit');
+
+const turn = () => new Promise((resolve) => setImmediate(resolve));
+
+class FakeWindow extends EventEmitter {
+  constructor({ visible = true } = {}) {
+    super();
+    this.visible = visible;
+    this.destroyed = false;
+    this.hideCalls = 0;
+  }
+
+  isDestroyed() { return this.destroyed; }
+  isVisible() { return this.visible; }
+  hide() {
+    this.hideCalls += 1;
+    this.visible = false;
+    setImmediate(() => this.emit('hide'));
+  }
+}
+
+function quitEvent() {
+  return {
+    defaultPrevented: false,
+    preventDefault() { this.defaultPrevented = true; },
+  };
+}
+
+test('a visible macOS window settles its hide event before quit is retried', async () => {
+  const app = new EventEmitter();
+  let quitCalls = 0;
+  app.quit = () => { quitCalls += 1; };
+  const window = new FakeWindow();
+  installMacOSQuitVisibilityGate({
+    app,
+    BrowserWindow: { getAllWindows: () => [window] },
+    platform: 'darwin',
+  });
+
+  const first = quitEvent();
+  app.emit('before-quit', first);
+  assert.equal(first.defaultPrevented, true);
+  assert.equal(window.hideCalls, 1);
+  assert.equal(quitCalls, 0);
+
+  await turn();
+  await turn();
+  assert.equal(quitCalls, 1);
+
+  const retry = quitEvent();
+  app.emit('before-quit', retry);
+  assert.equal(retry.defaultPrevented, false);
+  assert.equal(window.hideCalls, 1);
+});
+
+test('coalesced hide events cannot strand the quit gate', async () => {
+  const window = new FakeWindow();
+  window.hide = function hideWithoutEvent() {
+    this.hideCalls += 1;
+    this.visible = false;
+  };
+  await settleWindowHidden(window);
+  assert.equal(window.hideCalls, 1);
+  assert.equal(window.listenerCount('hide'), 0);
+  assert.equal(window.listenerCount('closed'), 0);
+});
+
+test('non-macOS quit behavior is untouched', () => {
+  const app = new EventEmitter();
+  installMacOSQuitVisibilityGate({
+    app,
+    BrowserWindow: { getAllWindows: () => [new FakeWindow()] },
+    platform: 'win32',
+  });
+  assert.equal(app.listenerCount('before-quit'), 0);
+});


### PR DESCRIPTION
## What changed

- gate the first macOS quit attempt until every visible BrowserWindow has emitted `hide`
- retry `app.quit()` only after Electron’s visibility bookkeeping is settled
- capture uncaught Electron main-process exceptions in desktop acceptance runs so native dialogs cannot be masked by a green suite
- add focused unit coverage for visible, coalesced-hide, and non-macOS paths

## Root cause

Electron 43’s internal `BrowserWindow.visibilityChanged` listener calls `isVisible()` and `isMinimized()` whenever `hide` fires. Under rapid process relaunches, macOS can deliver the final visibility event after the native BrowserWindow has already been destroyed, raising `TypeError: Object has been destroyed` in a modal main-process dialog. The acceptance harness previously did not fail on that shutdown exception.

## Impact

macOS shutdown and relaunch now settle visibility while the native object is still live. Windows and Linux behavior is unchanged. Acceptance runs fail closed on any uncaught main-process exception.

## Validation

- `npm run test:unit` — 811/811 assertions
- `npm run test:acceptance:desktop` — 114/114 scenarios, 688/688 steps
- 20 consecutive stress passes across F28-1, F28-16, F32-2, and F33-3 — 80/80 scenarios, 720/720 steps
- unfixed build reproduced the exact Electron stack twice on stress pass 4; fixed build recorded zero exceptions