### PR TITLE
Release Blanc 1.6.0

### DIFF
--- a/docs/press/release-notes/v1.6.0.md
+++ b/docs/press/release-notes/v1.6.0.md
@@ -1,0 +1,7 @@
+# Blanc 1.6.0
+
+## Changed
+
+- Closing a tab now returns you to the tab you were actually on before it, not whichever tab happened to sit to its right. Blanc keeps a per-window history of which tabs you activated, and each close walks one step back through it — open something from mid-list, close it, and you're back where you started. When the history runs out (right after a relaunch, say), the old nearest-neighbor rule still applies.
+- The island is a steadier target. Its approach animation no longer pulls sideways toward your cursor, the remaining rise and growth are about half their old size, and the motion now finishes while your cursor is still on its way in — so by the time you click, nothing under the pointer is moving. The old motion could shift the pill's edge buttons by up to fifteen pixels mid-aim, which is exactly the kind of mis-click bait a browser's chrome shouldn't be.
+- Quiet tabs now show themselves by their fade alone. The `quiet` labels that repeated down the command panel and tab rail — one per dimmed row, which after a session restore meant most rows — are gone. A quiet row still dims to half strength, brightens when you reach for it, and still announces itself as quiet to screen readers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -6,7 +6,7 @@ import MemoryChart from '../components/MemoryChart.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 import releaseData from '../data/releases.json';
 
-const VERSION = '1.5.1';
+const VERSION = '1.6.0';
 const TAG = `v${VERSION}`;
 /* Wherever this page states a version and a date together, the date is that
    version's own ship date — read from the generated changelog data rather than

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.5.1');
+  assert.equal(packageVersion, '1.6.0');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
Version bump to 1.6.0 with release notes and press-page pins.

## Changed (see docs/press/release-notes/v1.6.0.md)

- Closing a tab returns to the previously active tab (per-window activation history; neighbor rule as fallback).
- Calmer island proximity motion: no sideways lean, ~half the rise/scale, fully settled 80px before the cursor arrives.
- Quiet tabs are dim-only — the per-row `quiet` labels are removed; accessible names keep the word.

Electron stays at ^43.4.0 (current Chromium-stable line, shipped in 1.5.1 yesterday).

🤖 Generated with [Claude Code](https://claude.com/claude-code)