### PR TITLE
Quiet tabs: dim-only — remove the per-row "quiet" text markers

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -75,3 +75,9 @@ change needed); sentinel re-armed. The deviations that were queued:
 - DesignSync write ordering: read → finalize_plan (deletes REQUIRED even if `[]`) → write_files.
 - 2026-08-16: Design API had a ~20-minute full 503 outage (reads and writes) mid-push; the same
   planId worked once the service recovered — outages here are worth waiting out, not replanning.
+- 2026-08-18: the APP diverged from the pushed Island.jsx — the per-row quiet word markers
+  (`.bw-row-quiet` in the DS mirror; `.row-quiet`/`.vertical-tab-quiet` in the app) were REMOVED
+  from the app (user decision, docs/superpowers/specs/2026-08-18-quiet-marker-dim-only-design.md;
+  quiet is dim-only now, aria keeps the word). Island.jsx, Island.prompt.md, and the chrome.card.html
+  quiet demo are stale until the next approved DesignSync push — do NOT re-mirror the chip back into
+  the app, and don't use DS renders of quiet rows as approval proof meanwhile.

--- a/docs/superpowers/specs/2026-08-18-quiet-marker-dim-only-design.md
+++ b/docs/superpowers/specs/2026-08-18-quiet-marker-dim-only-design.md
@@ -29,7 +29,10 @@ quiet tab just wakes it with a brief reload; nothing is lost or hidden.
 - The Glance picker's sub-metadata line (`domain · group · quiet`) — that is
   descriptive text in a picker, not a per-row badge, and the picker rows do
   not dim.
-- The `/sleep` command name and all "quiet" terminology (spec F-series).
+- The `/sleep` command name and all "quiet" terminology. (F31's visible-state
+  clause in `spec/features.md` is **updated** in this change — it mandated the
+  word marker and now records the dim-only decision; the rest of the F-series
+  is untouched.)
 - "private" keeps its chip (panel) and bare-text marker (rail): it is rare
   and identity-class, not row metadata. The "quiet must not drift from
   private" style comments are deleted along with the shared selectors.
@@ -43,4 +46,12 @@ quiet tab just wakes it with a brief reload; nothing is lost or hidden.
 - `src/renderer/styles.css` — drop `.row-quiet` / `.vertical-tab-quiet` from
   their shared chip/marker blocks; comments updated.
 - `test/unit/quiet-tabs-chrome.test.js` — the marker-presence guards flip to
