### PR TITLE
Pin site deploys to Cloudflare production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,14 @@ npm run dist:dir                # quick unpacked build in dist/, no installer
 npm run release                 # scripts/release.sh: clean, build, sign, publish to GitHub Releases
 ```
 
+After a release, `npm run site:deploy` is the production Cloudflare Pages
+command. It deliberately includes `--branch=main` because the required clean
+release checkout is detached at `origin/main`; without that flag Wrangler
+creates a `HEAD` preview and leaves `blancbrowser.com` unchanged. A successful
+post-release deployment is not complete until `wrangler pages deployment list
+--project-name=blancbrowser` shows the expected source SHA as `Production` on
+branch `main` and the canonical changelog shows the new version.
+
 There is no linter configured. Unit coverage runs with `npm run test:unit`; desktop acceptance, packaged migration/first-run, OAuth, DNS, and substrate checks have their own scripts in `package.json`. There is no generic `npm test` script.
 
 `npm run release` bumps nothing itself — bump `version` in `package.json` (and consider the `electron` devDependency, since Chromium can't be swapped out of a running app) *before* running it. It shells out to `scripts/release.sh`, which authenticates via the `gh` CLI's own cached session (no `GH_TOKEN` needed locally), builds unpublished, then uses `gh release create` directly instead of electron-builder's own GitHub publisher — that publisher races its per-artifact upload tasks against each other on first publish for a tag and can leave a release missing `latest-mac.yml` or a blockmap; creating the release once with the complete macOS asset set avoids that. **Released versions are immutable:** the script checks local/remote tags and GitHub releases before building and fails if the version already exists; always bump to a new version, never overwrite assets. It also refuses dirty desktop release sources and wipes `dist/` before building so artifacts correspond to committed code and stale files never linger.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,14 @@ npm run dist:dir                # quick unpacked build in dist/, no installer
 npm run release                 # scripts/release.sh: clean, build, sign, publish to GitHub Releases
 ```
 
