### PR TITLE
Name v1.6.0's changes in the changelog feature overlay

### DIFF
--- a/site/src/data/release-feature-names.json
+++ b/site/src/data/release-feature-names.json
@@ -1,4 +1,5 @@
 {
+  "1.6.0": ["Return to previous tab", "Calmer Island motion", "Dim-only quiet tabs"],
   "1.5.0": ["Reopen Closed Tab", "Closed-tab picker", "Group close undo", "New-tab prompt", "Start page layouts", "First-run setup"],
   "1.4.0": ["Glance"],
   "1.3.0": ["Multiple windows", "Local profiles"],


### PR DESCRIPTION
## Why

`npm run test:unit` fails on the `site-changelog` guard **"feature-bearing releases always carry concise, searchable feature names"** with `1.6.0 needs at least one feature name`. `parity-guards.yml` runs `npm run test:unit` on every push/PR, so this is a red gate on any branch.

## Root cause

v1.6.0 is a minor (`.0`) release, which `site/src/lib/release-features.mjs` **deliberately** classifies as feature-bearing (the conservative `.0` fallback) — so the changelog already renders its "new features" badge. But its release notes are a `## Changed` section, so the bold-lead auto-extraction (which only reads `## Added`/`## Features` headings) can't derive names, and there was no curated overlay entry. The guard exists to catch exactly that badge-without-names inconsistency.

## Fix

Add the curated `"1.6.0"` entry to `site/src/data/release-feature-names.json` — the same editorial-overlay mechanism every prior release uses:

```json
"1.6.0": ["Return to previous tab", "Calmer Island motion", "Dim-only quiet tabs"]
```

Names describe v1.6.0's three actual changes (previous-tab focus on close, calmer Island proximity motion, dim-only quiet tabs); each is ≤40 chars. The overlay was chosen over editing the published GitHub release body because v1.6.0's changes are genuinely *Changed*, not *Added* — reshaping them into an `## Added` bold-lead section would misrepresent the release and would also mean mutating a published release plus regenerating `releases.json`.

## Verification

- `node --test test/unit/site-changelog.test.js` → **20/20**
- `npm run test:unit` → **844/844**, no regressions
- Replicated `changelog.astro`'s logic against the real data: v1.6.0 renders the badge + 3 chips (all ≤40 chars), and **no** other release is missing names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)