-  absence guards in the same commit (deliberate policy change).
+  a whole-source absence guard in the same commit (deliberate policy change).
+- `spec/features.md` — F31's visible-state clause rewritten to the dim-only
+  contract, so the platform-neutral spec and the reference implementation
+  agree (same-commit rule, applied to the contract layer too).
+- `test/desktop/steps/quiet-tabs.steps.js` — the panel naming assertion is
+  comma-anchored (`/,\s*quiet/`); the bare `/quiet/` form matched the
+  fixture's own "quietable" title and could never fail.
+- `.design-sync/NOTES.md` — records that the Design System mirror
+  (`Island.jsx`'s `.bw-row-quiet`) is stale until the next approved push.

--- a/docs/superpowers/specs/2026-08-18-quiet-marker-dim-only-design.md
+++ b/docs/superpowers/specs/2026-08-18-quiet-marker-dim-only-design.md
@@ -1,0 +1,46 @@
+# Quiet tabs: dim-only marker (remove the "quiet" text labels)
+
+**Date:** 2026-08-18
+**Status:** Approved
+
+## Problem
+
+The ⌘L panel and the vertical rail render a lowercase mono "quiet" text
+marker on every quiet row. After a session restore most tabs are quiet, so
+the list shows a column of repeated labels at ragged x-positions — visual
+junk (user report with screenshot).
+
+## Decision
+
+Remove the visual "quiet" markers everywhere. The whole-row dim (0.5 opacity,
+hover/focus restores) becomes the only visual signal, in the panel and rail
+alike.
+
+This knowingly re-accepts the trade-off PR #123 avoided: right after a
+relaunch every restored row is dim at once, and a uniformly dim list doesn't
+read as a state. Accepted 2026-08-18 because the stakes are low — clicking a
+quiet tab just wakes it with a brief reload; nothing is lost or hidden.
+
+## What stays
+
+- The row dim in both surfaces, including hover/focus restore.
+- The word "quiet" in every **accessible name** (panel `Switch to …, quiet`,
+  rail states list) — screen-reader users keep the state.
+- The Glance picker's sub-metadata line (`domain · group · quiet`) — that is
+  descriptive text in a picker, not a per-row badge, and the picker rows do
+  not dim.
+- The `/sleep` command name and all "quiet" terminology (spec F-series).
+- "private" keeps its chip (panel) and bare-text marker (rail): it is rare
+  and identity-class, not row metadata. The "quiet must not drift from
+  private" style comments are deleted along with the shared selectors.
+
+## Changes
+
+- `src/renderer/overlay.js` — delete the `.row-quiet` tag block; keep the
+  row's `quiet` class and aria word.
+- `src/renderer/vertical-tabs.js` — delete the `.vertical-tab-quiet` marker
+  block; keep the aria states entry.
+- `src/renderer/styles.css` — drop `.row-quiet` / `.vertical-tab-quiet` from
+  their shared chip/marker blocks; comments updated.
+- `test/unit/quiet-tabs-chrome.test.js` — the marker-presence guards flip to
+  absence guards in the same commit (deliberate policy change).

--- a/spec/features.md
+++ b/spec/features.md
@@ -575,16 +575,17 @@ From the desktop `DEFAULTS`:
   return on ordinary static documents and are explicitly not promised on
   virtualized feeds (D23). A private tab comes back **where** it was, not **how**
   it was: private tabs retain no page state.
-- **The state is visible, and it is called "quiet"** everywhere a person or a
+- **The state is dim-only on screen, and it is called "quiet"** everywhere a
   screen reader can meet it — the panel row and the vertical rail row each dim
   as one unit, restoring full strength on hover/focus (the row is about to
-  wake), **and each carries the word `quiet`** in the same lowercase mono voice
-  as `private`, with `, quiet` in each accessible name. The word is load-bearing,
-  not decoration: restored tabs are born quiet, so after a relaunch nearly every
-  row is dim at once, and a uniformly dimmed list reads as ordinary styling
-  rather than as a state. There is no glyph or pictogram. It is deliberately
-  unmarked on the pill dots, in the Quick Switcher, in the native window menu,
-  and on the start page.
+  wake), with `, quiet` in each accessible name. There is no per-row text
+  marker, glyph, or pictogram: the word markers that used to ride beside
+  `private` were removed 2026-08-18 (the repeated labels read as junk once a
+  restore quiets most rows at once). The known cost — a fully-restored list
+  dims uniformly and reads as ordinary styling until some tabs wake — is
+  accepted: waking is transparent, so nothing is lost by not noticing. It is
+  deliberately unmarked on the pill dots, in the Quick Switcher, in the native
+  window menu, and on the start page.
 - Restored sessions come back quiet: after a relaunch only the active tab loads
   (F18).
 - The *behaviour* is D8; *who decides when* is D23.

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -467,11 +467,9 @@
       row.append(tag);
     }
 
-    // Quiet is dim-only: the row's `quiet` class fades it, and the accessible
-    // name above carries the word. The per-row "quiet" text marker was removed
-    // 2026-08-18 — after a restore most rows are quiet and the repeated labels
-    // read as junk. That a fully-restored list dims uniformly (and so reads as
-    // nothing) is a known, accepted trade-off: waking is transparent.
+    // Quiet is dim-only (the row's `quiet` class + the aria word above); no
+    // per-row marker — see docs/superpowers/specs/2026-08-18-quiet-marker-
+    // dim-only-design.md before reintroducing one.
 
     const pin = document.createElement('button');
     pin.className = 'row-pin' + (tab.pinned ? ' on' : '');

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -467,16 +467,11 @@
       row.append(tag);
     }
 
