### PR TITLE
Refresh 1.5.0 shutdown notes

### DIFF
--- a/docs/press/release-notes/v1.5.0.md
+++ b/docs/press/release-notes/v1.5.0.md
@@ -20,12 +20,13 @@
 ## Fixed
 
 - Answering a permission prompt after closing its tab no longer grants or remembers that permission. Previously a prompt left open outlived the tab, and a late "Allow" saved a decision for a page that no longer existed — affecting every future visit to that site.
+- Quitting or relaunching on macOS no longer intermittently opens an Electron “Object has been destroyed” error dialog.
 - macOS raises one "change your default browser?" dialog instead of two.
 - Onboarding buttons stay readable on hover.
 
 ## Release verification
 
-- The source gate includes 807 unit tests and 114 runnable desktop acceptance scenarios with 688 steps, covering closed-tab tier selection, the held-tab permission firewall, group-close undo, and the new-tab prompt. Packaged verification exercises first run, release regressions, live favicon compatibility, and migration from public Stable v1.4.0.
+- The source gate includes 811 unit tests and 114 runnable desktop acceptance scenarios with 688 steps, covering closed-tab tier selection, the held-tab permission firewall, group-close undo, the new-tab prompt, and macOS shutdown visibility. Packaged verification exercises first run, release regressions, live favicon compatibility, and migration from public Stable v1.4.0.
 - Audio stopping when a held tab is closed, and the macOS microphone indicator clearing on close, were confirmed by hand on real hardware; the microphone result was independently corroborated against the operating system's own audio-device state.
 - `SHA256SUMS` is authenticated with a Sigstore bundle whose expected certificate identity is `anthony@bnfy.me` and whose expected OIDC issuer is `https://github.com/login/oauth`.
 


### PR DESCRIPTION
## What changed

- add the macOS shutdown/relaunch error-dialog fix to the 1.5.0 release notes
- update the verified unit-test count from 807 to 811
- include macOS shutdown visibility in the source-gate coverage summary

## Why

PRs #147 and #148 landed after the release notes were staged. The release source now contains four additional unit assertions and a user-visible macOS crash fix, so the checked-in notes must match the immutable 1.5.0 artifacts before release.

## Validation

- `node --test test/unit/press-kit.test.js` — 2/2 passed
- exact source gate already verified on merged main: 811/811 unit assertions and 114/114 desktop scenarios with 688/688 steps