+After a release, `npm run site:deploy` is the production Cloudflare Pages
+command. It deliberately includes `--branch=main` because the required clean
+release checkout is detached at `origin/main`; without that flag Wrangler
+creates a `HEAD` preview and leaves `blancbrowser.com` unchanged. A successful
+post-release deployment is not complete until `wrangler pages deployment list
+--project-name=blancbrowser` shows the expected source SHA as `Production` on
+branch `main` and the canonical changelog shows the new version.
+
 There is no linter configured and no plain `npm test` — the real commands are `npm run test:unit` (node --test over `test/unit/`), `npm run test:acceptance:dry` / `test:acceptance:desktop` (Cucumber scenarios in `spec/acceptance/`, the latter launching the app via Playwright), `npm run test:oauth:desktop`, and `npm run substrate:check` (tokens/settings/copy/adblock generated files match their sources).
 
 `npm run release` bumps nothing itself — bump `version` in `package.json` (and consider the `electron` devDependency, since Chromium can't be swapped out of a running app) *before* running it. It shells out to `scripts/release.sh`, which authenticates via the `gh` CLI's own cached session (no `GH_TOKEN` needed locally), builds unpublished, then uses `gh release create` directly instead of electron-builder's own GitHub publisher — that publisher races its per-artifact upload tasks against each other on first publish for a tag and can leave a release missing `latest-mac.yml` or a blockmap; creating the release once with the complete macOS asset set avoids that. **Released versions are immutable:** the script checks local/remote tags and GitHub releases before building and fails if the version already exists; always bump to a new version, never overwrite assets. It also refuses dirty desktop release sources and wipes `dist/` before building so artifacts correspond to committed code and stale files never linger.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -136,8 +136,12 @@ terminal capture, agent tool result, or log, revoke it and replace the
 
 After publication, regenerate and commit `site/src/data/releases.json`, advance
 the public and migration baselines, run `npm run site:build`, push, then run
-`npm run site:deploy`. Verify the canonical changelog and homepage version, not
-only the Cloudflare preview URL. The v1.4.0 incident and recovery are recorded
+`npm run site:deploy` from the clean checkout at `origin/main`. That script must
+keep its explicit `--branch=main`: a detached release worktree otherwise deploys
+to a `HEAD` preview without updating `blancbrowser.com`. Confirm `wrangler pages
+deployment list --project-name=blancbrowser` reports the expected source SHA as
+`Environment: Production` and `Branch: main`, then verify the canonical
+changelog and homepage version, not only a Cloudflare preview URL. The v1.4.0 incident and recovery are recorded
 in `docs/release-incidents/2026-08-15-v1.4.0.md`.
 
 ## 1. Verify the files

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "site:changelog:check": "node scripts/generate-site-changelog.mjs --check",
     "site:dev": "npm --prefix site run dev",
     "site:build": "npm --prefix site run build",
-    "site:deploy": "npm --prefix site run build && npx wrangler pages deploy site/dist --project-name=blancbrowser",
+    "site:deploy": "npm --prefix site run build && npx wrangler pages deploy site/dist --project-name=blancbrowser --branch=main",
     "test:unit": "node --test test/unit/*.test.js",
     "test:oauth:desktop": "node --test test/oauth/desktop.test.js",
     "test:oauth:live": "node scripts/oauth-canary.js",

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -29,11 +29,15 @@ external hashed files. Internal links are root-relative extensionless
 
 Commands (root proxies): `npm run site:dev`, `npm run site:build`, and
 `npm run site:deploy` (build + `npx wrangler pages deploy site/dist
---project-name=blancbrowser` to the Cloudflare Pages project `blancbrowser`,
+--project-name=blancbrowser --branch=main` to the Cloudflare Pages project `blancbrowser`,
 BNFY account, canonical domain `blancbrowser.com`; `getbowser.com` 301s there).
 **Deploy `site/dist`, never `site/`.** CI (`.github/workflows/site.yml`) builds
 the site on any change to `site/**`, root `package.json` (a build input — the
 JSON-LD `softwareVersion` imports its `version`), or the changelog generator.
+The explicit `--branch=main` is mandatory: release worktrees are detached at
+`origin/main`, and without it Wrangler labels the upload as a `HEAD` preview
+that never reaches the canonical domain. After deployment, confirm Wrangler
+reports `Environment: Production`, `Branch: main`, and the expected source SHA.
 
 **Changelog pipeline:** `scripts/generate-site-changelog.mjs` (root, needs an
 authenticated `gh`) fetches GitHub releases, scrubs the legacy "Bowser" name,

--- a/test/unit/site-deploy.test.js
+++ b/test/unit/site-deploy.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+test('site deploy pins Cloudflare Pages production instead of detached HEAD preview', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  const command = pkg.scripts?.['site:deploy'] || '';
+
+  assert.match(command, /wrangler pages deploy site\/dist\b/);
+  assert.match(command, /--project-name=blancbrowser\b/);
+  assert.match(command, /--branch=main\b/);
+});
+
+test('agent release runbooks require a production deployment assertion', () => {
+  for (const file of ['AGENTS.md', 'CLAUDE.md', 'site/CLAUDE.md', 'docs/release-verification.md']) {
+    const contents = fs.readFileSync(path.join(ROOT, file), 'utf8');
+    assert.match(contents, /--branch=main/, `${file} must preserve the production branch flag`);
+    assert.match(contents, /Production/, `${file} must require a production-environment check`);
+  }
+});


### PR DESCRIPTION
## Summary
- force the release-time site deploy command to target Cloudflare Pages branch main
- document why detached origin/main release worktrees otherwise become HEAD previews
- require operators to verify Production, main, and the expected source SHA
- add regression coverage for the production branch flag and agent runbooks

## Verification
- npm run test:unit (816/816)
- npm run site:build
- live recovery verified: Cloudflare Production / main / 1835ad6 and blancbrowser.com/changelog serves Blanc 1.5.0