-    // Quiet needs an ABSOLUTE marker, not only the row dim: restored tabs are
-    // born quiet, so after a relaunch nearly every row is dim at once and a
-    // uniformly dimmed list reads as ordinary styling rather than as a state.
-    // Same lowercase mono voice as "private", and always visible at rest.
-    if (tab.asleep) {
-      const tag = document.createElement('span');
-      tag.className = 'row-quiet';
-      tag.textContent = 'quiet';
-      row.append(tag);
-    }
+    // Quiet is dim-only: the row's `quiet` class fades it, and the accessible
+    // name above carries the word. The per-row "quiet" text marker was removed
+    // 2026-08-18 — after a restore most rows are quiet and the repeated labels
+    // read as junk. That a fully-restored list dims uniformly (and so reads as
+    // nothing) is a known, accepted trade-off: waking is transparent.
 
     const pin = document.createElement('button');
     pin.className = 'row-pin' + (tab.pinned ? ' on' : '');

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -693,10 +693,9 @@ body.mac .vertical-tabs-toolbar {
   color: var(--text-dim);
 }
 
-/* The rail's word-markers share one block for the same reason as the panel's
-   chips: "quiet" must not drift from "private". */
-.vertical-tab-private,
-.vertical-tab-quiet {
+/* The rail's private word-marker. (The matching "quiet" marker was removed
+   2026-08-18 — quiet is dim-only now, via the row-level dim further down.) */
+.vertical-tab-private {
   max-width: 50px;
   overflow: hidden;
   color: var(--text-dim);
@@ -2104,11 +2103,10 @@ body[data-glance-purpose="change"] .glance-picker {
   stroke-linejoin: round;
 }
 
-/* "private" tag on private tabs in the switcher list */
-/* "quiet" rides beside "private" and shares its declaration block, so the two
-   row tags cannot drift apart. */
-.island-row .row-private,
-.island-row .row-quiet {
+/* "private" tag on private tabs in the switcher list. (The "quiet" chip that
+   rode beside it was removed 2026-08-18 — quiet is dim-only now, via the
+   row-level dim further down.) */
+.island-row .row-private {
   font-family: var(--font-mono);
   font-size: 10px;
   color: var(--text-dim);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -693,8 +693,7 @@ body.mac .vertical-tabs-toolbar {
   color: var(--text-dim);
 }
 
-/* The rail's private word-marker. (The matching "quiet" marker was removed
-   2026-08-18 — quiet is dim-only now, via the row-level dim further down.) */
+/* The rail's private word-marker. (Quiet is dim-only — 2026-08-18 spec.) */
 .vertical-tab-private {
   max-width: 50px;
   overflow: hidden;
@@ -2103,9 +2102,8 @@ body[data-glance-purpose="change"] .glance-picker {
   stroke-linejoin: round;
 }
 
-/* "private" tag on private tabs in the switcher list. (The "quiet" chip that
-   rode beside it was removed 2026-08-18 — quiet is dim-only now, via the
-   row-level dim further down.) */
+/* "private" tag on private tabs in the switcher list. (Quiet is dim-only —
+   2026-08-18 spec.) */
 .island-row .row-private {
   font-family: var(--font-mono);
   font-size: 10px;

--- a/src/renderer/vertical-tabs.js
+++ b/src/renderer/vertical-tabs.js
@@ -388,9 +388,8 @@
       privateMarker.setAttribute('aria-hidden', 'true');
       primary.appendChild(privateMarker);
     }
-    // Quiet is dim-only here too (see overlay.js's twin): the row dim plus the
-    // aria states entry above. The bare-text "quiet" marker was removed
-    // 2026-08-18 alongside the panel's.
+    // Quiet is dim-only here too (row dim + the aria states entry above); see
+    // the 2026-08-18 quiet-marker-dim-only spec before reintroducing a marker.
     if (tab.pinned) {
       primary.appendChild(makeMarker('vertical-tab-state vertical-tab-pin', ICONS.pin, 'Pinned'));
     }

--- a/src/renderer/vertical-tabs.js
+++ b/src/renderer/vertical-tabs.js
@@ -388,15 +388,9 @@
       privateMarker.setAttribute('aria-hidden', 'true');
       primary.appendChild(privateMarker);
     }
-    // See overlay.js's twin: the row dim is a relative signal, so quiet also
-    // carries a word — the rail's markers are bare text, like its "private".
-    if (tab.asleep) {
-      const quietMarker = document.createElement('span');
-      quietMarker.className = 'vertical-tab-quiet';
-      quietMarker.textContent = 'quiet';
-      quietMarker.setAttribute('aria-hidden', 'true');
-      primary.appendChild(quietMarker);
-    }
+    // Quiet is dim-only here too (see overlay.js's twin): the row dim plus the
+    // aria states entry above. The bare-text "quiet" marker was removed
+    // 2026-08-18 alongside the panel's.
     if (tab.pinned) {
       primary.appendChild(makeMarker('vertical-tab-state vertical-tab-pin', ICONS.pin, 'Pinned'));
     }

--- a/test/desktop/steps/quiet-tabs.steps.js
+++ b/test/desktop/steps/quiet-tabs.steps.js
@@ -349,7 +349,10 @@ Then('the panel stays open and names the row quiet', async function () {
   const row = rows.find((candidate) => candidate.title === this.quietCandidateTitle);
   assert.ok(row, 'quiet candidate missing from panel');
   assert.equal(row.quiet, true);
-  assert.match(row.label.toLowerCase(), /quiet/);
+  // Comma-anchored: the fixture is titled "quietable", so a bare /quiet/ would
+  // match the title substring and could never fail. The aria suffix is the
+  // only place the panel names the state now that the row is dim-only.
+  assert.match(row.label.toLowerCase(), /,\s*quiet/);
 });
 
 Then('the panel stays open and explains that no tab can be quieted', async function () {

--- a/test/unit/quiet-tabs-chrome.test.js
+++ b/test/unit/quiet-tabs-chrome.test.js
@@ -86,14 +86,7 @@ test('the row primary button carries the row layout', () => {
 test('a quiet panel row is classed and named "quiet" — dim-only, no visual tag', () => {
   assert.match(panelRowSource, /tab\.asleep \? ' quiet' : ''/);
   assert.match(panelRowSource, /tab\.asleep \? 'quiet' : ''/);
-  // The per-row "quiet" text marker was removed 2026-08-18 (user decision):
-  // after a restore most rows are quiet and the repeated labels read as junk.
-  // The row dim is the only visual; the accessible name keeps the word. A
-  // uniformly-dim restored list reading as nothing is a known, accepted
-  // trade-off — do not reintroduce a tag (or a glyph) without a new decision.
-  assert.doesNotMatch(panelRowSource, /row-quiet/);
   assert.doesNotMatch(panelRowSource, /QUIET_GLYPH|<svg/);
-  assert.doesNotMatch(styles, /\.row-quiet/);
 });
 
 test('no chrome surface ever says "asleep" to a user or a screen reader', () => {
@@ -136,9 +129,6 @@ test('a quiet rail row is classed and named "quiet" — dim-only, like the panel
   assert.match(railRowSource, /\(tab\.asleep \? ' quiet' : ''\)/);
   // The field is `asleep`; the string in the accessible name is 'quiet'.
   assert.match(railRowSource, /tab\.asleep && 'quiet'/);
-  // The bare-text marker was removed 2026-08-18 alongside the panel's chip.
-  assert.doesNotMatch(railRowSource, /vertical-tab-quiet/);
-  assert.doesNotMatch(styles, /\.vertical-tab-quiet/);
   // A word in the accessible name, never a glyph — no icon entry survives.
   assert.doesNotMatch(railSource, /QUIET_GLYPH|ICONS\.quiet/);
 });
@@ -263,13 +253,15 @@ test('the quiet glyph is fully deleted — file, serving allowlist, and referenc
   assert.doesNotMatch(chromeProtocol, /quiet-glyph/);
 });
 
-// The word markers that used to ride beside "private" on each surface were
-// removed 2026-08-18 (user decision): after a restore most rows are quiet and
-// the repeated labels read as junk. Quiet is dim-only now — the absence
-// guards live in the per-surface row tests above; "private" keeps its marker.
-test('the "private" markers survive quiet\'s removal on both surfaces', () => {
-  assert.match(styles, /\.island-row \.row-private\s*\{/, 'panel private chip');
-  assert.match(styles, /\.vertical-tab-private\s*\{/, 'rail private word-marker');
+// Quiet is dim-only: the per-row word markers were removed 2026-08-18 (user
+// decision — see docs/superpowers/specs/2026-08-18-quiet-marker-dim-only-
+// design.md). Do not reintroduce a marker without a new decision. Whole-file
+// scope on purpose: a marker reintroduced from ANY overlay/rail function, or
+// its CSS, fails here — not just one rebuilt inside tabRow.
+test('no quiet marker survives anywhere — chrome JS or CSS', () => {
+  assert.doesNotMatch(overlaySource, /row-quiet/);
+  assert.doesNotMatch(railSource, /vertical-tab-quiet/);
+  assert.doesNotMatch(styles, /row-quiet|vertical-tab-quiet/);
 });
 
 // Extracts the declarations of the first rule whose selector list starts with

--- a/test/unit/quiet-tabs-chrome.test.js
+++ b/test/unit/quiet-tabs-chrome.test.js
@@ -83,15 +83,17 @@ test('the row primary button carries the row layout', () => {
   assert.match(styles, /\.island-row \.row-primary\s*\{[^}]*min-width: 0;/s);
 });
 
-test('a quiet panel row is classed, named, and tagged "quiet"', () => {
+test('a quiet panel row is classed and named "quiet" — dim-only, no visual tag', () => {
   assert.match(panelRowSource, /tab\.asleep \? ' quiet' : ''/);
   assert.match(panelRowSource, /tab\.asleep \? 'quiet' : ''/);
-  // A WORD, not a pictogram: the tag reads at any density, unlike the row dim.
-  assert.match(panelRowSource, /tag\.className = 'row-quiet'/);
-  assert.match(panelRowSource, /tag\.textContent = 'quiet'/);
+  // The per-row "quiet" text marker was removed 2026-08-18 (user decision):
+  // after a restore most rows are quiet and the repeated labels read as junk.
+  // The row dim is the only visual; the accessible name keeps the word. A
+  // uniformly-dim restored list reading as nothing is a known, accepted
+  // trade-off — do not reintroduce a tag (or a glyph) without a new decision.
+  assert.doesNotMatch(panelRowSource, /row-quiet/);
   assert.doesNotMatch(panelRowSource, /QUIET_GLYPH|<svg/);
-  // Always visible, like .row-private — never a hover-gated .row-tag.
-  assert.doesNotMatch(styles, /\.island-row\.tab-row \.row-quiet/);
+  assert.doesNotMatch(styles, /\.row-quiet/);
 });
 
 test('no chrome surface ever says "asleep" to a user or a screen reader', () => {
@@ -130,13 +132,14 @@ test('the rail tabRow could be lifted from source', () => {
   assert.ok(railRowSource, 'tabRow not found in vertical-tabs.js — update this test with it');
 });
 
-test('a quiet rail row is classed, named, and marked with the word "quiet"', () => {
+test('a quiet rail row is classed and named "quiet" — dim-only, like the panel', () => {
   assert.match(railRowSource, /\(tab\.asleep \? ' quiet' : ''\)/);
   // The field is `asleep`; the string in the accessible name is 'quiet'.
   assert.match(railRowSource, /tab\.asleep && 'quiet'/);
-  assert.match(railRowSource, /quietMarker\.className = 'vertical-tab-quiet'/);
-  assert.match(railRowSource, /quietMarker\.textContent = 'quiet'/);
-  // A word, never a glyph — no icon entry survives for it.
+  // The bare-text marker was removed 2026-08-18 alongside the panel's chip.
+  assert.doesNotMatch(railRowSource, /vertical-tab-quiet/);
+  assert.doesNotMatch(styles, /\.vertical-tab-quiet/);
+  // A word in the accessible name, never a glyph — no icon entry survives.
   assert.doesNotMatch(railSource, /QUIET_GLYPH|ICONS\.quiet/);
 });
 
@@ -260,27 +263,13 @@ test('the quiet glyph is fully deleted — file, serving allowlist, and referenc
   assert.doesNotMatch(chromeProtocol, /quiet-glyph/);
 });
 
-// The row dim alone is a RELATIVE signal: restored tabs are born quiet, so
-// after a relaunch nearly every row is dim at once and the state stops reading.
-// Each surface therefore also carries the word, sharing its "private" block.
-test('each surface tags a quiet row with the word, beside "private"', () => {
-  assert.match(
-    styles,
-    /\.island-row \.row-private,\s*\n\s*\.island-row \.row-quiet\s*\{/,
-    'panel chips must share one declaration block'
-  );
-  assert.match(
-    styles,
-    /\.vertical-tab-private,\s*\n\s*\.vertical-tab-quiet\s*\{/,
-    'rail word-markers must share one declaration block'
-  );
-  // No SECOND, parallel rule may re-declare either one and let them drift. A
-  // `doesNotMatch` on the selector cannot express this — it would match the
-  // shared block's own second selector line — so count instead: each selector
-  // may appear exactly once in the stylesheet, inside the block above.
-  const occurrences = (needle) => styles.split(needle).length - 1;
-  assert.equal(occurrences('.island-row .row-quiet'), 1, 'one .row-quiet rule only');
-  assert.equal(occurrences('.vertical-tab-quiet'), 1, 'one .vertical-tab-quiet rule only');
+// The word markers that used to ride beside "private" on each surface were
+// removed 2026-08-18 (user decision): after a restore most rows are quiet and
+// the repeated labels read as junk. Quiet is dim-only now — the absence
+// guards live in the per-surface row tests above; "private" keeps its marker.
+test('the "private" markers survive quiet\'s removal on both surfaces', () => {
+  assert.match(styles, /\.island-row \.row-private\s*\{/, 'panel private chip');
+  assert.match(styles, /\.vertical-tab-private\s*\{/, 'rail private word-marker');
 });
 
 // Extracts the declarations of the first rule whose selector list starts with


### PR DESCRIPTION
## What

After a session restore most rows are quiet, so the ⌘L panel and the vertical rail showed a column of repeated `quiet` chips/markers at ragged x-positions — visual junk (user report with screenshot).

The per-row "quiet" text markers are removed on both surfaces. The whole-row dim (0.5 opacity, hover/focus restores full strength) is now the only visual signal.

**Kept:** the word `quiet` in every accessible name (panel and rail), the Glance picker's `domain · group · quiet` metadata line, the `/sleep` command, and "private"'s chip/marker.

**Known, accepted trade-off** (walked through explicitly): right after a relaunch every restored row is dim at once, so the state doesn't read visually until some tabs wake. Accepted because waking is transparent — a beat of reload, nothing lost. This re-decides the PR #123 rationale deliberately; the guard test now asserts the markers' absence and documents the decision.

## Verification

- `npm run test:unit` — 844 pass; `test/unit/quiet-tabs-chrome.test.js` marker-presence guards flipped to absence guards in the same commit
- `npm run substrate:check` — clean
- Live Playwright-Electron run: a genuinely-quieted tab's panel row has the `quiet` class at computed opacity 0.5, zero `.row-quiet` elements in the document, and its accessible name still ends ", quiet"

Spec: `docs/superpowers/specs/2026-08-18-quiet-marker-dim-only-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)