### PR TITLE
Force 1Password desktop auth for releases

### DIFF
--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -39,7 +39,10 @@ could not authorize the agent PTY during the v1.4.0 release.
 
 Before starting, unlock the 1Password desktop app and confirm `gh auth status`
 succeeds in that same Terminal window. Do not fetch or paste either secret and
-do not run `op signin`; `release.sh` owns the `op run` boundary.
+do not run `op signin`; `release.sh` owns the `op run` boundary and forces its
+desktop-app path with `OP_BIOMETRIC_UNLOCK_ENABLED=true`. If `op` offers to add
+an account manually, cancel it: that is a failed app-integration connection,
+not a release authentication step.
 
 For the normal Apple-Silicon stable release:
 
@@ -57,8 +60,9 @@ The two approval gates happen late enough that the Terminal window must remain
 available:
 
 1. **1Password / Apple notarization.** `op run` must ask to authorize
-   Terminal.app. Approve it there. If the dialog names ChatGPT or Codex, stop:
-   the release was launched from the wrong process and will time out.
+   Terminal.app. Approve it there. If the dialog names ChatGPT or Codex, or the
+   CLI asks to add an account manually, stop; neither is a valid release
+   authorization.
 2. **Sigstore / GitHub identity.** The release-scoped browser shim opens the
    fresh OIDC page in Safari and the callback targets
    `127.0.0.1:${BLANC_COSIGN_REDIRECT_PORT:-49197}`. Complete it immediately;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -219,12 +219,14 @@ echo "==> Preflighting the macOS identity and provisioning profile"
 node scripts/preflight-mac-signing.mjs
 
 echo "==> Cleaning and building notarized macOS artifacts"
-echo "    1Password must authorize Terminal.app. Abort if the prompt names ChatGPT or Codex."
+echo "    1Password desktop-app integration is forced for this command."
+echo "    Approve only a Terminal.app authorization; cancel any manual-account prompt."
 rm -rf dist
 MAC_BUILD_ARGS=()
 $HAS_MAC_ARM64 && MAC_BUILD_ARGS+=(--arm64)
 $HAS_MAC_X64 && MAC_BUILD_ARGS+=(--x64)
-if ! op run --env-file=.env.1password --no-masking -- \
+if ! OP_BIOMETRIC_UNLOCK_ENABLED=true \
+  op run --env-file=.env.1password --no-masking -- \
   npx electron-builder --mac "${MAC_BUILD_ARGS[@]}" --publish never; then
   echo "Signed/notarized macOS build failed. Nothing has been published." >&2
   exit 1

--- a/test/unit/release-manifest.test.js
+++ b/test/unit/release-manifest.test.js
@@ -190,6 +190,10 @@ test('release operator authentication uses the proven native Terminal and Safari
   assert.equal(spawnSync('bash', ['-n', releasePath]).status, 0);
   assert.match(releaseScript, /TERM_PROGRAM:-.*Apple_Terminal/);
   assert.match(releaseScript, /Agent\/Codex PTYs cannot complete 1Password/);
+  assert.match(
+    releaseScript,
+    /OP_BIOMETRIC_UNLOCK_ENABLED=true\s+\\\s*\n\s*op run --env-file=\.env\.1password/
+  );
   assert.ok(releaseScript.includes('${BLANC_MIGRATION_BASE_VERSION:-1.4.0}'));
   assert.ok(releaseScript.includes('${BLANC_COSIGN_REDIRECT_PORT:-49197}'));
   assert.ok(releaseScript.includes('http://127.0.0.1:$COSIGN_REDIRECT_PORT/auth/callback'));


### PR DESCRIPTION
## What changed

- force 1Password CLI desktop-app integration for the notarized macOS build with `OP_BIOMETRIC_UNLOCK_ENABLED=true`
- make the runbook explicitly reject the manual-account prompt
- add a regression assertion covering the release authentication boundary

## Root cause

`release.sh` relied on the 1Password app setting alone. On this release host, `op run` did not discover the desktop integration and fell back to the interactive manual-account flow, which cannot be used for the release.

## Impact

Release authentication now takes the intended Terminal.app → 1Password desktop authorization path and overrides any stale shell-level biometric integration setting for that command.

## Validation

- `bash -n scripts/release.sh`
- `node --test test/unit/release-manifest.test.js` (7/7 passing)
- `npm run test:unit` (814/814 passing)
- `git diff --check`