### PR TITLE
Blanc Patron design spec + Phase 1 entitlement plan

### DIFF
--- a/copy/generated/SlashCommands.strings
+++ b/copy/generated/SlashCommands.strings
@@ -19,3 +19,4 @@
 "slash_block_ads" = "Block ads here, or toggle blocking everywhere";
 "slash_allow_ads" = "Allow ads on this site";
 "slash_theme" = "Cycle appearance, or choose system / light / dark";
+"slash_patron" = "Support Blanc with a Patron subscription";

--- a/copy/generated/slash_commands.xml
+++ b/copy/generated/slash_commands.xml
@@ -20,4 +20,5 @@
     <string name="slash_block_ads">Block ads here, or toggle blocking everywhere</string>
     <string name="slash_allow_ads">Allow ads on this site</string>
     <string name="slash_theme">Cycle appearance, or choose system / light / dark</string>
+    <string name="slash_patron">Support Blanc with a Patron subscription</string>
 </resources>

--- a/copy/slash-commands.json
+++ b/copy/slash-commands.json
@@ -25,6 +25,7 @@
     { "command": "/find", "hint": "Find in page" },
     { "command": "/block-ads", "hint": "Block ads here, or toggle blocking everywhere" },
     { "command": "/allow-ads", "hint": "Allow ads on this site" },
-    { "command": "/theme", "hint": "Cycle appearance, or choose system / light / dark", "doc": { "command": "/theme [system|light|dark]", "hint": "Cycle appearance, or switch directly to system, light, or dark" } }
+    { "command": "/theme", "hint": "Cycle appearance, or choose system / light / dark", "doc": { "command": "/theme [system|light|dark]", "hint": "Cycle appearance, or switch directly to system, light, or dark" } },
+    { "command": "/patron", "hint": "Support Blanc with a Patron subscription" }
   ]
 }

--- a/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
+++ b/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
@@ -640,50 +640,88 @@ git commit -m "feat(patron): Settings Patron section and Patron-gated colorways"
 ### Task 9: Start page callout + `/patron` slash command
 
 **Files:**
-- Modify: `src/renderer/pages/newtab.html` / `newtab.js` / `pages.css` — start page callout.
+- Modify: `src/main/main.js` — add `patronActive` to `startPageStatus()` (line ~5665); add `patron` section mapping in `tabs:open-page` handler (line ~4319); add `/patron` to the `SLASH_COMMANDS` menu-doc array.
+- Modify: `src/main/pages.js` — include `patronActive` in the `pages:start:data` response.
+- Modify: `src/renderer/pages/newtab.html` / `newtab.js` / `pages.css` — start page callout, driven by both initial data and live status pushes.
 - Modify: `src/renderer/overlay.js` — `/patron` slash command.
 - Modify: `src/renderer/pages/shortcuts.js` — mirror the new command in the reference list.
-- Modify: `src/main/main.js` — add `/patron` to the `SLASH_COMMANDS` menu-doc array.
 - Modify: `copy/slash-commands.json` — add the command entry (substrate S3).
-- Modify: `src/main/pages.js` — include `patronActive` in the `pages:start:data` response so the start page knows whether to show the callout.
 
 **Interfaces:**
-- Consumes: `patronActive` from the `pages:start:data` payload and from the overlay's `state`.
+- Consumes: `patronActive` from both the `pages:start:data` initial payload and the `pages:start:status` live push.
 
-- [ ] **Step 1: Add `patronActive` to `pages:start:data`**
+- [ ] **Step 1: Add `patronActive` to both data and status channels**
 
-In `pages.js`, the `pages:start:data` handler (line ~232) returns groups, blocked counts, remote devices, and onboarding state. Add `patronActive: settings.isPatronActive()` to the returned object so the start page can gate the callout.
+In `pages.js`, add `patronActive: settings.isPatronActive()` to the `pages:start:data` handler's returned object (line ~232) so the start page gets the initial state on load.
 
-- [ ] **Step 2: Start page callout**
+In `main.js`, add `patronActive: settings.isPatronActive()` to `startPageStatus()` (line ~5665). This function is broadcast via `broadcastStartPageStatus()`, which fires on every `settings.onSettingsChanged` (line ~5688) — and `setPatron` fires those listeners, so an activation mid-session pushes the new state to every open start page without a reload.
 
-In `newtab.js`, when `patronActive` is false, render a quiet, non-intrusive callout in the ledger layout — below the favorites grid and above the footer. Keep it understated (one line, e.g. "Support Blanc" with a link that opens `blanc://settings/` scrolled to the Patron section). When `patronActive` is true, hide it. The callout must not dominate the start page or feel like an ad — this is an indie browser asking for support, not a nag screen.
+- [ ] **Step 2: Start page callout with live updates**
 
-- [ ] **Step 3: `/patron` slash command**
+In `newtab.js`, render a quiet, non-intrusive callout in the ledger layout — below the favorites grid and above the footer. Keep it understated (one line, e.g. "Support Blanc" with a link). When `patronActive` is true, hide it. The callout must not dominate the start page or feel like an ad.
+
+The callout state must update from **both** paths:
+
+```js
+// On initial load (from pages:start:data)
+function renderPatronCallout(patronActive) {
+  const el = document.getElementById('patron-callout');
+  if (el) el.hidden = !!patronActive;
+}
+
+// Called from the existing dataReady handler
+renderPatronCallout(data.patronActive);
+
+// On live status push (from pages:start:status) — add to the existing onStatus handler
+window.bowserPages?.start.onStatus((status) => {
+  renderLaunchStatus(status);
+  if (status?.layout && status.layout !== state.layout) applyLayout(status.layout);
+  if ('patronActive' in status) renderPatronCallout(status.patronActive);
+});
+```
+
+The callout link uses `window.bowserPages.openPage('settings', 'patron')` to deep-link to the Patron section (Step 3 wires the anchor).
+
+- [ ] **Step 3: `/patron` slash command + section deep-link**
+
+Add the `patron` section mapping in the `tabs:open-page` handler in `main.js` (line ~4319). Task 8 creates the Patron settings group with `id="group-patron"` (replacing the existing `#group-supporter`):
+
+```js
+const sectionMap = {
+  blocking: '#group-privacy',
+  patron: '#group-patron',
+};
+const fragment = name === 'settings' && sectionMap[section] ? sectionMap[section] : '';
+```
 
 Add to the `COMMANDS` array in `overlay.js`:
 
 ```js
-{ cmd: '/patron', hint: 'Support Blanc with a Patron subscription', run: () => window.browserAPI.openPage('settings') },
+{ cmd: '/patron', hint: 'Support Blanc with a Patron subscription', run: () => window.browserAPI.openPage('settings', 'patron') },
 ```
 
-The command opens Settings; the Patron section (Task 8) is the activation surface. Mirror the entry in `pages/shortcuts.js`, `main.js`'s `SLASH_COMMANDS`, and `copy/slash-commands.json`. Run `npm run copy:check` to verify the substrate guard passes.
+Mirror the entry in `pages/shortcuts.js`, `main.js`'s `SLASH_COMMANDS`, and `copy/slash-commands.json`. Run `npm run copy:check` to verify the substrate guard passes.
 
 - [ ] **Step 4: Verify manually (relaunch required)**
 
-Relaunch `npm start`. Confirm: the start page shows the callout when not a Patron and hides it after activation; `/patron` appears in the slash-command list and opens Settings; the shortcuts page lists it; `npm run copy:check` passes.
+Relaunch `npm start`. Confirm:
+- Start page shows callout when not a Patron.
+- Activating a sandbox key mid-session hides the callout on an already-open start page (the `pages:start:status` push, not a reload).
+- The callout link and `/patron` both open Settings scrolled to the Patron section.
+- `/patron` appears in the slash-command list; the shortcuts page lists it; `npm run copy:check` passes.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/renderer/pages/newtab.html src/renderer/pages/newtab.js src/renderer/pages/pages.css src/renderer/overlay.js src/renderer/pages/shortcuts.js src/main/main.js src/main/pages.js copy/slash-commands.json
-git commit -m "feat(patron): start page callout and /patron slash command"
+git add src/main/main.js src/main/pages.js src/renderer/pages/newtab.html src/renderer/pages/newtab.js src/renderer/pages/pages.css src/renderer/overlay.js src/renderer/pages/shortcuts.js copy/slash-commands.json
+git commit -m "feat(patron): start page callout (live-updating) and /patron slash command with section deep-link"
 ```
 
 ---
 
 ## Self-Review
 
-**Spec coverage (Phase 1):** entitlement record + kinds (T2–T4); benefit_id allowlist + fail-closed (T1, T5); **persisted-derived activity, restart-safe** (T2, T4); migration persisted via ensureStore+flush (T3, T4); validation with statuses/`expires_at`/defensive benefit_id/**per-validation benefit re-check**/cadence/bootstrap/grace (T2, T5); **activation inspects nested license-key status+expiry before bootstrapping grace** (T5); **three-state `parseExpiresAt` (null/number/false)** — activation rejects malformed, validation treats as ambiguous (T1, T2 unit test); **per-environment org ID** (`PRODUCTION_ORG_ID`/`SANDBOX_ORG_ID`, T5); projection strips both in the *correct* file (T6); downgrade mirror + subscription-never-mirrored (T3, T4); **setPatron fires listeners → Dock reapply** (T4); graceful degradation to `paper` (T4, T8); 200-char guard + malformed-JSON handling (T5); never synced / never generic-write (T4); **upgrade surfaces beyond Settings** — start page callout + `/patron` slash command (T9). ✓
+**Spec coverage (Phase 1):** entitlement record + kinds (T2–T4); benefit_id allowlist + fail-closed (T1, T5); **persisted-derived activity, restart-safe** (T2, T4); migration persisted via ensureStore+flush (T3, T4); validation with statuses/`expires_at`/defensive benefit_id/**per-validation benefit re-check**/cadence/bootstrap/grace (T2, T5); **activation inspects nested license-key status+expiry before bootstrapping grace** (T5); **three-state `parseExpiresAt` (null/number/false)** — activation rejects malformed, validation treats as ambiguous (T1, T2 unit test); **per-environment org ID** (`PRODUCTION_ORG_ID`/`SANDBOX_ORG_ID`, T5); projection strips both in the *correct* file (T6); downgrade mirror + subscription-never-mirrored (T3, T4); **setPatron fires listeners → Dock reapply** (T4); graceful degradation to `paper` (T4, T8); 200-char guard + malformed-JSON handling (T5); never synced / never generic-write (T4); **upgrade surfaces beyond Settings** — start page callout (live-updated via `pages:start:status` on activation, not just initial load) + `/patron` slash command with `patron` section deep-link (T9). ✓
 
 **Placeholder scan:** the only blanks are the real Polar `benefit_id` values in `BENEFIT_ALLOWLIST` and `SANDBOX_ORG_ID` (T5) — user-side product/org ids that do not exist until the Polar products are created; flagged as a setup invariant, not a hidden TODO.
 

--- a/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
+++ b/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
@@ -19,11 +19,12 @@ Copied verbatim from `docs/superpowers/specs/2026-08-18-blanc-patron-design.md`;
 - **Device-local, never synced.** Neither `patron` nor `supporter` is in `SYNCED_KEYS`; the generic `setSettings()` whitelist ignores both.
 - **Renderer sees only `patronActive`** — never the key, activation id, benefit id, or Polar status. The `pages.js` `clientSettings()` projection strips **both** `supporter` and `patron`.
 - **Fail open except one path.** Network failure / ambiguous / unknown status → stay active within the 30-day offline grace (clock from `lastValidatedAt`, bootstrapped at activation). Only a **confirmed terminal outcome** revokes. The single fail-*closed* path: an unrecognized `benefit_id` at activation grants nothing.
-- **Expiration is a field, not a status.** Response carries `status` plus a separate `expires_at`; never treat `expired` as a status value.
+- **Expiration is a field, not a status.** Response carries `status` plus a separate `expires_at`; never treat `expired` as a status value. **`Date.parse()` can return `NaN`** — treat an unparseable `expires_at` as ambiguous (leave the record unchanged), never as an expired terminal state.
+- **Activation inspects the response.** A 2xx alone is not enough: the nested license key's `status` must be `granted` and `expires_at` (if present and parseable) must be in the future before a `subscription` record is created. A malformed or inactive activation response must not bootstrap 30 days of entitlement.
 - **Validation re-checks the benefit.** Each successful validation must resolve the returned `benefit_id` to the expected `subscription` benefit before it may extend entitlement.
 - **Distinct `benefit_id` per product** is a setup invariant, verified in sandbox before production cutover.
 - **No DRM, no lockout, no user-data loss** on lapse — degrade gracefully. Preserve the existing **200-character key guard** and reject malformed successful JSON.
-- **Polar base switches on `app.isPackaged`** (`sandbox-api.polar.sh` dev, `api.polar.sh` packaged); the `benefit_id` allowlist has separate sandbox/production tables on the same switch. Org id `6f675077-6cb1-4965-8db8-15838e5fdb38` (public, from `supporter.js`).
+- **Polar base AND org ID switch on `app.isPackaged`**: `sandbox-api.polar.sh` / `SANDBOX_ORG_ID` in dev, `api.polar.sh` / `PRODUCTION_ORG_ID` in packaged. The production org id (`6f675077-6cb1-4965-8db8-15838e5fdb38`, from `supporter.js`) does not exist in sandbox — sending it there fails every activation. The `benefit_id` allowlist has separate sandbox/production tables on the same switch.
 - **Colorway fallback is `paper`** (`DEFAULTS.appIcon`), applied on the read path; invalid writes are ignored.
 
 **Testing note:** run a single model file with `node --test test/unit/patron-model.test.js` (targeted TDD). `npm run test:unit` always expands to the whole suite — use it only for the final full-suite check.
@@ -36,7 +37,7 @@ Copied verbatim from `docs/superpowers/specs/2026-08-18-blanc-patron-design.md`;
 
 ## File Structure
 
-- **Create `src/main/patron-model.js`** — pure, no `require('electron')`. Exports `readBenefitId`, `resolveKind`, `GRACE_MS`, `isRecordActive`, `evaluateValidation`, `migrateSupporter`, `downgradeMirror`.
+- **Create `src/main/patron-model.js`** — pure, no `require('electron')`. Exports `readBenefitId`, `resolveKind`, `parseExpiresAt`, `GRACE_MS`, `isRecordActive`, `evaluateValidation`, `migrateSupporter`, `downgradeMirror`.
 - **Create `test/unit/patron-model.test.js`** — `node:test` coverage for every branch.
 - **Modify `src/main/settings.js`** — `patron` default; migration inside `ensureStore()`; `isPatronActive()`; `setPatron()` (fires `listeners`); `isAppIconAllowed()`; `getPatronRecord()` (main-only).
 - **Create `src/main/patron.js`** — Polar `activate` + `validateIfDue`, each delegating to `patron-model`.
@@ -55,6 +56,7 @@ Copied verbatim from `docs/superpowers/specs/2026-08-18-blanc-patron-design.md`;
 **Interfaces — Produces:**
 - `readBenefitId(payload) -> string | null` — defensively reads `benefit_id` from a Polar activate or validate payload: `payload.benefit_id`, then `payload.license_key?.benefit_id`, then `payload.activation?.license_key?.benefit_id`.
 - `resolveKind(benefitId, allowlist) -> 'founding'|'lifetime'|'subscription'|null` — **fail-closed**: requires `benefitId` be a non-empty string, uses an own-property check (rejects inherited `toString`/`constructor`/`__proto__`), and returns `null` unless the mapped value is a known kind.
+- `parseExpiresAt(raw) -> number | null` — returns a valid epoch-ms number, or `null` if the input is falsy, non-string, or `Date.parse` returns `NaN`. Centralizes the `NaN` guard so callers never compare a `NaN` expiry against `now` (which classifies as expired terminal — contrary to the spec's "ambiguous responses don't revoke" rule).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -62,7 +64,7 @@ Copied verbatim from `docs/superpowers/specs/2026-08-18-blanc-patron-design.md`;
 // test/unit/patron-model.test.js
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { readBenefitId, resolveKind } = require('../../src/main/patron-model');
+const { readBenefitId, resolveKind, parseExpiresAt } = require('../../src/main/patron-model');
 
 const ALLOW = { ben_supporter: 'founding', ben_annual: 'subscription', ben_monthly: 'subscription', ben_lifetime: 'lifetime' };
 
@@ -92,6 +94,15 @@ test('resolveKind fails closed on unknown, empty, non-string, and inherited prop
   // a benefit mapped to a NON-kind value must not leak through
   assert.equal(resolveKind('x', { x: 'not_a_kind' }), null);
 });
+
+test('parseExpiresAt returns epoch-ms for valid ISO strings, null for garbage/NaN/falsy', () => {
+  assert.equal(parseExpiresAt('2026-12-31T00:00:00Z'), Date.parse('2026-12-31T00:00:00Z'));
+  assert.equal(parseExpiresAt(null), null);
+  assert.equal(parseExpiresAt(undefined), null);
+  assert.equal(parseExpiresAt(''), null);
+  assert.equal(parseExpiresAt('not-a-date'), null); // Date.parse returns NaN → null
+  assert.equal(parseExpiresAt(12345), null);         // non-string → null
+});
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -116,6 +127,12 @@ function readBenefitId(payload) {
     ?? null;
 }
 
+function parseExpiresAt(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const ms = Date.parse(raw);
+  return Number.isNaN(ms) ? null : ms;
+}
+
 function resolveKind(benefitId, allowlist) {
   if (typeof benefitId !== 'string' || benefitId === '') return null;
   if (!allowlist || typeof allowlist !== 'object') return null;
@@ -124,13 +141,13 @@ function resolveKind(benefitId, allowlist) {
   return KINDS.has(kind) ? kind : null;
 }
 
-module.exports = { readBenefitId, resolveKind };
+module.exports = { readBenefitId, resolveKind, parseExpiresAt };
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `node --test test/unit/patron-model.test.js`
-Expected: PASS (3 tests).
+Expected: PASS (4 tests).
 
 - [ ] **Step 5: Commit**
 
@@ -192,6 +209,14 @@ test('revoked, expired, and benefit mismatch each degrade', () => {
   assert.equal(mismatch.record.lastStatus, 'benefit_mismatch');
 });
 
+test('NaN expires_at is ambiguous, not a terminal expired state', () => {
+  const now = 5000;
+  const nanExpiry = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: NaN, benefitOk: true }, record: sub(), now });
+  assert.equal(nanExpiry.active, true);
+  assert.equal(nanExpiry.record.lastValidatedAt, 1000); // unchanged — treated as ambiguous
+  assert.equal(nanExpiry.record.lastStatus, 'granted'); // unchanged — rides grace
+});
+
 test('unknown status and unreachable ride the grace, do not advance lastValidatedAt', () => {
   const withinNow = 1000 + GRACE_MS;
   const unknown = evaluateValidation({ outcome: { kind: 'ok', status: 'weird_new', expiresAt: null, benefitOk: true }, record: sub(), now: withinNow });
@@ -228,8 +253,12 @@ function evaluateValidation({ outcome, record, now }) {
   if (outcome.kind === 'ok') {
     next.lastAttemptedAt = now;
     const granted = outcome.status === 'granted';
-    const unexpired = outcome.expiresAt == null || outcome.expiresAt > now;
-    if (granted && unexpired && outcome.benefitOk) {
+    const expiryKnown = outcome.expiresAt != null && !Number.isNaN(outcome.expiresAt);
+    const unexpired = !expiryKnown || outcome.expiresAt > now;
+    const expiryAmbiguous = outcome.expiresAt != null && Number.isNaN(outcome.expiresAt);
+    if (expiryAmbiguous && granted) {
+      // NaN from Date.parse — ambiguous, not terminal; leave record unchanged (ride grace)
+    } else if (granted && unexpired && outcome.benefitOk) {
       next.lastStatus = 'granted';
       next.lastValidatedAt = now;
     } else if (TERMINAL.has(outcome.status)) {
@@ -246,7 +275,7 @@ function evaluateValidation({ outcome, record, now }) {
   return { active: isRecordActive(next, now), record: next };
 }
 
-module.exports = { readBenefitId, resolveKind, GRACE_MS, isRecordActive, evaluateValidation };
+module.exports = { readBenefitId, resolveKind, parseExpiresAt, GRACE_MS, isRecordActive, evaluateValidation };
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -317,7 +346,7 @@ function downgradeMirror(patron) {
   return { key: patron.key, activationId: patron.activationId ?? null, activatedAt: patron.activatedAt };
 }
 
-module.exports = { readBenefitId, resolveKind, GRACE_MS, isRecordActive, evaluateValidation, migrateSupporter, downgradeMirror };
+module.exports = { readBenefitId, resolveKind, parseExpiresAt, GRACE_MS, isRecordActive, evaluateValidation, migrateSupporter, downgradeMirror };
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -416,46 +445,57 @@ git commit -m "feat(patron): settings record, ensureStore migration+flush, isPat
 - Consumes: `readBenefitId`, `resolveKind`, `evaluateValidation` from `patron-model`; `setPatron`, `getPatronRecord` from `settings`.
 - Produces: `activate(key) -> Promise<{ ok, message?, kind? }>`, `validateIfDue() -> Promise<void>`.
 
-- [ ] **Step 1: Scaffold API base + allowlist + `activate` (with 200-char guard, fail-closed benefit, malformed-JSON catch)**
+- [ ] **Step 1: Scaffold API base + per-environment org ID + allowlist + `activate` (with 200-char guard, activation response validation, fail-closed benefit, malformed-JSON catch)**
 
 ```js
-const { app, net } = require('electron');
-const settings = require('./settings');
-const model = require('./patron-model');
+const { app, net } = require(‘electron’);
+const settings = require(‘./settings’);
+const model = require(‘./patron-model’);
 
-const ORG_ID = '6f675077-6cb1-4965-8db8-15838e5fdb38'; // public org "bnfy" (from supporter.js)
-const API_BASE = app.isPackaged ? 'https://api.polar.sh' : 'https://sandbox-api.polar.sh';
+const PRODUCTION_ORG_ID = ‘6f675077-6cb1-4965-8db8-15838e5fdb38’; // public org "bnfy" (from supporter.js)
+const SANDBOX_ORG_ID = ‘/* fill from Polar sandbox dashboard */’;
+const API_BASE = app.isPackaged ? ‘https://api.polar.sh’ : ‘https://sandbox-api.polar.sh’;
+const ORG_ID = app.isPackaged ? PRODUCTION_ORG_ID : SANDBOX_ORG_ID;
 const MAX_KEY_LENGTH = 200; // preserved from supporter.js — client-side stray-paste backstop
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 // SETUP INVARIANT: each product uses a DISTINCT license-key benefit. Fill from the Polar
 // dashboard; verify the SANDBOX ids in sandbox before the production cutover.
 const BENEFIT_ALLOWLIST = app.isPackaged
-  ? { /* prod:    '<supporter>':'founding', '<annual>':'subscription', '<monthly>':'subscription' */ }
-  : { /* sandbox: '<supporter>':'founding', '<annual>':'subscription', '<monthly>':'subscription' */ };
+  ? { /* prod:    ‘<supporter>’:’founding’, ‘<annual>’:’subscription’, ‘<monthly>’:’subscription’ */ }
+  : { /* sandbox: ‘<supporter>’:’founding’, ‘<annual>’:’subscription’, ‘<monthly>’:’subscription’ */ };
 
 async function readJson(res) { try { return await res.json(); } catch { return null; } }
 
 async function activate(key) {
-  const trimmed = String(key ?? '').trim();
-  if (!trimmed) return { ok: false, message: 'Enter a license key.' };
-  if (trimmed.length > MAX_KEY_LENGTH) return { ok: false, message: 'That doesn’t look like a license key.' };
+  const trimmed = String(key ?? ‘’).trim();
+  if (!trimmed) return { ok: false, message: ‘Enter a license key.’ };
+  if (trimmed.length > MAX_KEY_LENGTH) return { ok: false, message: ‘That doesn’t look like a license key.’ };
   let res;
   try {
     res = await net.fetch(`${API_BASE}/v1/customer-portal/license-keys/activate`, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ key: trimmed, organization_id: ORG_ID, label: 'Blanc' }),
+      method: ‘POST’, headers: { ‘Content-Type’: ‘application/json’ },
+      body: JSON.stringify({ key: trimmed, organization_id: ORG_ID, label: ‘Blanc’ }),
     });
   } catch { return { ok: false, message: "Couldn’t reach Polar — check your connection and try again." }; }
-  if (!res.ok) return { ok: false, message: 'That license key could not be activated.' };
+  if (!res.ok) return { ok: false, message: ‘That license key could not be activated.’ };
   const payload = await readJson(res);
   const benefitId = model.readBenefitId(payload);
   const kind = model.resolveKind(benefitId, BENEFIT_ALLOWLIST);
-  if (!payload || !kind) return { ok: false, message: 'That license key is not recognized.' }; // fail closed / malformed
+  if (!payload || !kind) return { ok: false, message: ‘That license key is not recognized.’ }; // fail closed / malformed
+  // For subscriptions, inspect the nested license key BEFORE bootstrapping 30 days of grace.
+  // A 2xx alone is not enough — the key must be granted and unexpired.
+  if (kind === ‘subscription’) {
+    const lk = payload.license_key ?? payload.activation?.license_key ?? {};
+    const lkStatus = lk.status;
+    const lkExpiry = model.parseExpiresAt(lk.expires_at);
+    if (lkStatus !== ‘granted’) return { ok: false, message: ‘That subscription is not currently active.’ };
+    if (lkExpiry !== null && lkExpiry <= Date.now()) return { ok: false, message: ‘That subscription has expired.’ };
+  }
   const now = Date.now();
   const activationId = payload.activation?.id ?? payload.id ?? null;
   const record = { kind, key: trimmed, activationId, benefitId, activatedAt: now,
-    ...(kind === 'subscription' ? { lastValidatedAt: now, lastAttemptedAt: now, lastStatus: 'granted' } : {}) };
+    ...(kind === ‘subscription’ ? { lastValidatedAt: now, lastAttemptedAt: now, lastStatus: ‘granted’ } : {}) };
   settings.setPatron(record); // isPatronActive derives activity; no separate flag
   return { ok: true, kind };
 }
@@ -479,7 +519,7 @@ async function validateIfDue() {
       outcome = { kind: 'unreachable' };                 // non-ok OR malformed successful JSON → ambiguous
     } else {
       const benefitOk = model.resolveKind(model.readBenefitId(body), BENEFIT_ALLOWLIST) === 'subscription';
-      outcome = { kind: 'ok', status: body.status, expiresAt: body.expires_at ? Date.parse(body.expires_at) : null, benefitOk };
+      outcome = { kind: 'ok', status: body.status, expiresAt: model.parseExpiresAt(body.expires_at), benefitOk };
     }
   } catch { outcome = { kind: 'unreachable' }; }
   const { record } = model.evaluateValidation({ outcome, record: p, now: Date.now() });
@@ -557,7 +597,7 @@ git commit -m "feat(patron): pages.js projection strips patron + adds patronActi
 
 - [ ] **Step 1: Schedule `validateIfDue` off the critical path**
 
-After the window is up and the app is idle (reuse the existing post-launch deferred-work hook; do **not** run during `installStartupNavigationGate`), call `patron.validateIfDue()` once, then on a daily interval. It must never block startup or navigation; its own once-per-day guard lives in the model wiring.
+Place a `setImmediate` call after `releaseStartup()` has released the navigation gate and restored tabs — alongside `setupAutoUpdater()` (line ~6244 of `main.js`). Fire `patron.validateIfDue()` once, then on a daily `setInterval`. It must never run during `installStartupNavigationGate` or block the ready chain; its own once-per-day guard (the `lastAttemptedAt` check in the model) prevents redundant network calls within a single run.
 
 - [ ] **Step 2: Verify manually**
 
@@ -597,9 +637,9 @@ git commit -m "feat(patron): Settings Patron section and Patron-gated colorways"
 
 ## Self-Review
 
-**Spec coverage (Phase 1):** entitlement record + kinds (T2–T4); benefit_id allowlist + fail-closed (T1, T5); **persisted-derived activity, restart-safe** (T2, T4); migration persisted via ensureStore+flush (T3, T4); validation with statuses/`expires_at`/defensive benefit_id/**per-validation benefit re-check**/cadence/bootstrap/grace (T2, T5); projection strips both in the *correct* file (T6); downgrade mirror + subscription-never-mirrored (T3, T4); **setPatron fires listeners → Dock reapply** (T4); graceful degradation to `paper` (T4, T8); 200-char guard + malformed-JSON handling (T5); never synced / never generic-write (T4). ✓
+**Spec coverage (Phase 1):** entitlement record + kinds (T2–T4); benefit_id allowlist + fail-closed (T1, T5); **persisted-derived activity, restart-safe** (T2, T4); migration persisted via ensureStore+flush (T3, T4); validation with statuses/`expires_at`/defensive benefit_id/**per-validation benefit re-check**/cadence/bootstrap/grace (T2, T5); **activation inspects nested license-key status+expiry before bootstrapping grace** (T5); **NaN `Date.parse` treated as ambiguous, not terminal** (T1 `parseExpiresAt`, T2 unit test); **per-environment org ID** (`PRODUCTION_ORG_ID`/`SANDBOX_ORG_ID`, T5); projection strips both in the *correct* file (T6); downgrade mirror + subscription-never-mirrored (T3, T4); **setPatron fires listeners → Dock reapply** (T4); graceful degradation to `paper` (T4, T8); 200-char guard + malformed-JSON handling (T5); never synced / never generic-write (T4). ✓
 
-**Placeholder scan:** the only blanks are the real Polar `benefit_id` values in `BENEFIT_ALLOWLIST` (T5) — user-side product ids that do not exist until the Polar products are created; flagged as a setup invariant, not a hidden TODO.
+**Placeholder scan:** the only blanks are the real Polar `benefit_id` values in `BENEFIT_ALLOWLIST` and `SANDBOX_ORG_ID` (T5) — user-side product/org ids that do not exist until the Polar products are created; flagged as a setup invariant, not a hidden TODO.
 
 **Type consistency:** `readBenefitId`, `resolveKind`, `GRACE_MS`, `isRecordActive`, `evaluateValidation`, `migrateSupporter`, `downgradeMirror`, `isPatronActive`, `setPatron`, `getPatronRecord`, `activate`, `validateIfDue` are used with consistent signatures across tasks. `evaluateValidation` consumers use only its `.record` (activity is re-derived by `isPatronActive`/`isRecordActive`), so no stale-flag path exists.
 

--- a/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
+++ b/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ship the Patron entitlement foundation — a device-local `patron` record with three kinds (`founding` / `lifetime` / `subscription`), Polar activation + subscription validation with a 30-day offline grace and graceful degradation, migration of existing `$19` Supporters to founding Patrons, and re-gating the three cosmetic colorways under Patron — with nothing else gating until this exists.
+**Goal:** Ship the Patron entitlement foundation — a device-local `patron` record with three kinds (`founding` / `lifetime` / `subscription`), Polar activation + subscription validation with a 30-day offline grace and graceful degradation, migration of existing `$19` Supporters to founding Patrons, re-gating the three cosmetic colorways under Patron, and upgrade surfaces (start page callout + `/patron` slash command) — with nothing else gating until this exists.
 
 **Architecture:** All entitlement *decisions* live in a new pure, Electron-free `src/main/patron-model.js` (mirrors `tabsync-model.js` / `session-workspace.js`), covered by `node:test` unit tests. **Subscription activity is derived from the persisted record** (`isRecordActive`), never a volatile in-memory flag, so a restart cannot lock out a valid subscriber. `src/main/patron.js` wraps Polar's `net.fetch` calls and delegates every decision to the pure model. `src/main/settings.js` gains the `patron` record, `isPatronActive()`, `setPatron()`, the extended `isAppIconAllowed()`, a one-time migration run **inside `ensureStore()`** (against `store.data`, flushed synchronously), and fires the existing `listeners` set on change. The renderer projection and activation IPC are edited in **`src/main/pages.js`** (where they actually live). `src/main/main.js` only schedules the daily background validation.
 
@@ -44,6 +44,9 @@ Copied verbatim from `docs/superpowers/specs/2026-08-18-blanc-patron-design.md`;
 - **Modify `src/main/pages.js`** — `clientSettings()` strips `patron` + adds `patronActive`; route `pages:settings:supporter-activate` to `patron.activate`.
 - **Modify `src/main/main.js`** — idle-scheduled daily `validateIfDue`.
 - **Modify `src/renderer/pages/settings.*`** — Patron section + colorways re-gated on `patronActive` (manual verification).
+- **Modify `src/renderer/pages/newtab.*`** — quiet Patron callout when not active; hidden when active.
+- **Modify `src/renderer/overlay.js`** — `/patron` slash command opens Settings.
+- **Modify `src/renderer/pages/shortcuts.js`** + **`src/main/main.js`** + **`copy/slash-commands.json`** — mirror the new command (substrate S3 guard).
 
 ---
 
@@ -634,9 +637,53 @@ git commit -m "feat(patron): Settings Patron section and Patron-gated colorways"
 
 ---
 
+### Task 9: Start page callout + `/patron` slash command
+
+**Files:**
+- Modify: `src/renderer/pages/newtab.html` / `newtab.js` / `pages.css` — start page callout.
+- Modify: `src/renderer/overlay.js` — `/patron` slash command.
+- Modify: `src/renderer/pages/shortcuts.js` — mirror the new command in the reference list.
+- Modify: `src/main/main.js` — add `/patron` to the `SLASH_COMMANDS` menu-doc array.
+- Modify: `copy/slash-commands.json` — add the command entry (substrate S3).
+- Modify: `src/main/pages.js` — include `patronActive` in the `pages:start:data` response so the start page knows whether to show the callout.
+
+**Interfaces:**
+- Consumes: `patronActive` from the `pages:start:data` payload and from the overlay's `state`.
+
+- [ ] **Step 1: Add `patronActive` to `pages:start:data`**
+
+In `pages.js`, the `pages:start:data` handler (line ~232) returns groups, blocked counts, remote devices, and onboarding state. Add `patronActive: settings.isPatronActive()` to the returned object so the start page can gate the callout.
+
+- [ ] **Step 2: Start page callout**
+
+In `newtab.js`, when `patronActive` is false, render a quiet, non-intrusive callout in the ledger layout — below the favorites grid and above the footer. Keep it understated (one line, e.g. "Support Blanc" with a link that opens `blanc://settings/` scrolled to the Patron section). When `patronActive` is true, hide it. The callout must not dominate the start page or feel like an ad — this is an indie browser asking for support, not a nag screen.
+
+- [ ] **Step 3: `/patron` slash command**
+
+Add to the `COMMANDS` array in `overlay.js`:
+
+```js
+{ cmd: '/patron', hint: 'Support Blanc with a Patron subscription', run: () => window.browserAPI.openPage('settings') },
+```
+
+The command opens Settings; the Patron section (Task 8) is the activation surface. Mirror the entry in `pages/shortcuts.js`, `main.js`'s `SLASH_COMMANDS`, and `copy/slash-commands.json`. Run `npm run copy:check` to verify the substrate guard passes.
+
+- [ ] **Step 4: Verify manually (relaunch required)**
+
+Relaunch `npm start`. Confirm: the start page shows the callout when not a Patron and hides it after activation; `/patron` appears in the slash-command list and opens Settings; the shortcuts page lists it; `npm run copy:check` passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/pages/newtab.html src/renderer/pages/newtab.js src/renderer/pages/pages.css src/renderer/overlay.js src/renderer/pages/shortcuts.js src/main/main.js src/main/pages.js copy/slash-commands.json
+git commit -m "feat(patron): start page callout and /patron slash command"
+```
+
+---
+
 ## Self-Review
 
-**Spec coverage (Phase 1):** entitlement record + kinds (T2–T4); benefit_id allowlist + fail-closed (T1, T5); **persisted-derived activity, restart-safe** (T2, T4); migration persisted via ensureStore+flush (T3, T4); validation with statuses/`expires_at`/defensive benefit_id/**per-validation benefit re-check**/cadence/bootstrap/grace (T2, T5); **activation inspects nested license-key status+expiry before bootstrapping grace** (T5); **three-state `parseExpiresAt` (null/number/false)** — activation rejects malformed, validation treats as ambiguous (T1, T2 unit test); **per-environment org ID** (`PRODUCTION_ORG_ID`/`SANDBOX_ORG_ID`, T5); projection strips both in the *correct* file (T6); downgrade mirror + subscription-never-mirrored (T3, T4); **setPatron fires listeners → Dock reapply** (T4); graceful degradation to `paper` (T4, T8); 200-char guard + malformed-JSON handling (T5); never synced / never generic-write (T4). ✓
+**Spec coverage (Phase 1):** entitlement record + kinds (T2–T4); benefit_id allowlist + fail-closed (T1, T5); **persisted-derived activity, restart-safe** (T2, T4); migration persisted via ensureStore+flush (T3, T4); validation with statuses/`expires_at`/defensive benefit_id/**per-validation benefit re-check**/cadence/bootstrap/grace (T2, T5); **activation inspects nested license-key status+expiry before bootstrapping grace** (T5); **three-state `parseExpiresAt` (null/number/false)** — activation rejects malformed, validation treats as ambiguous (T1, T2 unit test); **per-environment org ID** (`PRODUCTION_ORG_ID`/`SANDBOX_ORG_ID`, T5); projection strips both in the *correct* file (T6); downgrade mirror + subscription-never-mirrored (T3, T4); **setPatron fires listeners → Dock reapply** (T4); graceful degradation to `paper` (T4, T8); 200-char guard + malformed-JSON handling (T5); never synced / never generic-write (T4); **upgrade surfaces beyond Settings** — start page callout + `/patron` slash command (T9). ✓
 
 **Placeholder scan:** the only blanks are the real Polar `benefit_id` values in `BENEFIT_ALLOWLIST` and `SANDBOX_ORG_ID` (T5) — user-side product/org ids that do not exist until the Polar products are created; flagged as a setup invariant, not a hidden TODO.
 

--- a/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
+++ b/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
@@ -19,7 +19,7 @@ Copied verbatim from `docs/superpowers/specs/2026-08-18-blanc-patron-design.md`;
 - **Device-local, never synced.** Neither `patron` nor `supporter` is in `SYNCED_KEYS`; the generic `setSettings()` whitelist ignores both.
 - **Renderer sees only `patronActive`** — never the key, activation id, benefit id, or Polar status. The `pages.js` `clientSettings()` projection strips **both** `supporter` and `patron`.
 - **Fail open except one path.** Network failure / ambiguous / unknown status → stay active within the 30-day offline grace (clock from `lastValidatedAt`, bootstrapped at activation). Only a **confirmed terminal outcome** revokes. The single fail-*closed* path: an unrecognized `benefit_id` at activation grants nothing.
-- **Expiration is a field, not a status.** Response carries `status` plus a separate `expires_at`; never treat `expired` as a status value. **`Date.parse()` can return `NaN`** — treat an unparseable `expires_at` as ambiguous (leave the record unchanged), never as an expired terminal state.
+- **Expiration is a field, not a status.** Response carries `status` plus a separate `expires_at`; never treat `expired` as a status value. **`parseExpiresAt` returns three states:** `null` (absent — no expiry), a number (valid epoch-ms), or `false` (present but malformed). Activation rejects `false`; validation treats `false` as ambiguous (rides grace). This prevents both a malformed string silently extending entitlement and a `NaN` comparison classifying as expired terminal.
 - **Activation inspects the response.** A 2xx alone is not enough: the nested license key's `status` must be `granted` and `expires_at` (if present and parseable) must be in the future before a `subscription` record is created. A malformed or inactive activation response must not bootstrap 30 days of entitlement.
 - **Validation re-checks the benefit.** Each successful validation must resolve the returned `benefit_id` to the expected `subscription` benefit before it may extend entitlement.
 - **Distinct `benefit_id` per product** is a setup invariant, verified in sandbox before production cutover.
@@ -56,7 +56,7 @@ Copied verbatim from `docs/superpowers/specs/2026-08-18-blanc-patron-design.md`;
 **Interfaces — Produces:**
 - `readBenefitId(payload) -> string | null` — defensively reads `benefit_id` from a Polar activate or validate payload: `payload.benefit_id`, then `payload.license_key?.benefit_id`, then `payload.activation?.license_key?.benefit_id`.
 - `resolveKind(benefitId, allowlist) -> 'founding'|'lifetime'|'subscription'|null` — **fail-closed**: requires `benefitId` be a non-empty string, uses an own-property check (rejects inherited `toString`/`constructor`/`__proto__`), and returns `null` unless the mapped value is a known kind.
-- `parseExpiresAt(raw) -> number | null` — returns a valid epoch-ms number, or `null` if the input is falsy, non-string, or `Date.parse` returns `NaN`. Centralizes the `NaN` guard so callers never compare a `NaN` expiry against `now` (which classifies as expired terminal — contrary to the spec's "ambiguous responses don't revoke" rule).
+- `parseExpiresAt(raw) -> number | null | false` — three states: absent/falsy → `null` (no expiry set); valid ISO string → epoch-ms number; present-but-malformed → `false`. Callers distinguish "no expiry" (allow) from "invalid expiry" (activation rejects; validation treats as ambiguous). This prevents both a malformed string silently extending entitlement and a `NaN` comparison classifying as expired terminal.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -95,13 +95,17 @@ test('resolveKind fails closed on unknown, empty, non-string, and inherited prop
   assert.equal(resolveKind('x', { x: 'not_a_kind' }), null);
 });
 
-test('parseExpiresAt returns epoch-ms for valid ISO strings, null for garbage/NaN/falsy', () => {
-  assert.equal(parseExpiresAt('2026-12-31T00:00:00Z'), Date.parse('2026-12-31T00:00:00Z'));
-  assert.equal(parseExpiresAt(null), null);
-  assert.equal(parseExpiresAt(undefined), null);
-  assert.equal(parseExpiresAt(''), null);
-  assert.equal(parseExpiresAt('not-a-date'), null); // Date.parse returns NaN → null
-  assert.equal(parseExpiresAt(12345), null);         // non-string → null
+test('parseExpiresAt: three states — null (absent), number (valid), false (malformed)', () => {
+  // absent / falsy → null (no expiry set)
+  assert.strictEqual(parseExpiresAt(null), null);
+  assert.strictEqual(parseExpiresAt(undefined), null);
+  assert.strictEqual(parseExpiresAt(''), null);
+  // valid ISO string → epoch-ms
+  assert.strictEqual(parseExpiresAt('2026-12-31T00:00:00Z'), Date.parse('2026-12-31T00:00:00Z'));
+  // present but malformed → false
+  assert.strictEqual(parseExpiresAt('not-a-date'), false);  // Date.parse returns NaN
+  assert.strictEqual(parseExpiresAt(12345), false);          // wrong type
+  assert.strictEqual(parseExpiresAt(true), false);           // wrong type
 });
 ```
 
@@ -128,9 +132,10 @@ function readBenefitId(payload) {
 }
 
 function parseExpiresAt(raw) {
-  if (!raw || typeof raw !== 'string') return null;
+  if (raw == null || raw === '') return null;        // absent — no expiry set
+  if (typeof raw !== 'string') return false;         // present but wrong type — malformed
   const ms = Date.parse(raw);
-  return Number.isNaN(ms) ? null : ms;
+  return Number.isNaN(ms) ? false : ms;              // unparseable string — malformed
 }
 
 function resolveKind(benefitId, allowlist) {
@@ -209,12 +214,12 @@ test('revoked, expired, and benefit mismatch each degrade', () => {
   assert.equal(mismatch.record.lastStatus, 'benefit_mismatch');
 });
 
-test('NaN expires_at is ambiguous, not a terminal expired state', () => {
+test('malformed expiry (false) is ambiguous, not a terminal expired state', () => {
   const now = 5000;
-  const nanExpiry = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: NaN, benefitOk: true }, record: sub(), now });
-  assert.equal(nanExpiry.active, true);
-  assert.equal(nanExpiry.record.lastValidatedAt, 1000); // unchanged — treated as ambiguous
-  assert.equal(nanExpiry.record.lastStatus, 'granted'); // unchanged — rides grace
+  const malformed = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: false, benefitOk: true }, record: sub(), now });
+  assert.equal(malformed.active, true);
+  assert.equal(malformed.record.lastValidatedAt, 1000); // unchanged — treated as ambiguous
+  assert.equal(malformed.record.lastStatus, 'granted'); // unchanged — rides grace
 });
 
 test('unknown status and unreachable ride the grace, do not advance lastValidatedAt', () => {
@@ -253,12 +258,9 @@ function evaluateValidation({ outcome, record, now }) {
   if (outcome.kind === 'ok') {
     next.lastAttemptedAt = now;
     const granted = outcome.status === 'granted';
-    const expiryKnown = outcome.expiresAt != null && !Number.isNaN(outcome.expiresAt);
-    const unexpired = !expiryKnown || outcome.expiresAt > now;
-    const expiryAmbiguous = outcome.expiresAt != null && Number.isNaN(outcome.expiresAt);
-    if (expiryAmbiguous && granted) {
-      // NaN from Date.parse — ambiguous, not terminal; leave record unchanged (ride grace)
-    } else if (granted && unexpired && outcome.benefitOk) {
+    if (outcome.expiresAt === false && granted) {
+      // malformed expiry — ambiguous, not terminal; leave record unchanged (ride grace)
+    } else if (granted && (outcome.expiresAt === null || outcome.expiresAt > now) && outcome.benefitOk) {
       next.lastStatus = 'granted';
       next.lastValidatedAt = now;
     } else if (TERMINAL.has(outcome.status)) {
@@ -448,55 +450,52 @@ git commit -m "feat(patron): settings record, ensureStore migration+flush, isPat
 - [ ] **Step 1: Scaffold API base + per-environment org ID + allowlist + `activate` (with 200-char guard, activation response validation, fail-closed benefit, malformed-JSON catch)**
 
 ```js
-const { app, net } = require(‘electron’);
-const settings = require(‘./settings’);
-const model = require(‘./patron-model’);
+const { app, net } = require('electron');
+const settings = require('./settings');
+const model = require('./patron-model');
 
-const PRODUCTION_ORG_ID = ‘6f675077-6cb1-4965-8db8-15838e5fdb38’; // public org "bnfy" (from supporter.js)
-const SANDBOX_ORG_ID = ‘/* fill from Polar sandbox dashboard */’;
-const API_BASE = app.isPackaged ? ‘https://api.polar.sh’ : ‘https://sandbox-api.polar.sh’;
+const PRODUCTION_ORG_ID = '6f675077-6cb1-4965-8db8-15838e5fdb38';
+const SANDBOX_ORG_ID = '/* fill from Polar sandbox dashboard */';
+const API_BASE = app.isPackaged ? 'https://api.polar.sh' : 'https://sandbox-api.polar.sh';
 const ORG_ID = app.isPackaged ? PRODUCTION_ORG_ID : SANDBOX_ORG_ID;
-const MAX_KEY_LENGTH = 200; // preserved from supporter.js — client-side stray-paste backstop
+const MAX_KEY_LENGTH = 200;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-// SETUP INVARIANT: each product uses a DISTINCT license-key benefit. Fill from the Polar
-// dashboard; verify the SANDBOX ids in sandbox before the production cutover.
 const BENEFIT_ALLOWLIST = app.isPackaged
-  ? { /* prod:    ‘<supporter>’:’founding’, ‘<annual>’:’subscription’, ‘<monthly>’:’subscription’ */ }
-  : { /* sandbox: ‘<supporter>’:’founding’, ‘<annual>’:’subscription’, ‘<monthly>’:’subscription’ */ };
+  ? { /* prod:    '<supporter>':'founding', '<annual>':'subscription', '<monthly>':'subscription' */ }
+  : { /* sandbox: '<supporter>':'founding', '<annual>':'subscription', '<monthly>':'subscription' */ };
 
 async function readJson(res) { try { return await res.json(); } catch { return null; } }
 
 async function activate(key) {
-  const trimmed = String(key ?? ‘’).trim();
-  if (!trimmed) return { ok: false, message: ‘Enter a license key.’ };
-  if (trimmed.length > MAX_KEY_LENGTH) return { ok: false, message: ‘That doesn’t look like a license key.’ };
+  const trimmed = String(key ?? '').trim();
+  if (!trimmed) return { ok: false, message: 'Enter a license key.' };
+  if (trimmed.length > MAX_KEY_LENGTH) return { ok: false, message: 'That key is too long.' };
   let res;
   try {
-    res = await net.fetch(`${API_BASE}/v1/customer-portal/license-keys/activate`, {
-      method: ‘POST’, headers: { ‘Content-Type’: ‘application/json’ },
-      body: JSON.stringify({ key: trimmed, organization_id: ORG_ID, label: ‘Blanc’ }),
+    res = await net.fetch(API_BASE + '/v1/customer-portal/license-keys/activate', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: trimmed, organization_id: ORG_ID, label: 'Blanc' }),
     });
-  } catch { return { ok: false, message: "Couldn’t reach Polar — check your connection and try again." }; }
-  if (!res.ok) return { ok: false, message: ‘That license key could not be activated.’ };
+  } catch { return { ok: false, message: 'Could not reach Polar. Check your connection and try again.' }; }
+  if (!res.ok) return { ok: false, message: 'That license key could not be activated.' };
   const payload = await readJson(res);
   const benefitId = model.readBenefitId(payload);
   const kind = model.resolveKind(benefitId, BENEFIT_ALLOWLIST);
-  if (!payload || !kind) return { ok: false, message: ‘That license key is not recognized.’ }; // fail closed / malformed
-  // For subscriptions, inspect the nested license key BEFORE bootstrapping 30 days of grace.
-  // A 2xx alone is not enough — the key must be granted and unexpired.
-  if (kind === ‘subscription’) {
+  if (!payload || !kind) return { ok: false, message: 'That license key is not recognized.' };
+  if (kind === 'subscription') {
     const lk = payload.license_key ?? payload.activation?.license_key ?? {};
     const lkStatus = lk.status;
     const lkExpiry = model.parseExpiresAt(lk.expires_at);
-    if (lkStatus !== ‘granted’) return { ok: false, message: ‘That subscription is not currently active.’ };
-    if (lkExpiry !== null && lkExpiry <= Date.now()) return { ok: false, message: ‘That subscription has expired.’ };
+    if (lkStatus !== 'granted') return { ok: false, message: 'That subscription is not currently active.' };
+    if (lkExpiry === false) return { ok: false, message: 'That subscription has an invalid expiry.' };
+    if (typeof lkExpiry === 'number' && lkExpiry <= Date.now()) return { ok: false, message: 'That subscription has expired.' };
   }
   const now = Date.now();
   const activationId = payload.activation?.id ?? payload.id ?? null;
   const record = { kind, key: trimmed, activationId, benefitId, activatedAt: now,
-    ...(kind === ‘subscription’ ? { lastValidatedAt: now, lastAttemptedAt: now, lastStatus: ‘granted’ } : {}) };
-  settings.setPatron(record); // isPatronActive derives activity; no separate flag
+    ...(kind === 'subscription' ? { lastValidatedAt: now, lastAttemptedAt: now, lastStatus: 'granted' } : {}) };
+  settings.setPatron(record);
   return { ok: true, kind };
 }
 ```
@@ -597,7 +596,7 @@ git commit -m "feat(patron): pages.js projection strips patron + adds patronActi
 
 - [ ] **Step 1: Schedule `validateIfDue` off the critical path**
 
-Place a `setImmediate` call after `releaseStartup()` has released the navigation gate and restored tabs — alongside `setupAutoUpdater()` (line ~6244 of `main.js`). Fire `patron.validateIfDue()` once, then on a daily `setInterval`. It must never run during `installStartupNavigationGate` or block the ready chain; its own once-per-day guard (the `lastAttemptedAt` check in the model) prevents redundant network calls within a single run.
+Add a `setImmediate` at the tail of `releaseStartup()` itself (after `maybeSendLaunchPing()`, line ~6179 of `main.js`), so it fires only after the navigation gate is released, tabs are restored, and session persistence is resumed. `setupAutoUpdater()` (line ~6244) is NOT post-release in the blocking path — it runs immediately after starting the async blocker controller, before `releaseStartup` is ever called. Inside the `setImmediate`, fire `patron.validateIfDue()` once and start a daily `setInterval`. The model's own `lastAttemptedAt` guard prevents redundant network calls within a single run.
 
 - [ ] **Step 2: Verify manually**
 
@@ -637,7 +636,7 @@ git commit -m "feat(patron): Settings Patron section and Patron-gated colorways"
 
 ## Self-Review
 
-**Spec coverage (Phase 1):** entitlement record + kinds (T2–T4); benefit_id allowlist + fail-closed (T1, T5); **persisted-derived activity, restart-safe** (T2, T4); migration persisted via ensureStore+flush (T3, T4); validation with statuses/`expires_at`/defensive benefit_id/**per-validation benefit re-check**/cadence/bootstrap/grace (T2, T5); **activation inspects nested license-key status+expiry before bootstrapping grace** (T5); **NaN `Date.parse` treated as ambiguous, not terminal** (T1 `parseExpiresAt`, T2 unit test); **per-environment org ID** (`PRODUCTION_ORG_ID`/`SANDBOX_ORG_ID`, T5); projection strips both in the *correct* file (T6); downgrade mirror + subscription-never-mirrored (T3, T4); **setPatron fires listeners → Dock reapply** (T4); graceful degradation to `paper` (T4, T8); 200-char guard + malformed-JSON handling (T5); never synced / never generic-write (T4). ✓
+**Spec coverage (Phase 1):** entitlement record + kinds (T2–T4); benefit_id allowlist + fail-closed (T1, T5); **persisted-derived activity, restart-safe** (T2, T4); migration persisted via ensureStore+flush (T3, T4); validation with statuses/`expires_at`/defensive benefit_id/**per-validation benefit re-check**/cadence/bootstrap/grace (T2, T5); **activation inspects nested license-key status+expiry before bootstrapping grace** (T5); **three-state `parseExpiresAt` (null/number/false)** — activation rejects malformed, validation treats as ambiguous (T1, T2 unit test); **per-environment org ID** (`PRODUCTION_ORG_ID`/`SANDBOX_ORG_ID`, T5); projection strips both in the *correct* file (T6); downgrade mirror + subscription-never-mirrored (T3, T4); **setPatron fires listeners → Dock reapply** (T4); graceful degradation to `paper` (T4, T8); 200-char guard + malformed-JSON handling (T5); never synced / never generic-write (T4). ✓
 
 **Placeholder scan:** the only blanks are the real Polar `benefit_id` values in `BENEFIT_ALLOWLIST` and `SANDBOX_ORG_ID` (T5) — user-side product/org ids that do not exist until the Polar products are created; flagged as a setup invariant, not a hidden TODO.
 

--- a/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
+++ b/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
@@ -1,0 +1,591 @@
+# Blanc Patron — Entitlement Layer Implementation Plan (Phase 1 of 4)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the Patron entitlement foundation — a device-local `patron` record with three kinds (`founding` / `lifetime` / `subscription`), Polar activation + subscription validation with a 30-day offline grace and graceful degradation, migration of existing `$19` Supporters to founding Patrons, and the re-gating of the three cosmetic colorways under Patron — with nothing else gating until this exists.
+
+**Architecture:** All entitlement *decisions* live in a new pure, Electron-free `src/main/patron-model.js` (mirrors `tabsync-model.js` / `session-workspace.js`), covered by `node:test` unit tests. `src/main/patron.js` wraps Polar's `net.fetch` calls and calls the pure model for every decision. `src/main/settings.js` gains the `patron` record, `isPatronActive()`, `setPatron()`, the extended `isAppIconAllowed()` predicate, the renderer projection that strips `patron`, and a one-time upgrade migration. `src/main/main.js` schedules the daily background validation and wires the activation IPC.
+
+**Tech Stack:** Electron (main process), `net.fetch` for Polar's public customer-portal API, `node --test` (`npm run test:unit`) over `test/unit/`, the repo's `JsonStore` persistence.
+
+## Global Constraints
+
+Copied verbatim from `docs/superpowers/specs/2026-08-18-blanc-patron-design.md`; every task's requirements implicitly include these:
+
+- **Patron only ever ADDS.** Nothing shipped today (the whole browser + all of today's Personal-only Profile Sync) ever moves behind Patron.
+- **`patron` is the single canonical record.** No Patron-era entitlement check may read `supporter`; `supporter` becomes a downgrade mirror only.
+- **A `subscription` is NEVER written to `supporter`** (an old build reads any non-null `supporter` as a *permanent* grant).
+- **Device-local, never synced.** Neither `patron` nor `supporter` is in `SYNCED_KEYS`; the generic `setSettings()` whitelist must ignore both.
+- **Renderer sees only `patronActive`** (a boolean) — never the key, activation id, benefit id, or Polar status. `getSettings()` must strip **both** `supporter` and `patron`.
+- **Fail open except one path.** Network failure / ambiguous / unknown status → stay active within the 30-day offline grace (clock from `lastValidatedAt`, bootstrapped at activation). Only a **confirmed terminal status** revokes. The single fail-*closed* path: an unrecognized `benefit_id` at activation grants nothing.
+- **Expiration is a field, not a status.** Response carries `status` plus separate `expires_at`; never treat `expired` as a status value.
+- **Distinct `benefit_id` per product** is a setup invariant, verified in sandbox before production cutover.
+- **No DRM, no lockout, no user-data loss** on lapse — degrade gracefully.
+- **Polar base switches on `app.isPackaged`** (`sandbox-api.polar.sh` in dev, `api.polar.sh` packaged) — already in `supporter.js`. The `benefit_id` allowlist has separate sandbox/production tables on the same switch.
+- **Colorway fallback is `paper`** (`DEFAULTS.appIcon`), applied on the read path; invalid writes are ignored (not reset).
+
+## Roadmap (the other three plans, written after this one lands)
+
+- **Phase 2 — Named Workspaces** (the anchor): profile-scoped `workspaces.json`, ⌘L management UI, single-window binding, continuous autosave, Patron-gated creation.
+- **Phase 3 — Supporting bundle**: custom slash commands / keybindings; Patron badge in Settings.
+- **Phase 4 — Site + copy**: restrained Patron section with the plain validation disclosure.
+
+## File Structure
+
+- **Create `src/main/patron-model.js`** — pure, no `require('electron')`. Exports `resolveKind`, `evaluateValidation`, `migrateSupporter`, `downgradeMirror`, `GRACE_MS`, `readBenefitId`. One responsibility: entitlement decisions as pure functions.
+- **Create `test/unit/patron-model.test.js`** — `node:test` coverage for every branch of the above.
+- **Modify `src/main/settings.js`** — `patron` default; `isPatronActive()`; `setPatron()`; extend `isAppIconAllowed()`; strip `patron` in the renderer projection; run `migrateSupporter` once on load; keep the `supporter` downgrade mirror for founding/lifetime.
+- **Create `src/main/patron.js`** — Polar `activate` + `validate` network calls (Electron `net.fetch`), each delegating decisions to `patron-model`; the `validateIfDue` entry point. Supersedes `supporter.js`'s `activateSupporter` (which is folded in and re-exported for the existing IPC name).
+- **Modify `src/main/main.js`** — daily idle-scheduled `validateIfDue`; wire the settings-page activation IPC to `patron.activate`.
+- **Modify `src/renderer/pages/settings.*`** — Patron section (key input + status) and the three colorways re-gated on `patronActive`. (Manual verification — chrome/UI is not unit-tested per repo norm.)
+
+---
+
+### Task 1: Pure benefit_id → kind resolution (`resolveKind`, `readBenefitId`)
+
+**Files:**
+- Create: `src/main/patron-model.js`
+- Test: `test/unit/patron-model.test.js`
+
+**Interfaces:**
+- Produces:
+  - `readBenefitId(payload) -> string | null` — defensively reads `benefit_id` from a Polar activate or validate payload: checks `payload.benefit_id`, then `payload.license_key?.benefit_id`, then `payload.activation?.license_key?.benefit_id`.
+  - `resolveKind(benefitId, allowlist) -> 'founding' | 'lifetime' | 'subscription' | null` — maps a benefit id through the given allowlist object (`{ [benefitId]: kind }`); returns `null` for a missing/unknown id (fail closed).
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/unit/patron-model.test.js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { readBenefitId, resolveKind } = require('../../src/main/patron-model');
+
+const ALLOW = { ben_supporter: 'founding', ben_annual: 'subscription', ben_monthly: 'subscription', ben_lifetime: 'lifetime' };
+
+test('readBenefitId reads root, nested license_key, and nested activation', () => {
+  assert.equal(readBenefitId({ benefit_id: 'a' }), 'a');
+  assert.equal(readBenefitId({ license_key: { benefit_id: 'b' } }), 'b');
+  assert.equal(readBenefitId({ activation: { license_key: { benefit_id: 'c' } } }), 'c');
+  assert.equal(readBenefitId({}), null);
+  assert.equal(readBenefitId(null), null);
+});
+
+test('resolveKind maps known benefits and fails closed on unknown', () => {
+  assert.equal(resolveKind('ben_supporter', ALLOW), 'founding');
+  assert.equal(resolveKind('ben_annual', ALLOW), 'subscription');
+  assert.equal(resolveKind('ben_lifetime', ALLOW), 'lifetime');
+  assert.equal(resolveKind('ben_unknown', ALLOW), null);
+  assert.equal(resolveKind(null, ALLOW), null);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- test/unit/patron-model.test.js`
+Expected: FAIL — cannot find module `patron-model`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+// src/main/patron-model.js
+// Pure entitlement decisions — NO require('electron'). Mirrors the Electron-free
+// pattern of tabsync-model.js / session-workspace.js so every branch is unit-testable.
+
+function readBenefitId(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  return payload.benefit_id
+    ?? payload.license_key?.benefit_id
+    ?? payload.activation?.license_key?.benefit_id
+    ?? null;
+}
+
+function resolveKind(benefitId, allowlist) {
+  if (!benefitId) return null;
+  return allowlist[benefitId] ?? null;
+}
+
+module.exports = { readBenefitId, resolveKind };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- test/unit/patron-model.test.js`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/patron-model.js test/unit/patron-model.test.js
+git commit -m "feat(patron): pure benefit_id resolution with defensive read + fail-closed mapping"
+```
+
+---
+
+### Task 2: Pure validation state machine (`evaluateValidation`, `GRACE_MS`)
+
+**Files:**
+- Modify: `src/main/patron-model.js`
+- Test: `test/unit/patron-model.test.js`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 at runtime (same module).
+- Produces:
+  - `GRACE_MS` — `30 * 24 * 60 * 60 * 1000`.
+  - `evaluateValidation({ outcome, record, now }) -> { active: boolean, record }` — the pure state machine. `outcome` is one of:
+    - `{ kind: 'ok', status: string, expiresAt: number|null }` — a parsed Polar response.
+    - `{ kind: 'unreachable' }` — network failure/ambiguous.
+    It returns the next `record` (with updated `lastValidatedAt` / `lastAttemptedAt` / `lastStatus`) and whether the subscription is currently `active`. Founding/lifetime never call this. Rules: `status === 'granted'` and (`expiresAt` null or `> now`) → active, set `lastValidatedAt = now`. Known terminal (`revoked`, `disabled`) or granted-but-`expiresAt <= now` → not active (confirmed lapse). Unknown status or `unreachable` → active **iff** `now - lastValidatedAt <= GRACE_MS`, and does **not** advance `lastValidatedAt`. `lastAttemptedAt` is set to `now` in every case.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// append to test/unit/patron-model.test.js
+const { evaluateValidation, GRACE_MS } = require('../../src/main/patron-model');
+
+const base = (over = {}) => ({
+  kind: 'subscription', key: 'k', activationId: 'a', benefitId: 'ben_annual',
+  activatedAt: 0, lastValidatedAt: 1000, lastAttemptedAt: 1000, lastStatus: 'granted', ...over,
+});
+
+test('granted, unexpired → active and advances lastValidatedAt', () => {
+  const now = 5000;
+  const r = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: now + 1 }, record: base(), now });
+  assert.equal(r.active, true);
+  assert.equal(r.record.lastValidatedAt, now);
+  assert.equal(r.record.lastAttemptedAt, now);
+});
+
+test('revoked → confirmed lapse, not active', () => {
+  const r = evaluateValidation({ outcome: { kind: 'ok', status: 'revoked', expiresAt: null }, record: base(), now: 5000 });
+  assert.equal(r.active, false);
+  assert.equal(r.record.lastAttemptedAt, 5000);
+});
+
+test('granted but expired → confirmed lapse, not active', () => {
+  const now = 5000;
+  const r = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: now - 1 }, record: base(), now });
+  assert.equal(r.active, false);
+});
+
+test('unknown status → rides grace, does NOT advance lastValidatedAt', () => {
+  const now = 1000 + GRACE_MS - 1;
+  const r = evaluateValidation({ outcome: { kind: 'ok', status: 'weird_new_status', expiresAt: null }, record: base(), now });
+  assert.equal(r.active, true);
+  assert.equal(r.record.lastValidatedAt, 1000); // unchanged
+});
+
+test('unreachable within grace → active; past grace → degrade', () => {
+  const withinNow = 1000 + GRACE_MS;
+  assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: base(), now: withinNow }).active, true);
+  const pastNow = 1000 + GRACE_MS + 1;
+  assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: base(), now: pastNow }).active, false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- test/unit/patron-model.test.js`
+Expected: FAIL — `evaluateValidation is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+// add to src/main/patron-model.js
+const GRACE_MS = 30 * 24 * 60 * 60 * 1000;
+const TERMINAL = new Set(['revoked', 'disabled']);
+
+function evaluateValidation({ outcome, record, now }) {
+  const next = { ...record, lastAttemptedAt: now };
+
+  if (outcome.kind === 'ok' && outcome.status === 'granted'
+      && (outcome.expiresAt == null || outcome.expiresAt > now)) {
+    next.lastStatus = 'granted';
+    next.lastValidatedAt = now;
+    return { active: true, record: next };
+  }
+
+  const confirmedTerminal =
+    (outcome.kind === 'ok' && TERMINAL.has(outcome.status)) ||
+    (outcome.kind === 'ok' && outcome.status === 'granted'
+      && outcome.expiresAt != null && outcome.expiresAt <= now);
+  if (confirmedTerminal) {
+    next.lastStatus = outcome.status;
+    return { active: false, record: next };
+  }
+
+  // unknown status OR unreachable → ambiguous: ride the offline grace, do not advance lastValidatedAt.
+  if (outcome.kind === 'ok') next.lastStatus = outcome.status;
+  const active = (now - record.lastValidatedAt) <= GRACE_MS;
+  return { active, record: next };
+}
+
+module.exports = { readBenefitId, resolveKind, evaluateValidation, GRACE_MS };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- test/unit/patron-model.test.js`
+Expected: PASS (all Task 1 + Task 2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/patron-model.js test/unit/patron-model.test.js
+git commit -m "feat(patron): validation state machine with 30-day offline grace, fail-open except confirmed terminal"
+```
+
+---
+
+### Task 3: Pure migration + downgrade mirror (`migrateSupporter`, `downgradeMirror`)
+
+**Files:**
+- Modify: `src/main/patron-model.js`
+- Test: `test/unit/patron-model.test.js`
+
+**Interfaces:**
+- Produces:
+  - `migrateSupporter({ supporter, patron, now }) -> { patron } | null` — if `supporter` is non-null and `patron` is null, returns `{ patron: { kind:'founding', key, activationId, benefitId:null, activatedAt } }` (using the supporter's fields, `activatedAt` falling back to `now`). Otherwise returns `null` (no change — idempotent).
+  - `downgradeMirror(patron) -> supporterRecord | null` — returns the legacy `{ key, activationId, activatedAt }` mirror to persist under `supporter` **only** for `founding`/`lifetime`; returns `null` for `subscription` or null patron (so a subscription is never mirrored).
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// append to test/unit/patron-model.test.js
+const { migrateSupporter, downgradeMirror } = require('../../src/main/patron-model');
+
+test('migrateSupporter creates a founding patron from a legacy supporter, once', () => {
+  const supporter = { key: 'k', activationId: 'a', activatedAt: 42 };
+  const out = migrateSupporter({ supporter, patron: null, now: 99 });
+  assert.deepEqual(out.patron, { kind: 'founding', key: 'k', activationId: 'a', benefitId: null, activatedAt: 42 });
+  // idempotent: already has a patron → null
+  assert.equal(migrateSupporter({ supporter, patron: out.patron, now: 99 }), null);
+  // nothing to migrate
+  assert.equal(migrateSupporter({ supporter: null, patron: null, now: 99 }), null);
+});
+
+test('downgradeMirror mirrors founding/lifetime but NEVER a subscription', () => {
+  assert.deepEqual(
+    downgradeMirror({ kind: 'founding', key: 'k', activationId: 'a', activatedAt: 42 }),
+    { key: 'k', activationId: 'a', activatedAt: 42 });
+  assert.deepEqual(
+    downgradeMirror({ kind: 'lifetime', key: 'k', activationId: 'a', activatedAt: 7 }),
+    { key: 'k', activationId: 'a', activatedAt: 7 });
+  assert.equal(downgradeMirror({ kind: 'subscription', key: 'k', activationId: 'a', activatedAt: 1 }), null);
+  assert.equal(downgradeMirror(null), null);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- test/unit/patron-model.test.js`
+Expected: FAIL — `migrateSupporter is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+// add to src/main/patron-model.js
+function migrateSupporter({ supporter, patron, now }) {
+  if (!supporter || patron) return null;
+  return {
+    patron: {
+      kind: 'founding',
+      key: supporter.key,
+      activationId: supporter.activationId ?? null,
+      benefitId: null,
+      activatedAt: supporter.activatedAt ?? now,
+    },
+  };
+}
+
+function downgradeMirror(patron) {
+  if (!patron || (patron.kind !== 'founding' && patron.kind !== 'lifetime')) return null;
+  return { key: patron.key, activationId: patron.activationId ?? null, activatedAt: patron.activatedAt };
+}
+
+module.exports = { readBenefitId, resolveKind, evaluateValidation, GRACE_MS, migrateSupporter, downgradeMirror };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- test/unit/patron-model.test.js`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/patron-model.js test/unit/patron-model.test.js
+git commit -m "feat(patron): pure migration + downgrade-mirror (subscription never mirrored to supporter)"
+```
+
+---
+
+### Task 4: Wire the model into `settings.js`
+
+**Files:**
+- Modify: `src/main/settings.js` (the `DEFAULTS`, the sanitize/projection paths, `isAppIconAllowed`, exports)
+- Test: `test/unit/settings-patron.test.js` (new — `settings.js` is `require`-able without Electron for these pure predicates; if it pulls Electron at import in this repo, fall back to the manual steps noted)
+
+**Interfaces:**
+- Consumes: `migrateSupporter`, `downgradeMirror` from `patron-model`.
+- Produces (on `settings.js` exports):
+  - `isPatronActive() -> boolean` — true for `founding`/`lifetime`; for `subscription`, true when `_patronSubscriptionActive` (a cached boolean the main-process validator sets via `setPatron`); false when `patron` is null.
+  - `setPatron(record)` — the only writer of `patron`; also writes the `downgradeMirror(record)` into `supporter` (or clears it) so founding/lifetime survive a downgrade and a subscription never does.
+  - `isAppIconAllowed(id)` — now `APP_ICONS.includes(id) || (SUPPORTER_ICONS.includes(id) && isPatronActive())`.
+
+- [ ] **Step 1: Add the `patron` default and migration on load**
+
+In `DEFAULTS`, beside `supporter: null`, add `patron: null`. In the store's post-load sanitize (where `getSettings()`/read coercion runs), call `migrateSupporter` and, if it returns a change, persist the new `patron` (leaving `supporter` intact as the mirror).
+
+```js
+// near the top: const { migrateSupporter, downgradeMirror } = require('./patron-model');
+// in the load/sanitize path, after the store data is available:
+const migrated = migrateSupporter({ supporter: data.supporter, patron: data.patron, now: Date.now() });
+if (migrated) data.patron = migrated.patron;
+```
+
+- [ ] **Step 2: Add `isPatronActive`, `setPatron`, extend `isAppIconAllowed`**
+
+```js
+let _patronSubscriptionActive = false; // set by the main-process validator via setPatron/refresh
+
+function isPatronActive() {
+  const p = ensureStore().data.patron;
+  if (!p) return false;
+  if (p.kind === 'founding' || p.kind === 'lifetime') return true;
+  return _patronSubscriptionActive; // subscription: gated by the last validation result
+}
+
+function setPatron(record, { subscriptionActive } = {}) {
+  ensureStore().update((data) => {
+    data.patron = record;
+    data.supporter = downgradeMirror(record); // founding/lifetime mirror; subscription/null → null
+  });
+  if (typeof subscriptionActive === 'boolean') _patronSubscriptionActive = subscriptionActive;
+}
+
+function isAppIconAllowed(id) {
+  return APP_ICONS.includes(id) || (SUPPORTER_ICONS.includes(id) && isPatronActive());
+}
+```
+
+Replace the existing `isSupporterActive`-based `isAppIconAllowed` body accordingly. Keep `isSupporterActive` exported for now (used only by the legacy read path) but ensure **no entitlement check** calls it — `isAppIconAllowed` now calls `isPatronActive`.
+
+- [ ] **Step 3: Strip `patron` in the renderer projection**
+
+Find where `getSettings()` builds the renderer-facing object (today it strips `supporter` and exposes `supporterActive`). Add: delete `patron`, and expose `patronActive: isPatronActive()` (keep `supporterActive` as an alias equal to `patronActive` for any existing renderer reference until Phase 4 updates copy).
+
+```js
+// in the projection:
+delete clean.supporter;
+delete clean.patron;
+clean.patronActive = isPatronActive();
+clean.supporterActive = clean.patronActive; // temporary alias
+```
+
+- [ ] **Step 4: Keep `patron`/`supporter` out of the generic write + sync**
+
+Confirm the `setSettings()` whitelist copies **neither** `patron` nor `supporter` (it already omits `supporter`; add an explicit guard/comment so `patron` is never accepted from a renderer partial). Confirm `SYNCED_KEYS` contains neither (it does not — do not add them).
+
+- [ ] **Step 5: Unit-test the projection + predicate (or verify manually)**
+
+```js
+// test/unit/settings-patron.test.js  (only if settings.js imports without Electron in this repo)
+const { test } = require('node:test');
+const assert = require('node:assert');
+// Drive via the exported helpers against a temp userData; if settings.js requires electron
+// at import time, SKIP this file and use the manual check below instead.
+```
+
+Manual fallback (always valid): `npm start`, then in the main-process console set a founding patron and confirm a renderer `getSettings()` payload contains `patronActive: true` and **no** `patron`/`supporter` field.
+
+- [ ] **Step 6: Run tests + commit**
+
+Run: `npm run test:unit`
+Expected: PASS (existing suite + patron-model; settings-patron if applicable).
+
+```bash
+git add src/main/settings.js test/unit/settings-patron.test.js
+git commit -m "feat(patron): settings record, isPatronActive, projection strip, colorway re-gate, migration on load"
+```
+
+---
+
+### Task 5: Polar network module (`src/main/patron.js`)
+
+**Files:**
+- Create: `src/main/patron.js`
+- Modify: `src/main/supporter.js` (re-export the activation entry so the existing IPC name keeps working) — or delete once `main.js` points at `patron.js`.
+
+**Interfaces:**
+- Consumes: `readBenefitId`, `resolveKind`, `evaluateValidation` from `patron-model`; `setPatron`, and the stored `patron` record from `settings`.
+- Produces:
+  - `activate(key) -> { ok: boolean, message?, kind? }` — POSTs to `.../license-keys/activate` with `{ key, organization_id, label }`, reads `benefit_id` via `readBenefitId`, resolves the kind via the per-environment allowlist, and on a known kind calls `setPatron` with a record whose `lastValidatedAt`/`lastAttemptedAt` are bootstrapped to now (activation is an online success) and `subscriptionActive: true` for the subscription kind. **Unknown benefit_id → `{ ok:false }`, grants nothing (fail closed).**
+  - `validateIfDue() -> Promise<void>` — for a `subscription` patron only, and at most once per `lastAttemptedAt + 1 day`, POSTs to `.../license-keys/validate` with `{ organization_id, key, activation_id }`, parses `{ status, expires_at }` into an `outcome`, runs `evaluateValidation`, and persists the returned record via `setPatron({...}, { subscriptionActive: active })`. Network failure → `outcome: { kind:'unreachable' }`.
+
+- [ ] **Step 1: Scaffold the per-environment allowlist + API base**
+
+```js
+const { app, net } = require('electron');
+const settings = require('./settings');
+const model = require('./patron-model');
+
+const ORG_ID = '6f675077-6cb1-4965-8db8-15838e5fdb38'; // production org "bnfy" (public, from supporter.js)
+const API_BASE = app.isPackaged ? 'https://api.polar.sh' : 'https://sandbox-api.polar.sh';
+
+// SETUP INVARIANT: each product uses a DISTINCT license-key benefit. Fill these from the
+// Polar dashboard; verify the sandbox ids in sandbox before production cutover.
+const BENEFIT_ALLOWLIST = app.isPackaged
+  ? { /* prod: */ }   // { '<supporter>': 'founding', '<annual>': 'subscription', '<monthly>': 'subscription', '<lifetime?>': 'lifetime' }
+  : { /* sandbox: */ };
+```
+
+- [ ] **Step 2: Implement `activate`**
+
+```js
+async function activate(key) {
+  const trimmed = String(key ?? '').trim();
+  if (!trimmed) return { ok: false, message: 'Enter a license key.' };
+  let res;
+  try {
+    res = await net.fetch(`${API_BASE}/v1/customer-portal/license-keys/activate`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: trimmed, organization_id: ORG_ID, label: 'Blanc' }),
+    });
+  } catch { return { ok: false, message: "Couldn't reach Polar — check your connection and try again." }; }
+  if (!res.ok) return { ok: false, message: 'That license key could not be activated.' };
+  const payload = await res.json();
+  const kind = model.resolveKind(model.readBenefitId(payload), BENEFIT_ALLOWLIST);
+  if (!kind) return { ok: false, message: 'That license key is not recognized.' }; // fail closed
+  const now = Date.now();
+  const activationId = payload.activation?.id ?? payload.id ?? null;
+  const record = { kind, key: trimmed, activationId, benefitId: model.readBenefitId(payload), activatedAt: now,
+    ...(kind === 'subscription' ? { lastValidatedAt: now, lastAttemptedAt: now, lastStatus: 'granted' } : {}) };
+  settings.setPatron(record, { subscriptionActive: kind === 'subscription' });
+  return { ok: true, kind };
+}
+```
+
+- [ ] **Step 3: Implement `validateIfDue`**
+
+```js
+const DAY_MS = 24 * 60 * 60 * 1000;
+async function validateIfDue() {
+  const p = settings.getPatronRecord(); // add a tiny getter to settings that returns the raw record (main-process only)
+  if (!p || p.kind !== 'subscription') return;
+  if (Date.now() - (p.lastAttemptedAt ?? 0) < DAY_MS) return;
+  let outcome;
+  try {
+    const res = await net.fetch(`${API_BASE}/v1/customer-portal/license-keys/validate`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ organization_id: ORG_ID, key: p.key, activation_id: p.activationId }),
+    });
+    if (!res.ok) outcome = { kind: 'unreachable' };
+    else { const b = await res.json(); outcome = { kind: 'ok', status: b.status, expiresAt: b.expires_at ? Date.parse(b.expires_at) : null }; }
+  } catch { outcome = { kind: 'unreachable' }; }
+  const { active, record } = model.evaluateValidation({ outcome, record: p, now: Date.now() });
+  settings.setPatron(record, { subscriptionActive: active });
+}
+
+module.exports = { activate, validateIfDue };
+```
+
+- [ ] **Step 4: Add the `getPatronRecord` main-process getter to `settings.js`**
+
+```js
+// settings.js — main-process only; NEVER exposed to renderers
+function getPatronRecord() { return ensureStore().data.patron; }
+// add getPatronRecord to module.exports
+```
+
+- [ ] **Step 5: Verify manually (network path — not unit-tested)**
+
+`npm start`, activate a Polar **sandbox** subscription key via the Settings flow (Task 6/7), confirm `settings.json` gains a `subscription` `patron` record with bootstrapped `lastValidatedAt`, and that an unknown-benefit key returns "not recognized" and writes nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/patron.js src/main/settings.js
+git commit -m "feat(patron): Polar activate + daily validate wired through the pure model"
+```
+
+---
+
+### Task 6: Schedule validation + wire activation IPC in `main.js`
+
+**Files:**
+- Modify: `src/main/main.js`
+
+**Interfaces:**
+- Consumes: `patron.activate`, `patron.validateIfDue`.
+
+- [ ] **Step 1: Schedule `validateIfDue` off the critical path**
+
+After the window is up and the app is idle (reuse the existing post-launch idle hook the app already uses for deferred work; do **not** run it during `installStartupNavigationGate`), call `patron.validateIfDue()` once, then on a daily interval. Never block startup or navigation on it.
+
+- [ ] **Step 2: Point the existing activation IPC at `patron.activate`**
+
+The Settings page already has a supporter-activate IPC (`pages:settings:supporter-activate` per the Phase 1 spec). Route it to `patron.activate` (keep the channel name to avoid a renderer change here; rename in Phase 4). Return `{ ok, message }` to the renderer.
+
+- [ ] **Step 3: Verify manually**
+
+`npm start`; confirm no validation call fires before the blocker/navigation gate resolves (check with a logging breakpoint), and that activation from Settings persists a record.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/main.js
+git commit -m "feat(patron): idle-scheduled daily validation + activation IPC wiring"
+```
+
+---
+
+### Task 7: Settings UI — Patron section + re-gated colorways
+
+**Files:**
+- Modify: `src/renderer/pages/settings.html` / `settings.js` (renderer) / `pages.css`
+
+**Interfaces:**
+- Consumes: the renderer `patronActive` boolean; the activation IPC.
+
+- [ ] **Step 1: Render the Patron section**
+
+A "Blanc Patron" section: license-key input + Activate button, and a quiet status line ("Patron active" / inactive) driven by `patronActive`. Reuse the existing supporter-section markup where it exists.
+
+- [ ] **Step 2: Re-gate the three colorways on `patronActive`**
+
+The `ember`/`plum`/`gold` tiles show locked (dimmed + "Patron" tag) unless `patronActive`; clicking a locked tile points to the Patron section. This is the existing supporter-tile behavior with the gate switched from `supporterActive` to `patronActive`.
+
+- [ ] **Step 3: Verify manually (chrome requires a relaunch)**
+
+Relaunch `npm start` (chrome HTML loads once at window creation). Confirm: locked tiles when inactive; after activating a sandbox key, tiles unlock and the Dock colorway applies; on a simulated lapse the colorway reverts to `paper`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/pages/settings.html src/renderer/pages/settings.js src/renderer/pages/pages.css
+git commit -m "feat(patron): Settings Patron section and Patron-gated colorways"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 scope):**
+- Entitlement record + three kinds → Tasks 2–4. ✓
+- benefit_id allowlist + fail-closed unknown → Tasks 1, 5. ✓
+- Retire $19 checkout → user-side (noted in spec §Polar; not a code task). Flagged in handoff.
+- Migration of legacy supporter → founding → Tasks 3, 4. ✓
+- Validation model (endpoint, statuses, expires_at-not-a-status, defensive benefit_id, cadence, bootstrap, grace) → Tasks 2, 5. ✓
+- Renderer projection strips both → Task 4. ✓
+- Downgrade mirror + subscription-never-mirrored → Tasks 3, 4. ✓
+- Graceful degradation (colorway→paper) → Tasks 4, 7. ✓
+- Never synced / never in generic write → Task 4. ✓
+- Distinct-benefit sandbox verification → Task 5 setup invariant + handoff note. ✓
+
+**Placeholder scan:** The only intentional blanks are the real Polar `benefit_id` values in Task 5's `BENEFIT_ALLOWLIST` — these are user-side product ids that do not exist until the Polar products are created (spec: account/product setup is user-side). Flagged explicitly, not a hidden TODO.
+
+**Type consistency:** `resolveKind`, `readBenefitId`, `evaluateValidation`, `migrateSupporter`, `downgradeMirror`, `GRACE_MS`, `isPatronActive`, `setPatron`, `getPatronRecord`, `activate`, `validateIfDue` are used with consistent signatures across tasks.
+
+## Out of this plan (later phases)
+
+Named Workspaces, custom commands/keybindings, the Patron badge, and the site copy are Phases 2–4. Retiring the $19 checkout and creating the Polar subscription products (with distinct benefits) are **user-side** setup, prerequisite to Task 5 producing real ids.

--- a/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
+++ b/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
@@ -268,8 +268,8 @@ function evaluateValidation({ outcome, record, now }) {
       next.lastValidatedAt = now;
     } else if (TERMINAL.has(outcome.status)) {
       next.lastStatus = outcome.status;               // confirmed terminal
-    } else if (granted && !unexpired) {
-      next.lastStatus = 'expired';                    // derived terminal
+    } else if (granted && outcome.expiresAt !== null && outcome.expiresAt <= now) {
+      next.lastStatus = 'expired';                    // derived terminal (expiresAt is a number here; false handled above)
     } else if (granted && !outcome.benefitOk) {
       next.lastStatus = 'benefit_mismatch';           // derived terminal
     }

--- a/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
+++ b/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
@@ -658,29 +658,37 @@ In `main.js`, add `patronActive: settings.isPatronActive()` to `startPageStatus(
 
 - [ ] **Step 2: Start page callout with live updates**
 
-In `newtab.js`, render a quiet, non-intrusive callout in the ledger layout — below the favorites grid and above the footer. Keep it understated (one line, e.g. "Support Blanc" with a link). When `patronActive` is true, hide it. The callout must not dominate the start page or feel like an ad.
+In `newtab.html`, render a quiet, non-intrusive callout in the ledger layout — below the favorites grid and above the footer. Keep it understated (one line, e.g. "Support Blanc"). The callout must not dominate the start page or feel like an ad.
 
-The callout state must update from **both** paths:
+**The link is a plain internal-page anchor, NOT a bridge call.** New-tab pages get `window.bowserPages`, which has no `openPage` — only the chrome/overlay preload exposes `browserAPI.openPage`. So the callout reuses the exact pattern the Favorites label already uses on this page (`<a href="blanc://bookmarks/">favorites</a>`, `newtab.html:26`):
+
+```html
+<p id="patron-callout" class="ledger-patron" hidden>
+  <a href="blanc://settings/#group-patron">Support Blanc</a>
+</p>
+```
+
+The utility-page router intercepts that navigation: `isUtilityUrl('blanc://settings/#group-patron')` is true (host `settings`), and `showUtilityPage` passes the full URL — fragment included — into the sheet navigation, so Settings opens at the Patron section. This is the same fragment-deep-link path the `blocking`→`#group-privacy` link already uses. No new privileged IPC bridge is added.
+
+The callout's *visibility* is state-driven and must update from **both** paths:
 
 ```js
-// On initial load (from pages:start:data)
+// hide when the user is already a Patron
 function renderPatronCallout(patronActive) {
   const el = document.getElementById('patron-callout');
   if (el) el.hidden = !!patronActive;
 }
 
-// Called from the existing dataReady handler
+// initial load (from pages:start:data, in the existing dataReady handler)
 renderPatronCallout(data.patronActive);
 
-// On live status push (from pages:start:status) — add to the existing onStatus handler
+// live status push (from pages:start:status) — add to the existing onStatus handler
 window.bowserPages?.start.onStatus((status) => {
   renderLaunchStatus(status);
   if (status?.layout && status.layout !== state.layout) applyLayout(status.layout);
   if ('patronActive' in status) renderPatronCallout(status.patronActive);
 });
 ```
-
-The callout link uses `window.bowserPages.openPage('settings', 'patron')` to deep-link to the Patron section (Step 3 wires the anchor).
 
 - [ ] **Step 3: `/patron` slash command + section deep-link**
 

--- a/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
+++ b/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
@@ -458,15 +458,23 @@ const settings = require('./settings');
 const model = require('./patron-model');
 
 const PRODUCTION_ORG_ID = '6f675077-6cb1-4965-8db8-15838e5fdb38';
-const SANDBOX_ORG_ID = '/* fill from Polar sandbox dashboard */';
+const SANDBOX_ORG_ID = 'a6ffc65a-8ba3-4973-8a2a-e057aa811f9f';
 const API_BASE = app.isPackaged ? 'https://api.polar.sh' : 'https://sandbox-api.polar.sh';
 const ORG_ID = app.isPackaged ? PRODUCTION_ORG_ID : SANDBOX_ORG_ID;
 const MAX_KEY_LENGTH = 200;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const BENEFIT_ALLOWLIST = app.isPackaged
-  ? { /* prod:    '<supporter>':'founding', '<annual>':'subscription', '<monthly>':'subscription' */ }
-  : { /* sandbox: '<supporter>':'founding', '<annual>':'subscription', '<monthly>':'subscription' */ };
+  ? {
+      '2ffaf466-652d-4e45-b92f-560fc25d3c53': 'founding',      // Blanc Supporter License
+      'df98506e-a88a-4364-b4c9-cc424dda01f0': 'subscription',  // Blanc Patron Monthly License
+      'ed1cce8c-d87e-4d27-b9d7-d30bda2de402': 'subscription',  // Blanc Patron Annual License
+    }
+  : {
+      'de6e9525-3cc4-4232-b96f-f459d56afb19': 'founding',      // sandbox Blanc Supporter License
+      '2f5e210c-7d63-4ba6-8818-45f3b7fc9b93': 'subscription',  // sandbox Blanc Patron Monthly License
+      '27ecc7d8-f31e-4951-8235-22dda51327c4': 'subscription',  // sandbox Blanc Patron Annual License
+    };
 
 async function readJson(res) { try { return await res.json(); } catch { return null; } }
 
@@ -731,7 +739,7 @@ git commit -m "feat(patron): start page callout (live-updating) and /patron slas
 
 **Spec coverage (Phase 1):** entitlement record + kinds (T2–T4); benefit_id allowlist + fail-closed (T1, T5); **persisted-derived activity, restart-safe** (T2, T4); migration persisted via ensureStore+flush (T3, T4); validation with statuses/`expires_at`/defensive benefit_id/**per-validation benefit re-check**/cadence/bootstrap/grace (T2, T5); **activation inspects nested license-key status+expiry before bootstrapping grace** (T5); **three-state `parseExpiresAt` (null/number/false)** — activation rejects malformed, validation treats as ambiguous (T1, T2 unit test); **per-environment org ID** (`PRODUCTION_ORG_ID`/`SANDBOX_ORG_ID`, T5); projection strips both in the *correct* file (T6); downgrade mirror + subscription-never-mirrored (T3, T4); **setPatron fires listeners → Dock reapply** (T4); graceful degradation to `paper` (T4, T8); 200-char guard + malformed-JSON handling (T5); never synced / never generic-write (T4); **upgrade surfaces beyond Settings** — start page callout (live-updated via `pages:start:status` on activation, not just initial load) + `/patron` slash command with `patron` section deep-link (T9). ✓
 
-**Placeholder scan:** the only blanks are the real Polar `benefit_id` values in `BENEFIT_ALLOWLIST` and `SANDBOX_ORG_ID` (T5) — user-side product/org ids that do not exist until the Polar products are created; flagged as a setup invariant, not a hidden TODO.
+**Placeholder scan:** none remain. The real Polar `benefit_id` values in `BENEFIT_ALLOWLIST` and `SANDBOX_ORG_ID` (T5) are filled in from the 2026-08-18 Polar setup (both products Private in production, Public in sandbox). They are public identifiers, not secrets, and ship in the packaged app exactly as the production org id already does in `supporter.js`.
 
 **Type consistency:** `readBenefitId`, `resolveKind`, `GRACE_MS`, `isRecordActive`, `evaluateValidation`, `migrateSupporter`, `downgradeMirror`, `isPatronActive`, `setPatron`, `getPatronRecord`, `activate`, `validateIfDue` are used with consistent signatures across tasks. `evaluateValidation` consumers use only its `.record` (activity is re-derived by `isPatronActive`/`isRecordActive`), so no stale-flag path exists.
 

--- a/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
+++ b/docs/superpowers/plans/2026-08-18-blanc-patron-entitlement-layer.md
@@ -2,55 +2,59 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ship the Patron entitlement foundation — a device-local `patron` record with three kinds (`founding` / `lifetime` / `subscription`), Polar activation + subscription validation with a 30-day offline grace and graceful degradation, migration of existing `$19` Supporters to founding Patrons, and the re-gating of the three cosmetic colorways under Patron — with nothing else gating until this exists.
+**Goal:** Ship the Patron entitlement foundation — a device-local `patron` record with three kinds (`founding` / `lifetime` / `subscription`), Polar activation + subscription validation with a 30-day offline grace and graceful degradation, migration of existing `$19` Supporters to founding Patrons, and re-gating the three cosmetic colorways under Patron — with nothing else gating until this exists.
 
-**Architecture:** All entitlement *decisions* live in a new pure, Electron-free `src/main/patron-model.js` (mirrors `tabsync-model.js` / `session-workspace.js`), covered by `node:test` unit tests. `src/main/patron.js` wraps Polar's `net.fetch` calls and calls the pure model for every decision. `src/main/settings.js` gains the `patron` record, `isPatronActive()`, `setPatron()`, the extended `isAppIconAllowed()` predicate, the renderer projection that strips `patron`, and a one-time upgrade migration. `src/main/main.js` schedules the daily background validation and wires the activation IPC.
+**Architecture:** All entitlement *decisions* live in a new pure, Electron-free `src/main/patron-model.js` (mirrors `tabsync-model.js` / `session-workspace.js`), covered by `node:test` unit tests. **Subscription activity is derived from the persisted record** (`isRecordActive`), never a volatile in-memory flag, so a restart cannot lock out a valid subscriber. `src/main/patron.js` wraps Polar's `net.fetch` calls and delegates every decision to the pure model. `src/main/settings.js` gains the `patron` record, `isPatronActive()`, `setPatron()`, the extended `isAppIconAllowed()`, a one-time migration run **inside `ensureStore()`** (against `store.data`, flushed synchronously), and fires the existing `listeners` set on change. The renderer projection and activation IPC are edited in **`src/main/pages.js`** (where they actually live). `src/main/main.js` only schedules the daily background validation.
 
-**Tech Stack:** Electron (main process), `net.fetch` for Polar's public customer-portal API, `node --test` (`npm run test:unit`) over `test/unit/`, the repo's `JsonStore` persistence.
+**Tech Stack:** Electron (main process), `net.fetch` for Polar's public customer-portal API, `node --test` over `test/unit/`, the repo's `JsonStore` persistence.
 
 ## Global Constraints
 
-Copied verbatim from `docs/superpowers/specs/2026-08-18-blanc-patron-design.md`; every task's requirements implicitly include these:
+Copied verbatim from `docs/superpowers/specs/2026-08-18-blanc-patron-design.md`; every task implicitly includes these:
 
 - **Patron only ever ADDS.** Nothing shipped today (the whole browser + all of today's Personal-only Profile Sync) ever moves behind Patron.
 - **`patron` is the single canonical record.** No Patron-era entitlement check may read `supporter`; `supporter` becomes a downgrade mirror only.
 - **A `subscription` is NEVER written to `supporter`** (an old build reads any non-null `supporter` as a *permanent* grant).
-- **Device-local, never synced.** Neither `patron` nor `supporter` is in `SYNCED_KEYS`; the generic `setSettings()` whitelist must ignore both.
-- **Renderer sees only `patronActive`** (a boolean) — never the key, activation id, benefit id, or Polar status. `getSettings()` must strip **both** `supporter` and `patron`.
-- **Fail open except one path.** Network failure / ambiguous / unknown status → stay active within the 30-day offline grace (clock from `lastValidatedAt`, bootstrapped at activation). Only a **confirmed terminal status** revokes. The single fail-*closed* path: an unrecognized `benefit_id` at activation grants nothing.
-- **Expiration is a field, not a status.** Response carries `status` plus separate `expires_at`; never treat `expired` as a status value.
+- **Subscription activity derives from the persisted record**, not an in-memory boolean (a module cache resets to false on restart and would skip up to 24h of validation, locking out a valid subscriber).
+- **Device-local, never synced.** Neither `patron` nor `supporter` is in `SYNCED_KEYS`; the generic `setSettings()` whitelist ignores both.
+- **Renderer sees only `patronActive`** — never the key, activation id, benefit id, or Polar status. The `pages.js` `clientSettings()` projection strips **both** `supporter` and `patron`.
+- **Fail open except one path.** Network failure / ambiguous / unknown status → stay active within the 30-day offline grace (clock from `lastValidatedAt`, bootstrapped at activation). Only a **confirmed terminal outcome** revokes. The single fail-*closed* path: an unrecognized `benefit_id` at activation grants nothing.
+- **Expiration is a field, not a status.** Response carries `status` plus a separate `expires_at`; never treat `expired` as a status value.
+- **Validation re-checks the benefit.** Each successful validation must resolve the returned `benefit_id` to the expected `subscription` benefit before it may extend entitlement.
 - **Distinct `benefit_id` per product** is a setup invariant, verified in sandbox before production cutover.
-- **No DRM, no lockout, no user-data loss** on lapse — degrade gracefully.
-- **Polar base switches on `app.isPackaged`** (`sandbox-api.polar.sh` in dev, `api.polar.sh` packaged) — already in `supporter.js`. The `benefit_id` allowlist has separate sandbox/production tables on the same switch.
-- **Colorway fallback is `paper`** (`DEFAULTS.appIcon`), applied on the read path; invalid writes are ignored (not reset).
+- **No DRM, no lockout, no user-data loss** on lapse — degrade gracefully. Preserve the existing **200-character key guard** and reject malformed successful JSON.
+- **Polar base switches on `app.isPackaged`** (`sandbox-api.polar.sh` dev, `api.polar.sh` packaged); the `benefit_id` allowlist has separate sandbox/production tables on the same switch. Org id `6f675077-6cb1-4965-8db8-15838e5fdb38` (public, from `supporter.js`).
+- **Colorway fallback is `paper`** (`DEFAULTS.appIcon`), applied on the read path; invalid writes are ignored.
+
+**Testing note:** run a single model file with `node --test test/unit/patron-model.test.js` (targeted TDD). `npm run test:unit` always expands to the whole suite — use it only for the final full-suite check.
 
 ## Roadmap (the other three plans, written after this one lands)
 
-- **Phase 2 — Named Workspaces** (the anchor): profile-scoped `workspaces.json`, ⌘L management UI, single-window binding, continuous autosave, Patron-gated creation.
+- **Phase 2 — Named Workspaces** (anchor): profile-scoped `workspaces.json`, ⌘L management UI, single-window binding, continuous autosave, Patron-gated creation.
 - **Phase 3 — Supporting bundle**: custom slash commands / keybindings; Patron badge in Settings.
-- **Phase 4 — Site + copy**: restrained Patron section with the plain validation disclosure.
+- **Phase 4 — Site + copy**: restrained Patron section with the plain validation disclosure; rename the legacy `supporter-activate` IPC / `supporterActive` alias.
 
 ## File Structure
 
-- **Create `src/main/patron-model.js`** — pure, no `require('electron')`. Exports `resolveKind`, `evaluateValidation`, `migrateSupporter`, `downgradeMirror`, `GRACE_MS`, `readBenefitId`. One responsibility: entitlement decisions as pure functions.
-- **Create `test/unit/patron-model.test.js`** — `node:test` coverage for every branch of the above.
-- **Modify `src/main/settings.js`** — `patron` default; `isPatronActive()`; `setPatron()`; extend `isAppIconAllowed()`; strip `patron` in the renderer projection; run `migrateSupporter` once on load; keep the `supporter` downgrade mirror for founding/lifetime.
-- **Create `src/main/patron.js`** — Polar `activate` + `validate` network calls (Electron `net.fetch`), each delegating decisions to `patron-model`; the `validateIfDue` entry point. Supersedes `supporter.js`'s `activateSupporter` (which is folded in and re-exported for the existing IPC name).
-- **Modify `src/main/main.js`** — daily idle-scheduled `validateIfDue`; wire the settings-page activation IPC to `patron.activate`.
-- **Modify `src/renderer/pages/settings.*`** — Patron section (key input + status) and the three colorways re-gated on `patronActive`. (Manual verification — chrome/UI is not unit-tested per repo norm.)
+- **Create `src/main/patron-model.js`** — pure, no `require('electron')`. Exports `readBenefitId`, `resolveKind`, `GRACE_MS`, `isRecordActive`, `evaluateValidation`, `migrateSupporter`, `downgradeMirror`.
+- **Create `test/unit/patron-model.test.js`** — `node:test` coverage for every branch.
+- **Modify `src/main/settings.js`** — `patron` default; migration inside `ensureStore()`; `isPatronActive()`; `setPatron()` (fires `listeners`); `isAppIconAllowed()`; `getPatronRecord()` (main-only).
+- **Create `src/main/patron.js`** — Polar `activate` + `validateIfDue`, each delegating to `patron-model`.
+- **Modify `src/main/pages.js`** — `clientSettings()` strips `patron` + adds `patronActive`; route `pages:settings:supporter-activate` to `patron.activate`.
+- **Modify `src/main/main.js`** — idle-scheduled daily `validateIfDue`.
+- **Modify `src/renderer/pages/settings.*`** — Patron section + colorways re-gated on `patronActive` (manual verification).
 
 ---
 
-### Task 1: Pure benefit_id → kind resolution (`resolveKind`, `readBenefitId`)
+### Task 1: Pure benefit_id resolution — fail-closed (`readBenefitId`, `resolveKind`)
 
 **Files:**
 - Create: `src/main/patron-model.js`
 - Test: `test/unit/patron-model.test.js`
 
-**Interfaces:**
-- Produces:
-  - `readBenefitId(payload) -> string | null` — defensively reads `benefit_id` from a Polar activate or validate payload: checks `payload.benefit_id`, then `payload.license_key?.benefit_id`, then `payload.activation?.license_key?.benefit_id`.
-  - `resolveKind(benefitId, allowlist) -> 'founding' | 'lifetime' | 'subscription' | null` — maps a benefit id through the given allowlist object (`{ [benefitId]: kind }`); returns `null` for a missing/unknown id (fail closed).
+**Interfaces — Produces:**
+- `readBenefitId(payload) -> string | null` — defensively reads `benefit_id` from a Polar activate or validate payload: `payload.benefit_id`, then `payload.license_key?.benefit_id`, then `payload.activation?.license_key?.benefit_id`.
+- `resolveKind(benefitId, allowlist) -> 'founding'|'lifetime'|'subscription'|null` — **fail-closed**: requires `benefitId` be a non-empty string, uses an own-property check (rejects inherited `toString`/`constructor`/`__proto__`), and returns `null` unless the mapped value is a known kind.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -70,18 +74,29 @@ test('readBenefitId reads root, nested license_key, and nested activation', () =
   assert.equal(readBenefitId(null), null);
 });
 
-test('resolveKind maps known benefits and fails closed on unknown', () => {
+test('resolveKind maps known benefits', () => {
   assert.equal(resolveKind('ben_supporter', ALLOW), 'founding');
   assert.equal(resolveKind('ben_annual', ALLOW), 'subscription');
   assert.equal(resolveKind('ben_lifetime', ALLOW), 'lifetime');
+});
+
+test('resolveKind fails closed on unknown, empty, non-string, and inherited props', () => {
   assert.equal(resolveKind('ben_unknown', ALLOW), null);
+  assert.equal(resolveKind('', ALLOW), null);
   assert.equal(resolveKind(null, ALLOW), null);
+  assert.equal(resolveKind(42, ALLOW), null);
+  // prototype-property inputs must NOT resolve to a truthy inherited value
+  assert.equal(resolveKind('toString', ALLOW), null);
+  assert.equal(resolveKind('constructor', ALLOW), null);
+  assert.equal(resolveKind('__proto__', ALLOW), null);
+  // a benefit mapped to a NON-kind value must not leak through
+  assert.equal(resolveKind('x', { x: 'not_a_kind' }), null);
 });
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npm run test:unit -- test/unit/patron-model.test.js`
+Run: `node --test test/unit/patron-model.test.js`
 Expected: FAIL — cannot find module `patron-model`.
 
 - [ ] **Step 3: Write minimal implementation**
@@ -90,6 +105,8 @@ Expected: FAIL — cannot find module `patron-model`.
 // src/main/patron-model.js
 // Pure entitlement decisions — NO require('electron'). Mirrors the Electron-free
 // pattern of tabsync-model.js / session-workspace.js so every branch is unit-testable.
+
+const KINDS = new Set(['founding', 'lifetime', 'subscription']);
 
 function readBenefitId(payload) {
   if (!payload || typeof payload !== 'object') return null;
@@ -100,8 +117,11 @@ function readBenefitId(payload) {
 }
 
 function resolveKind(benefitId, allowlist) {
-  if (!benefitId) return null;
-  return allowlist[benefitId] ?? null;
+  if (typeof benefitId !== 'string' || benefitId === '') return null;
+  if (!allowlist || typeof allowlist !== 'object') return null;
+  if (!Object.prototype.hasOwnProperty.call(allowlist, benefitId)) return null; // own-property only
+  const kind = allowlist[benefitId];
+  return KINDS.has(kind) ? kind : null;
 }
 
 module.exports = { readBenefitId, resolveKind };
@@ -109,83 +129,85 @@ module.exports = { readBenefitId, resolveKind };
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npm run test:unit -- test/unit/patron-model.test.js`
-Expected: PASS (2 tests).
+Run: `node --test test/unit/patron-model.test.js`
+Expected: PASS (3 tests).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add src/main/patron-model.js test/unit/patron-model.test.js
-git commit -m "feat(patron): pure benefit_id resolution with defensive read + fail-closed mapping"
+git commit -m "feat(patron): fail-closed benefit_id resolution (own-property, validated kind, defensive read)"
 ```
 
 ---
 
-### Task 2: Pure validation state machine (`evaluateValidation`, `GRACE_MS`)
+### Task 2: Derived activity + validation state machine (`isRecordActive`, `evaluateValidation`, `GRACE_MS`)
 
 **Files:**
 - Modify: `src/main/patron-model.js`
 - Test: `test/unit/patron-model.test.js`
 
-**Interfaces:**
-- Consumes: nothing from Task 1 at runtime (same module).
-- Produces:
-  - `GRACE_MS` — `30 * 24 * 60 * 60 * 1000`.
-  - `evaluateValidation({ outcome, record, now }) -> { active: boolean, record }` — the pure state machine. `outcome` is one of:
-    - `{ kind: 'ok', status: string, expiresAt: number|null }` — a parsed Polar response.
-    - `{ kind: 'unreachable' }` — network failure/ambiguous.
-    It returns the next `record` (with updated `lastValidatedAt` / `lastAttemptedAt` / `lastStatus`) and whether the subscription is currently `active`. Founding/lifetime never call this. Rules: `status === 'granted'` and (`expiresAt` null or `> now`) → active, set `lastValidatedAt = now`. Known terminal (`revoked`, `disabled`) or granted-but-`expiresAt <= now` → not active (confirmed lapse). Unknown status or `unreachable` → active **iff** `now - lastValidatedAt <= GRACE_MS`, and does **not** advance `lastValidatedAt`. `lastAttemptedAt` is set to `now` in every case.
+**Interfaces — Produces:**
+- `GRACE_MS = 30 * 24 * 60 * 60 * 1000`.
+- `isRecordActive(record, now) -> boolean` — the **single source of truth for current entitlement, derived purely from the persisted record** (so it is correct immediately on restart, before any network call). `founding`/`lifetime` → true. `subscription` → `record.lastStatus === 'granted' && (now - record.lastValidatedAt) <= GRACE_MS`. Anything else → false.
+- `evaluateValidation({ outcome, record, now }) -> { active, record }` — folds a validation `outcome` into the record, then returns `active: isRecordActive(next, now)`. `outcome` is `{ kind: 'ok', status, expiresAt, benefitOk }` or `{ kind: 'unreachable' }`. Only a **granted + unexpired + benefitOk** result advances `lastValidatedAt`/sets `lastStatus='granted'`. Confirmed terminal (`revoked`/`disabled`), granted-but-expired (`lastStatus='expired'`), and granted-but-benefit-mismatch (`lastStatus='benefit_mismatch'`) each set a non-`granted` `lastStatus` → derived-inactive. **Unknown status or `unreachable` leaves the record unchanged** (rides the grace off the last good `lastValidatedAt`). `lastAttemptedAt` is set to `now` on every `ok`/`unreachable` attempt.
 
 - [ ] **Step 1: Write the failing test**
 
 ```js
 // append to test/unit/patron-model.test.js
-const { evaluateValidation, GRACE_MS } = require('../../src/main/patron-model');
+const { evaluateValidation, isRecordActive, GRACE_MS } = require('../../src/main/patron-model');
 
-const base = (over = {}) => ({
+const sub = (over = {}) => ({
   kind: 'subscription', key: 'k', activationId: 'a', benefitId: 'ben_annual',
   activatedAt: 0, lastValidatedAt: 1000, lastAttemptedAt: 1000, lastStatus: 'granted', ...over,
 });
 
-test('granted, unexpired → active and advances lastValidatedAt', () => {
+test('isRecordActive: founding/lifetime always active; subscription needs granted + within grace', () => {
+  assert.equal(isRecordActive({ kind: 'founding' }, 9e15), true);
+  assert.equal(isRecordActive({ kind: 'lifetime' }, 9e15), true);
+  assert.equal(isRecordActive(null, 0), false);
+  // restart with a granted record still within grace → active WITHOUT any network call
+  assert.equal(isRecordActive(sub({ lastValidatedAt: 1000 }), 1000 + GRACE_MS), true);
+  // past grace → inactive
+  assert.equal(isRecordActive(sub({ lastValidatedAt: 1000 }), 1000 + GRACE_MS + 1), false);
+  // last confirmed status not granted → inactive regardless of grace
+  assert.equal(isRecordActive(sub({ lastStatus: 'revoked', lastValidatedAt: 9e15 }), 9e15), false);
+});
+
+test('granted + unexpired + benefitOk → active, advances lastValidatedAt', () => {
   const now = 5000;
-  const r = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: now + 1 }, record: base(), now });
+  const r = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: now + 1, benefitOk: true }, record: sub(), now });
   assert.equal(r.active, true);
   assert.equal(r.record.lastValidatedAt, now);
-  assert.equal(r.record.lastAttemptedAt, now);
+  assert.equal(r.record.lastStatus, 'granted');
 });
 
-test('revoked → confirmed lapse, not active', () => {
-  const r = evaluateValidation({ outcome: { kind: 'ok', status: 'revoked', expiresAt: null }, record: base(), now: 5000 });
-  assert.equal(r.active, false);
-  assert.equal(r.record.lastAttemptedAt, 5000);
-});
-
-test('granted but expired → confirmed lapse, not active', () => {
+test('revoked, expired, and benefit mismatch each degrade', () => {
   const now = 5000;
-  const r = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: now - 1 }, record: base(), now });
-  assert.equal(r.active, false);
+  assert.equal(evaluateValidation({ outcome: { kind: 'ok', status: 'revoked', expiresAt: null, benefitOk: true }, record: sub(), now }).active, false);
+  assert.equal(evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: now - 1, benefitOk: true }, record: sub(), now }).active, false);
+  const mismatch = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: now + 1, benefitOk: false }, record: sub(), now });
+  assert.equal(mismatch.active, false);
+  assert.equal(mismatch.record.lastStatus, 'benefit_mismatch');
 });
 
-test('unknown status → rides grace, does NOT advance lastValidatedAt', () => {
-  const now = 1000 + GRACE_MS - 1;
-  const r = evaluateValidation({ outcome: { kind: 'ok', status: 'weird_new_status', expiresAt: null }, record: base(), now });
-  assert.equal(r.active, true);
-  assert.equal(r.record.lastValidatedAt, 1000); // unchanged
-});
-
-test('unreachable within grace → active; past grace → degrade', () => {
+test('unknown status and unreachable ride the grace, do not advance lastValidatedAt', () => {
   const withinNow = 1000 + GRACE_MS;
-  assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: base(), now: withinNow }).active, true);
-  const pastNow = 1000 + GRACE_MS + 1;
-  assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: base(), now: pastNow }).active, false);
+  const unknown = evaluateValidation({ outcome: { kind: 'ok', status: 'weird_new', expiresAt: null, benefitOk: true }, record: sub(), now: withinNow });
+  assert.equal(unknown.active, true);
+  assert.equal(unknown.record.lastValidatedAt, 1000); // unchanged
+  assert.equal(unknown.record.lastStatus, 'granted'); // unchanged
+  assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: sub(), now: withinNow }).active, true);
+  assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: sub(), now: 1000 + GRACE_MS + 1 }).active, false);
+  assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: sub(), now: withinNow }).record.lastAttemptedAt, withinNow);
 });
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npm run test:unit -- test/unit/patron-model.test.js`
-Expected: FAIL — `evaluateValidation is not a function`.
+Run: `node --test test/unit/patron-model.test.js`
+Expected: FAIL — `isRecordActive is not a function`.
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -194,44 +216,49 @@ Expected: FAIL — `evaluateValidation is not a function`.
 const GRACE_MS = 30 * 24 * 60 * 60 * 1000;
 const TERMINAL = new Set(['revoked', 'disabled']);
 
-function evaluateValidation({ outcome, record, now }) {
-  const next = { ...record, lastAttemptedAt: now };
-
-  if (outcome.kind === 'ok' && outcome.status === 'granted'
-      && (outcome.expiresAt == null || outcome.expiresAt > now)) {
-    next.lastStatus = 'granted';
-    next.lastValidatedAt = now;
-    return { active: true, record: next };
-  }
-
-  const confirmedTerminal =
-    (outcome.kind === 'ok' && TERMINAL.has(outcome.status)) ||
-    (outcome.kind === 'ok' && outcome.status === 'granted'
-      && outcome.expiresAt != null && outcome.expiresAt <= now);
-  if (confirmedTerminal) {
-    next.lastStatus = outcome.status;
-    return { active: false, record: next };
-  }
-
-  // unknown status OR unreachable → ambiguous: ride the offline grace, do not advance lastValidatedAt.
-  if (outcome.kind === 'ok') next.lastStatus = outcome.status;
-  const active = (now - record.lastValidatedAt) <= GRACE_MS;
-  return { active, record: next };
+function isRecordActive(record, now) {
+  if (!record) return false;
+  if (record.kind === 'founding' || record.kind === 'lifetime') return true;
+  if (record.kind !== 'subscription') return false;
+  return record.lastStatus === 'granted' && (now - (record.lastValidatedAt ?? 0)) <= GRACE_MS;
 }
 
-module.exports = { readBenefitId, resolveKind, evaluateValidation, GRACE_MS };
+function evaluateValidation({ outcome, record, now }) {
+  const next = { ...record };
+  if (outcome.kind === 'ok') {
+    next.lastAttemptedAt = now;
+    const granted = outcome.status === 'granted';
+    const unexpired = outcome.expiresAt == null || outcome.expiresAt > now;
+    if (granted && unexpired && outcome.benefitOk) {
+      next.lastStatus = 'granted';
+      next.lastValidatedAt = now;
+    } else if (TERMINAL.has(outcome.status)) {
+      next.lastStatus = outcome.status;               // confirmed terminal
+    } else if (granted && !unexpired) {
+      next.lastStatus = 'expired';                    // derived terminal
+    } else if (granted && !outcome.benefitOk) {
+      next.lastStatus = 'benefit_mismatch';           // derived terminal
+    }
+    // else: unknown, non-terminal status → leave lastStatus/lastValidatedAt untouched (ride grace)
+  } else {
+    next.lastAttemptedAt = now;                       // unreachable → ride grace, unchanged otherwise
+  }
+  return { active: isRecordActive(next, now), record: next };
+}
+
+module.exports = { readBenefitId, resolveKind, GRACE_MS, isRecordActive, evaluateValidation };
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npm run test:unit -- test/unit/patron-model.test.js`
-Expected: PASS (all Task 1 + Task 2 tests).
+Run: `node --test test/unit/patron-model.test.js`
+Expected: PASS (Task 1 + Task 2 tests).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add src/main/patron-model.js test/unit/patron-model.test.js
-git commit -m "feat(patron): validation state machine with 30-day offline grace, fail-open except confirmed terminal"
+git commit -m "feat(patron): persisted-record-derived activity + validation state machine with benefit re-check"
 ```
 
 ---
@@ -242,10 +269,9 @@ git commit -m "feat(patron): validation state machine with 30-day offline grace,
 - Modify: `src/main/patron-model.js`
 - Test: `test/unit/patron-model.test.js`
 
-**Interfaces:**
-- Produces:
-  - `migrateSupporter({ supporter, patron, now }) -> { patron } | null` — if `supporter` is non-null and `patron` is null, returns `{ patron: { kind:'founding', key, activationId, benefitId:null, activatedAt } }` (using the supporter's fields, `activatedAt` falling back to `now`). Otherwise returns `null` (no change — idempotent).
-  - `downgradeMirror(patron) -> supporterRecord | null` — returns the legacy `{ key, activationId, activatedAt }` mirror to persist under `supporter` **only** for `founding`/`lifetime`; returns `null` for `subscription` or null patron (so a subscription is never mirrored).
+**Interfaces — Produces:**
+- `migrateSupporter({ supporter, patron, now }) -> { patron } | null` — if `supporter` non-null and `patron` null, returns `{ patron: { kind:'founding', key, activationId, benefitId:null, activatedAt } }` (activatedAt falling back to `now`). Otherwise `null` (idempotent — nothing to do).
+- `downgradeMirror(patron) -> { key, activationId, activatedAt } | null` — the legacy mirror to persist under `supporter`, **only** for `founding`/`lifetime`; `null` for `subscription` or null patron (a subscription is never mirrored).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -253,23 +279,17 @@ git commit -m "feat(patron): validation state machine with 30-day offline grace,
 // append to test/unit/patron-model.test.js
 const { migrateSupporter, downgradeMirror } = require('../../src/main/patron-model');
 
-test('migrateSupporter creates a founding patron from a legacy supporter, once', () => {
+test('migrateSupporter creates a founding patron once, idempotently', () => {
   const supporter = { key: 'k', activationId: 'a', activatedAt: 42 };
   const out = migrateSupporter({ supporter, patron: null, now: 99 });
   assert.deepEqual(out.patron, { kind: 'founding', key: 'k', activationId: 'a', benefitId: null, activatedAt: 42 });
-  // idempotent: already has a patron → null
-  assert.equal(migrateSupporter({ supporter, patron: out.patron, now: 99 }), null);
-  // nothing to migrate
-  assert.equal(migrateSupporter({ supporter: null, patron: null, now: 99 }), null);
+  assert.equal(migrateSupporter({ supporter, patron: out.patron, now: 99 }), null); // already migrated
+  assert.equal(migrateSupporter({ supporter: null, patron: null, now: 99 }), null); // nothing to migrate
 });
 
-test('downgradeMirror mirrors founding/lifetime but NEVER a subscription', () => {
-  assert.deepEqual(
-    downgradeMirror({ kind: 'founding', key: 'k', activationId: 'a', activatedAt: 42 }),
-    { key: 'k', activationId: 'a', activatedAt: 42 });
-  assert.deepEqual(
-    downgradeMirror({ kind: 'lifetime', key: 'k', activationId: 'a', activatedAt: 7 }),
-    { key: 'k', activationId: 'a', activatedAt: 7 });
+test('downgradeMirror mirrors founding/lifetime, NEVER a subscription', () => {
+  assert.deepEqual(downgradeMirror({ kind: 'founding', key: 'k', activationId: 'a', activatedAt: 42 }), { key: 'k', activationId: 'a', activatedAt: 42 });
+  assert.deepEqual(downgradeMirror({ kind: 'lifetime', key: 'k', activationId: 'a', activatedAt: 7 }), { key: 'k', activationId: 'a', activatedAt: 7 });
   assert.equal(downgradeMirror({ kind: 'subscription', key: 'k', activationId: 'a', activatedAt: 1 }), null);
   assert.equal(downgradeMirror(null), null);
 });
@@ -277,7 +297,7 @@ test('downgradeMirror mirrors founding/lifetime but NEVER a subscription', () =>
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npm run test:unit -- test/unit/patron-model.test.js`
+Run: `node --test test/unit/patron-model.test.js`
 Expected: FAIL — `migrateSupporter is not a function`.
 
 - [ ] **Step 3: Write minimal implementation**
@@ -286,15 +306,10 @@ Expected: FAIL — `migrateSupporter is not a function`.
 // add to src/main/patron-model.js
 function migrateSupporter({ supporter, patron, now }) {
   if (!supporter || patron) return null;
-  return {
-    patron: {
-      kind: 'founding',
-      key: supporter.key,
-      activationId: supporter.activationId ?? null,
-      benefitId: null,
-      activatedAt: supporter.activatedAt ?? now,
-    },
-  };
+  return { patron: {
+    kind: 'founding', key: supporter.key, activationId: supporter.activationId ?? null,
+    benefitId: null, activatedAt: supporter.activatedAt ?? now,
+  } };
 }
 
 function downgradeMirror(patron) {
@@ -302,19 +317,19 @@ function downgradeMirror(patron) {
   return { key: patron.key, activationId: patron.activationId ?? null, activatedAt: patron.activatedAt };
 }
 
-module.exports = { readBenefitId, resolveKind, evaluateValidation, GRACE_MS, migrateSupporter, downgradeMirror };
+module.exports = { readBenefitId, resolveKind, GRACE_MS, isRecordActive, evaluateValidation, migrateSupporter, downgradeMirror };
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npm run test:unit -- test/unit/patron-model.test.js`
-Expected: PASS (all tests).
+Run: `node --test test/unit/patron-model.test.js`
+Expected: PASS (all model tests).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add src/main/patron-model.js test/unit/patron-model.test.js
-git commit -m "feat(patron): pure migration + downgrade-mirror (subscription never mirrored to supporter)"
+git commit -m "feat(patron): pure migration + downgrade mirror (subscription never mirrored)"
 ```
 
 ---
@@ -322,90 +337,72 @@ git commit -m "feat(patron): pure migration + downgrade-mirror (subscription nev
 ### Task 4: Wire the model into `settings.js`
 
 **Files:**
-- Modify: `src/main/settings.js` (the `DEFAULTS`, the sanitize/projection paths, `isAppIconAllowed`, exports)
-- Test: `test/unit/settings-patron.test.js` (new — `settings.js` is `require`-able without Electron for these pure predicates; if it pulls Electron at import in this repo, fall back to the manual steps noted)
+- Modify: `src/main/settings.js` — `DEFAULTS`, `ensureStore()` (migration + synchronous flush), `isAppIconAllowed`, new `isPatronActive`/`setPatron`/`getPatronRecord`, exports.
 
 **Interfaces:**
-- Consumes: `migrateSupporter`, `downgradeMirror` from `patron-model`.
-- Produces (on `settings.js` exports):
-  - `isPatronActive() -> boolean` — true for `founding`/`lifetime`; for `subscription`, true when `_patronSubscriptionActive` (a cached boolean the main-process validator sets via `setPatron`); false when `patron` is null.
-  - `setPatron(record)` — the only writer of `patron`; also writes the `downgradeMirror(record)` into `supporter` (or clears it) so founding/lifetime survive a downgrade and a subscription never does.
-  - `isAppIconAllowed(id)` — now `APP_ICONS.includes(id) || (SUPPORTER_ICONS.includes(id) && isPatronActive())`.
+- Consumes: `migrateSupporter`, `downgradeMirror`, `isRecordActive` from `patron-model`.
+- Produces (settings exports): `isPatronActive()`, `setPatron(record)`, `getPatronRecord()` (main-only), extended `isAppIconAllowed(id)`.
 
-- [ ] **Step 1: Add the `patron` default and migration on load**
+- [ ] **Step 1: Add the `patron` default and the require**
 
-In `DEFAULTS`, beside `supporter: null`, add `patron: null`. In the store's post-load sanitize (where `getSettings()`/read coercion runs), call `migrateSupporter` and, if it returns a change, persist the new `patron` (leaving `supporter` intact as the mirror).
+Add `patron: null` in `DEFAULTS` beside `supporter: null`. At top: `const { migrateSupporter, downgradeMirror, isRecordActive } = require('./patron-model');`
+
+- [ ] **Step 2: Run the migration inside `ensureStore()` against `store.data`, then flush synchronously**
+
+Blocker: the migration must mutate the persisted store, not the shallow copy `getSettings()` returns. Add it inside `ensureStore()`, right after `store = new JsonStore('settings', DEFAULTS);` (line ~147) and before the return, following the existing synchronous-`store.flush()` pattern there:
 
 ```js
-// near the top: const { migrateSupporter, downgradeMirror } = require('./patron-model');
-// in the load/sanitize path, after the store data is available:
-const migrated = migrateSupporter({ supporter: data.supporter, patron: data.patron, now: Date.now() });
-if (migrated) data.patron = migrated.patron;
+    const migrated = migrateSupporter({ supporter: store.data.supporter, patron: store.data.patron, now: Date.now() });
+    if (migrated) {
+      store.data.patron = migrated.patron;      // supporter left intact — it is the downgrade mirror for founding
+      store.flush();                            // synchronous, like the onboarding-marker flushes above
+    }
 ```
 
-- [ ] **Step 2: Add `isPatronActive`, `setPatron`, extend `isAppIconAllowed`**
+- [ ] **Step 3: Add `isPatronActive`, `setPatron` (firing listeners), `getPatronRecord`; extend `isAppIconAllowed`**
+
+`setPatron` must fire the existing `listeners` set exactly as `setSupporter` does (line ~321) — otherwise activation won't reapply the Dock icon or update live UI:
 
 ```js
-let _patronSubscriptionActive = false; // set by the main-process validator via setPatron/refresh
-
 function isPatronActive() {
-  const p = ensureStore().data.patron;
-  if (!p) return false;
-  if (p.kind === 'founding' || p.kind === 'lifetime') return true;
-  return _patronSubscriptionActive; // subscription: gated by the last validation result
+  return isRecordActive(ensureStore().data.patron, Date.now());
 }
 
-function setPatron(record, { subscriptionActive } = {}) {
+// The activation flow's private write path — setSettings()'s whitelist has no `patron`.
+function setPatron(record) {
   ensureStore().update((data) => {
     data.patron = record;
     data.supporter = downgradeMirror(record); // founding/lifetime mirror; subscription/null → null
   });
-  if (typeof subscriptionActive === 'boolean') _patronSubscriptionActive = subscriptionActive;
+  for (const fn of listeners) fn(getSettings()); // reapplies applyAppIcon + live UI, like setSupporter
 }
+
+// Main-process only; NEVER exposed to a renderer.
+function getPatronRecord() { return ensureStore().data.patron; }
 
 function isAppIconAllowed(id) {
   return APP_ICONS.includes(id) || (SUPPORTER_ICONS.includes(id) && isPatronActive());
 }
 ```
 
-Replace the existing `isSupporterActive`-based `isAppIconAllowed` body accordingly. Keep `isSupporterActive` exported for now (used only by the legacy read path) but ensure **no entitlement check** calls it — `isAppIconAllowed` now calls `isPatronActive`.
+Replace the existing `isAppIconAllowed` body (which calls `isSupporterActive`). Leave `isSupporterActive` exported but ensure **no entitlement path calls it** (only the downgrade mirror concerns `supporter` now). Add `isPatronActive`, `setPatron`, `getPatronRecord` to `module.exports`.
 
-- [ ] **Step 3: Strip `patron` in the renderer projection**
+- [ ] **Step 4: Keep `patron` out of the generic write + sync**
 
-Find where `getSettings()` builds the renderer-facing object (today it strips `supporter` and exposes `supporterActive`). Add: delete `patron`, and expose `patronActive: isPatronActive()` (keep `supporterActive` as an alias equal to `patronActive` for any existing renderer reference until Phase 4 updates copy).
+Confirm `setSettings()`'s whitelist copies neither `supporter` nor `patron` (it already omits `supporter`; add a one-line comment that `patron` is likewise activation-flow-only). Confirm `SYNCED_KEYS` contains neither (it does not — do not add them).
 
-```js
-// in the projection:
-delete clean.supporter;
-delete clean.patron;
-clean.patronActive = isPatronActive();
-clean.supporterActive = clean.patronActive; // temporary alias
-```
+- [ ] **Step 5: Verify (manual — settings.js imports Electron at load, so no unit file)**
 
-- [ ] **Step 4: Keep `patron`/`supporter` out of the generic write + sync**
+`npm start`; in the main-process console call `settings.setPatron({kind:'founding',key:'x',activationId:null,activatedAt:Date.now()})` and confirm `isPatronActive()` is `true`, `isAppIconAllowed('ember')` is `true`, and the Dock icon reapplies (listener fired). Restart and confirm `isPatronActive()` is still `true` from the persisted record with no network call. Also confirm a legacy `settings.json` carrying only `supporter` gains a `patron:{kind:'founding'}` on next launch (migration + flush).
 
-Confirm the `setSettings()` whitelist copies **neither** `patron` nor `supporter` (it already omits `supporter`; add an explicit guard/comment so `patron` is never accepted from a renderer partial). Confirm `SYNCED_KEYS` contains neither (it does not — do not add them).
-
-- [ ] **Step 5: Unit-test the projection + predicate (or verify manually)**
-
-```js
-// test/unit/settings-patron.test.js  (only if settings.js imports without Electron in this repo)
-const { test } = require('node:test');
-const assert = require('node:assert');
-// Drive via the exported helpers against a temp userData; if settings.js requires electron
-// at import time, SKIP this file and use the manual check below instead.
-```
-
-Manual fallback (always valid): `npm start`, then in the main-process console set a founding patron and confirm a renderer `getSettings()` payload contains `patronActive: true` and **no** `patron`/`supporter` field.
-
-- [ ] **Step 6: Run tests + commit**
+- [ ] **Step 6: Run the full suite + commit**
 
 Run: `npm run test:unit`
-Expected: PASS (existing suite + patron-model; settings-patron if applicable).
+Expected: PASS (existing suite + patron-model).
 
 ```bash
-git add src/main/settings.js test/unit/settings-patron.test.js
-git commit -m "feat(patron): settings record, isPatronActive, projection strip, colorway re-gate, migration on load"
+git add src/main/settings.js
+git commit -m "feat(patron): settings record, ensureStore migration+flush, isPatronActive via persisted record, listener-firing setPatron"
 ```
 
 ---
@@ -414,63 +411,61 @@ git commit -m "feat(patron): settings record, isPatronActive, projection strip, 
 
 **Files:**
 - Create: `src/main/patron.js`
-- Modify: `src/main/supporter.js` (re-export the activation entry so the existing IPC name keeps working) — or delete once `main.js` points at `patron.js`.
 
 **Interfaces:**
-- Consumes: `readBenefitId`, `resolveKind`, `evaluateValidation` from `patron-model`; `setPatron`, and the stored `patron` record from `settings`.
-- Produces:
-  - `activate(key) -> { ok: boolean, message?, kind? }` — POSTs to `.../license-keys/activate` with `{ key, organization_id, label }`, reads `benefit_id` via `readBenefitId`, resolves the kind via the per-environment allowlist, and on a known kind calls `setPatron` with a record whose `lastValidatedAt`/`lastAttemptedAt` are bootstrapped to now (activation is an online success) and `subscriptionActive: true` for the subscription kind. **Unknown benefit_id → `{ ok:false }`, grants nothing (fail closed).**
-  - `validateIfDue() -> Promise<void>` — for a `subscription` patron only, and at most once per `lastAttemptedAt + 1 day`, POSTs to `.../license-keys/validate` with `{ organization_id, key, activation_id }`, parses `{ status, expires_at }` into an `outcome`, runs `evaluateValidation`, and persists the returned record via `setPatron({...}, { subscriptionActive: active })`. Network failure → `outcome: { kind:'unreachable' }`.
+- Consumes: `readBenefitId`, `resolveKind`, `evaluateValidation` from `patron-model`; `setPatron`, `getPatronRecord` from `settings`.
+- Produces: `activate(key) -> Promise<{ ok, message?, kind? }>`, `validateIfDue() -> Promise<void>`.
 
-- [ ] **Step 1: Scaffold the per-environment allowlist + API base**
+- [ ] **Step 1: Scaffold API base + allowlist + `activate` (with 200-char guard, fail-closed benefit, malformed-JSON catch)**
 
 ```js
 const { app, net } = require('electron');
 const settings = require('./settings');
 const model = require('./patron-model');
 
-const ORG_ID = '6f675077-6cb1-4965-8db8-15838e5fdb38'; // production org "bnfy" (public, from supporter.js)
+const ORG_ID = '6f675077-6cb1-4965-8db8-15838e5fdb38'; // public org "bnfy" (from supporter.js)
 const API_BASE = app.isPackaged ? 'https://api.polar.sh' : 'https://sandbox-api.polar.sh';
+const MAX_KEY_LENGTH = 200; // preserved from supporter.js — client-side stray-paste backstop
+const DAY_MS = 24 * 60 * 60 * 1000;
 
-// SETUP INVARIANT: each product uses a DISTINCT license-key benefit. Fill these from the
-// Polar dashboard; verify the sandbox ids in sandbox before production cutover.
+// SETUP INVARIANT: each product uses a DISTINCT license-key benefit. Fill from the Polar
+// dashboard; verify the SANDBOX ids in sandbox before the production cutover.
 const BENEFIT_ALLOWLIST = app.isPackaged
-  ? { /* prod: */ }   // { '<supporter>': 'founding', '<annual>': 'subscription', '<monthly>': 'subscription', '<lifetime?>': 'lifetime' }
-  : { /* sandbox: */ };
-```
+  ? { /* prod:    '<supporter>':'founding', '<annual>':'subscription', '<monthly>':'subscription' */ }
+  : { /* sandbox: '<supporter>':'founding', '<annual>':'subscription', '<monthly>':'subscription' */ };
 
-- [ ] **Step 2: Implement `activate`**
+async function readJson(res) { try { return await res.json(); } catch { return null; } }
 
-```js
 async function activate(key) {
   const trimmed = String(key ?? '').trim();
   if (!trimmed) return { ok: false, message: 'Enter a license key.' };
+  if (trimmed.length > MAX_KEY_LENGTH) return { ok: false, message: 'That doesn’t look like a license key.' };
   let res;
   try {
     res = await net.fetch(`${API_BASE}/v1/customer-portal/license-keys/activate`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ key: trimmed, organization_id: ORG_ID, label: 'Blanc' }),
     });
-  } catch { return { ok: false, message: "Couldn't reach Polar — check your connection and try again." }; }
+  } catch { return { ok: false, message: "Couldn’t reach Polar — check your connection and try again." }; }
   if (!res.ok) return { ok: false, message: 'That license key could not be activated.' };
-  const payload = await res.json();
-  const kind = model.resolveKind(model.readBenefitId(payload), BENEFIT_ALLOWLIST);
-  if (!kind) return { ok: false, message: 'That license key is not recognized.' }; // fail closed
+  const payload = await readJson(res);
+  const benefitId = model.readBenefitId(payload);
+  const kind = model.resolveKind(benefitId, BENEFIT_ALLOWLIST);
+  if (!payload || !kind) return { ok: false, message: 'That license key is not recognized.' }; // fail closed / malformed
   const now = Date.now();
   const activationId = payload.activation?.id ?? payload.id ?? null;
-  const record = { kind, key: trimmed, activationId, benefitId: model.readBenefitId(payload), activatedAt: now,
+  const record = { kind, key: trimmed, activationId, benefitId, activatedAt: now,
     ...(kind === 'subscription' ? { lastValidatedAt: now, lastAttemptedAt: now, lastStatus: 'granted' } : {}) };
-  settings.setPatron(record, { subscriptionActive: kind === 'subscription' });
+  settings.setPatron(record); // isPatronActive derives activity; no separate flag
   return { ok: true, kind };
 }
 ```
 
-- [ ] **Step 3: Implement `validateIfDue`**
+- [ ] **Step 2: Implement `validateIfDue` (subscription only; re-checks the benefit; malformed → unreachable)**
 
 ```js
-const DAY_MS = 24 * 60 * 60 * 1000;
 async function validateIfDue() {
-  const p = settings.getPatronRecord(); // add a tiny getter to settings that returns the raw record (main-process only)
+  const p = settings.getPatronRecord();
   if (!p || p.kind !== 'subscription') return;
   if (Date.now() - (p.lastAttemptedAt ?? 0) < DAY_MS) return;
   let outcome;
@@ -479,67 +474,105 @@ async function validateIfDue() {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ organization_id: ORG_ID, key: p.key, activation_id: p.activationId }),
     });
-    if (!res.ok) outcome = { kind: 'unreachable' };
-    else { const b = await res.json(); outcome = { kind: 'ok', status: b.status, expiresAt: b.expires_at ? Date.parse(b.expires_at) : null }; }
+    const body = res.ok ? await readJson(res) : null;
+    if (!body || typeof body.status !== 'string') {
+      outcome = { kind: 'unreachable' };                 // non-ok OR malformed successful JSON → ambiguous
+    } else {
+      const benefitOk = model.resolveKind(model.readBenefitId(body), BENEFIT_ALLOWLIST) === 'subscription';
+      outcome = { kind: 'ok', status: body.status, expiresAt: body.expires_at ? Date.parse(body.expires_at) : null, benefitOk };
+    }
   } catch { outcome = { kind: 'unreachable' }; }
-  const { active, record } = model.evaluateValidation({ outcome, record: p, now: Date.now() });
-  settings.setPatron(record, { subscriptionActive: active });
+  const { record } = model.evaluateValidation({ outcome, record: p, now: Date.now() });
+  settings.setPatron(record);
 }
 
 module.exports = { activate, validateIfDue };
 ```
 
-- [ ] **Step 4: Add the `getPatronRecord` main-process getter to `settings.js`**
+- [ ] **Step 3: Verify manually (network path — not unit-tested)**
 
-```js
-// settings.js — main-process only; NEVER exposed to renderers
-function getPatronRecord() { return ensureStore().data.patron; }
-// add getPatronRecord to module.exports
-```
+`npm start`; activate a Polar **sandbox** subscription key (via the Settings flow, Task 8): confirm a `subscription` record with bootstrapped `lastValidatedAt`/`lastStatus:'granted'`. Confirm an unknown-benefit key returns "not recognized" and writes nothing. Simulate a cancelled subscription in the Polar sandbox and confirm the next `validateIfDue` degrades (`lastStatus` becomes `revoked`, `isPatronActive()` false, Dock reverts to `paper`).
 
-- [ ] **Step 5: Verify manually (network path — not unit-tested)**
-
-`npm start`, activate a Polar **sandbox** subscription key via the Settings flow (Task 6/7), confirm `settings.json` gains a `subscription` `patron` record with bootstrapped `lastValidatedAt`, and that an unknown-benefit key returns "not recognized" and writes nothing.
-
-- [ ] **Step 6: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
-git add src/main/patron.js src/main/settings.js
-git commit -m "feat(patron): Polar activate + daily validate wired through the pure model"
+git add src/main/patron.js
+git commit -m "feat(patron): Polar activate + daily validate with benefit re-check, key guard, malformed-JSON handling"
 ```
 
 ---
 
-### Task 6: Schedule validation + wire activation IPC in `main.js`
+### Task 6: Renderer projection + activation IPC in `pages.js`
+
+**Files:**
+- Modify: `src/main/pages.js` — `clientSettings()` (line ~173) and the `pages:settings:supporter-activate` handler (line ~197).
+
+**Interfaces:**
+- Consumes: `settings.isPatronActive()`; `patron.activate`.
+
+- [ ] **Step 1: Strip `patron` in the projection, add `patronActive`**
+
+`clientSettings()` currently destructures `{ supporter: record, _syncMeta, ...rest }`. Add `patron` to the destructure so it is stripped, and expose `patronActive`:
+
+```js
+  const clientSettings = () => {
+    const { supporter: record, patron, _syncMeta, ...rest } = settings.getSettings();
+    return {
+      ...rest,
+      patronActive: settings.isPatronActive(),
+      supporterActive: settings.isPatronActive(), // temporary alias until Phase 4 renames renderer refs
+      supporterActivatedAt: record?.activatedAt ?? null,
+    };
+  };
+```
+
+- [ ] **Step 2: Route the activation IPC to `patron.activate`**
+
+Require patron at the top of `pages.js` (`const patron = require('./patron');`, alongside the existing `supporter` require) and route the handler (keep the channel name; Phase 4 renames it):
+
+```js
+  handle('pages:settings:supporter-activate', 'settings', (key) => patron.activate(key));
+```
+
+- [ ] **Step 3: Verify manually**
+
+`npm start`; confirm `pages:settings:get` returns `patronActive` and **no** `patron`/`supporter` field, and that activating from Settings persists a record and flips `patronActive`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/pages.js
+git commit -m "feat(patron): pages.js projection strips patron + adds patronActive; activation IPC routes to patron.activate"
+```
+
+---
+
+### Task 7: Schedule daily validation in `main.js`
 
 **Files:**
 - Modify: `src/main/main.js`
 
 **Interfaces:**
-- Consumes: `patron.activate`, `patron.validateIfDue`.
+- Consumes: `patron.validateIfDue`.
 
 - [ ] **Step 1: Schedule `validateIfDue` off the critical path**
 
-After the window is up and the app is idle (reuse the existing post-launch idle hook the app already uses for deferred work; do **not** run it during `installStartupNavigationGate`), call `patron.validateIfDue()` once, then on a daily interval. Never block startup or navigation on it.
+After the window is up and the app is idle (reuse the existing post-launch deferred-work hook; do **not** run during `installStartupNavigationGate`), call `patron.validateIfDue()` once, then on a daily interval. It must never block startup or navigation; its own once-per-day guard lives in the model wiring.
 
-- [ ] **Step 2: Point the existing activation IPC at `patron.activate`**
+- [ ] **Step 2: Verify manually**
 
-The Settings page already has a supporter-activate IPC (`pages:settings:supporter-activate` per the Phase 1 spec). Route it to `patron.activate` (keep the channel name to avoid a renderer change here; rename in Phase 4). Return `{ ok, message }` to the renderer.
+`npm start`; with a logging breakpoint, confirm no validate call fires before the blocker/navigation gate resolves, and that a subscription record older than a day triggers exactly one validate.
 
-- [ ] **Step 3: Verify manually**
-
-`npm start`; confirm no validation call fires before the blocker/navigation gate resolves (check with a logging breakpoint), and that activation from Settings persists a record.
-
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Commit**
 
 ```bash
 git add src/main/main.js
-git commit -m "feat(patron): idle-scheduled daily validation + activation IPC wiring"
+git commit -m "feat(patron): idle-scheduled daily subscription validation"
 ```
 
 ---
 
-### Task 7: Settings UI — Patron section + re-gated colorways
+### Task 8: Settings UI — Patron section + re-gated colorways
 
 **Files:**
 - Modify: `src/renderer/pages/settings.html` / `settings.js` (renderer) / `pages.css`
@@ -547,17 +580,11 @@ git commit -m "feat(patron): idle-scheduled daily validation + activation IPC wi
 **Interfaces:**
 - Consumes: the renderer `patronActive` boolean; the activation IPC.
 
-- [ ] **Step 1: Render the Patron section**
+- [ ] **Step 1: Render the Patron section** — a "Blanc Patron" block: license-key input + Activate button + a quiet status line driven by `patronActive`. Reuse the existing supporter-section markup.
 
-A "Blanc Patron" section: license-key input + Activate button, and a quiet status line ("Patron active" / inactive) driven by `patronActive`. Reuse the existing supporter-section markup where it exists.
+- [ ] **Step 2: Re-gate the three colorways on `patronActive`** — `ember`/`plum`/`gold` tiles show locked (dimmed + "Patron" tag) unless `patronActive`; a locked tile points to the Patron section. Existing supporter-tile behavior with the gate switched to `patronActive`.
 
-- [ ] **Step 2: Re-gate the three colorways on `patronActive`**
-
-The `ember`/`plum`/`gold` tiles show locked (dimmed + "Patron" tag) unless `patronActive`; clicking a locked tile points to the Patron section. This is the existing supporter-tile behavior with the gate switched from `supporterActive` to `patronActive`.
-
-- [ ] **Step 3: Verify manually (chrome requires a relaunch)**
-
-Relaunch `npm start` (chrome HTML loads once at window creation). Confirm: locked tiles when inactive; after activating a sandbox key, tiles unlock and the Dock colorway applies; on a simulated lapse the colorway reverts to `paper`.
+- [ ] **Step 3: Verify manually (chrome requires relaunch)** — relaunch `npm start`. Locked tiles when inactive; after activating a sandbox key, tiles unlock and the Dock colorway applies; on a simulated lapse the colorway reverts to `paper`.
 
 - [ ] **Step 4: Commit**
 
@@ -570,22 +597,12 @@ git commit -m "feat(patron): Settings Patron section and Patron-gated colorways"
 
 ## Self-Review
 
-**Spec coverage (Phase 1 scope):**
-- Entitlement record + three kinds → Tasks 2–4. ✓
-- benefit_id allowlist + fail-closed unknown → Tasks 1, 5. ✓
-- Retire $19 checkout → user-side (noted in spec §Polar; not a code task). Flagged in handoff.
-- Migration of legacy supporter → founding → Tasks 3, 4. ✓
-- Validation model (endpoint, statuses, expires_at-not-a-status, defensive benefit_id, cadence, bootstrap, grace) → Tasks 2, 5. ✓
-- Renderer projection strips both → Task 4. ✓
-- Downgrade mirror + subscription-never-mirrored → Tasks 3, 4. ✓
-- Graceful degradation (colorway→paper) → Tasks 4, 7. ✓
-- Never synced / never in generic write → Task 4. ✓
-- Distinct-benefit sandbox verification → Task 5 setup invariant + handoff note. ✓
+**Spec coverage (Phase 1):** entitlement record + kinds (T2–T4); benefit_id allowlist + fail-closed (T1, T5); **persisted-derived activity, restart-safe** (T2, T4); migration persisted via ensureStore+flush (T3, T4); validation with statuses/`expires_at`/defensive benefit_id/**per-validation benefit re-check**/cadence/bootstrap/grace (T2, T5); projection strips both in the *correct* file (T6); downgrade mirror + subscription-never-mirrored (T3, T4); **setPatron fires listeners → Dock reapply** (T4); graceful degradation to `paper` (T4, T8); 200-char guard + malformed-JSON handling (T5); never synced / never generic-write (T4). ✓
 
-**Placeholder scan:** The only intentional blanks are the real Polar `benefit_id` values in Task 5's `BENEFIT_ALLOWLIST` — these are user-side product ids that do not exist until the Polar products are created (spec: account/product setup is user-side). Flagged explicitly, not a hidden TODO.
+**Placeholder scan:** the only blanks are the real Polar `benefit_id` values in `BENEFIT_ALLOWLIST` (T5) — user-side product ids that do not exist until the Polar products are created; flagged as a setup invariant, not a hidden TODO.
 
-**Type consistency:** `resolveKind`, `readBenefitId`, `evaluateValidation`, `migrateSupporter`, `downgradeMirror`, `GRACE_MS`, `isPatronActive`, `setPatron`, `getPatronRecord`, `activate`, `validateIfDue` are used with consistent signatures across tasks.
+**Type consistency:** `readBenefitId`, `resolveKind`, `GRACE_MS`, `isRecordActive`, `evaluateValidation`, `migrateSupporter`, `downgradeMirror`, `isPatronActive`, `setPatron`, `getPatronRecord`, `activate`, `validateIfDue` are used with consistent signatures across tasks. `evaluateValidation` consumers use only its `.record` (activity is re-derived by `isPatronActive`/`isRecordActive`), so no stale-flag path exists.
 
 ## Out of this plan (later phases)
 
-Named Workspaces, custom commands/keybindings, the Patron badge, and the site copy are Phases 2–4. Retiring the $19 checkout and creating the Polar subscription products (with distinct benefits) are **user-side** setup, prerequisite to Task 5 producing real ids.
+Named Workspaces, custom commands/keybindings, the Patron badge, and site copy are Phases 2–4. Retiring the $19 checkout and creating the Polar subscription products (with **distinct** benefits) are **user-side** setup, prerequisite to Task 5's allowlist holding real ids.

--- a/docs/superpowers/specs/2026-08-18-blanc-patron-design.md
+++ b/docs/superpowers/specs/2026-08-18-blanc-patron-design.md
@@ -1,0 +1,409 @@
+# Blanc Patron — a recurring supporter tier with a real reason to upgrade
+
+**Date:** 2026-08-18
+**Status:** **Locked** 2026-08-18 (after review round 3). Ready for implementation planning.
+**Supersedes/extends:** [2026-07-06 Monetization Phase 1](2026-07-06-monetization-phase1-design.md) (the one-time $19 "Blanc Supporter")
+
+## Context
+
+Phase 1 (July 6) laid trust-aligned rails: a Polar Sponsor button, a "Support Blanc"
+site link, and **Blanc Supporter** — a **$19 one-time** license unlocking three cosmetic
+Dock colorways (`ember`, `plum`, `gold`), macOS-only. Its governing philosophy, encoded
+in `src/main/supporter.js`: *activate once online, trust the local record forever — no
+revalidation, no lockout, works offline; perks are cosmetics, DRM would betray the brand.*
+Phase 1 explicitly deferred "Sync (paid), a Pro subscription, and search partnerships" to
+future phases.
+
+This spec is that next phase, chosen through brainstorming with these decisions locked:
+
+- **Goal:** build toward real income (not merely rails, not merely cost-recovery).
+- **Engine:** consumer **recurring** revenue — the model that compounds with the audience
+  being grown, chosen over B2B/white-label and search-rev-share as the near-term lead.
+- **Honest expectation, stated up front:** at Blanc's current scale (~738 cumulative
+  downloads, a few hundred active installs) a supporter subscription is **supplementary**
+  income, exactly as Orion+ is supplementary to Kagi's search subscription. Competitive
+  research confirmed the pattern: no independent browser makes *real* income from the
+  browser alone at small scale — the ones that do have either scale (Vivaldi's search
+  rev-share, millions of users) or an adjacent paid product (Kagi search, Mullvad VPN).
+  Zen — larger than Blanc — still runs on donations alone. Patron is the **rail that is
+  ready when scale arrives**; it is not expected to be a salary today. The "real income"
+  ambition needs a second leg later (scale → a privacy search rev-share, or an adjacent
+  product), noted here and out of scope for this spec.
+
+### Why "Patron"
+
+Named to sidestep the saturated tier ladder (Plus / Pro / Premium / Ultra / Max) entirely.
+Blanc rejects the corporate browser playbook everywhere else; the paid tier should too.
+"Patron" names the **relationship** — funding independent work — not a power level. It fits
+Blanc's quiet, faintly literary register (the same register as `paper`/`ink`/`sage`,
+Quiet Tabs, lowercase mono group labels), and it resolves the Supporter question cleanly:
+
+- The **product** is **Blanc Patron**.
+- A subscriber **is a Patron**.
+- **Existing one-time Supporters become founding Patrons** — grandfathered permanently,
+  honoring the "trusted forever" promise already in the code. "Supporter" survives as the
+  umbrella word for anyone who has ever chipped in (one-time donors + Patrons).
+
+## The free / paid line (the load-bearing principle)
+
+**Non-negotiable: Patron only ever ADDS. Nothing shipped today ever moves behind it.**
+Charging for a currently-free feature is a bait-and-switch a privacy audience punishes
+hard. This principle already caught one error in design: open-tab + tab-group sync was
+initially proposed as the paid anchor, but a grep of `sync.js` / `tabsync.js` /
+`session-snapshot.js` confirmed it is **already shipped and free**, gated only by a free
+per-device "share this device's open tabs" toggle. Paywalling it would have violated this
+principle. Corrected below.
+
+### Free forever
+
+- **All existing browsing features**: ad/tracker blocking (EasyList/EasyPrivacy, on by
+  default, both sessions), the Island, Quiet Tabs, Reopen Closed Tab, private tabs, tab
+  groups, local profiles, the Quick Switcher, slash commands, permission policy, WebAuthn.
+- **All of today's Profile Sync**: Favorites, settings, **and open-tab / tab-group
+  snapshots**. Whatever a user can sync today, they keep syncing, free, forever. (Note:
+  Profile Sync and remote-tab presentation are **Personal-profile only** today; this spec
+  does not change that.)
+
+**Brand sentence (revised).** The earlier "everything that runs on your machine is free"
+was false once the anchor became an on-device paid feature (Named Workspaces, custom
+bindings). The honest line is:
+
+> **Core browsing stays free forever. Patron funds Blanc and adds optional organization
+> tools — it never gates the browsing you already do.**
+
+### Patron (recurring, strictly additive)
+
+| Benefit | Kind | Cost to run | Status |
+|---|---|---|---|
+| **Named Workspaces** (the anchor) | On-device | ~zero | New build (this spec) |
+| Custom slash commands / keybindings | On-device | ~zero | New build (follow-on) |
+| The three cosmetic colorways (`ember`/`plum`/`gold`) | On-device | ~zero | Already ships; re-gate under Patron |
+| Patron badge in Settings | On-device | ~zero | New (light) |
+| **v2 authenticated sync** (more devices, higher limits, faster) — *future flagship* | Server | real, recurring | Separate project; out of scope here |
+
+Two benefits that would otherwise look "light" are deliberately **not** in this project:
+- **v2 sync** — unbuilt, its own reviewed project. Named as the future flagship; it also
+  completes a compounding story (Named Workspaces on-device now; v2 sync later lets them
+  follow you across devices).
+- **Early-access / release-candidate channel** — moved out of scope. It is *not* a light
+  perk: the current updater has exactly one signed public-release path, and a Patron-only
+  channel needs its own artifact, update metadata, signing, rollback, and access-control
+  design. That is its own project (see Out of scope).
+
+## Anchor feature — Named Workspaces
+
+**What it is:** user-facing, savable, nameable sets of tabs + groups that a Patron can
+switch between and restore — "Work," "Personal," "Project X." The organizational tier above
+tab groups.
+
+**Why it anchors (where generic "workflow" did not):** graspable ("save and switch between
+named sets of tabs" needs no explanation), **sticky** (once you've built your workspaces
+you're invested in your own setup — a retention driver, which is what makes a subscription
+hold), proven (the headline upgrade feature in Arc and Vivaldi), and on-brand (living behind
+Patron keeps the free browser minimal — Patron *protects* Blanc's minimalism rather than
+fighting it).
+
+**Additive, verified:** "workspace" in Blanc today is **purely internal** — the per-window
+session-persistence layer in `src/main/session-workspace.js` (versioned records in
+`session.json`), with **zero user-facing surface** (no UI, no copy references). So a Named
+Workspaces feature is genuinely new — nothing is taken away.
+
+### Workspaces are profile-scoped (correctness requirement)
+
+`session-workspace.js`'s `EMPTY_ENTRY` carries a `profileId`, and that is load-bearing: a
+workspace **cannot move tabs between named local profiles**, because each profile has its
+own Electron session — cookies, storage, and remembered permissions differ. A tab restored
+into the wrong profile would be logged out or mis-scoped. Therefore:
+
+- **A workspace belongs to exactly one local profile.** Switching workspaces only ever swaps
+  tab sets *within* the current profile; there is no cross-profile workspace.
+- **Storage: a profile-scoped `workspaces.json`**, one `JsonStore` per profile (Personal at
+  the userData root like its other JSON files; named profiles under `profiles/<opaque-id>/`,
+  matching where profile Favorites/history/permissions already live). It is **not** folded
+  into `session.json` — that file carries the delicate v2 + v0-flat rollback mirror for
+  1.0.x downgrades, and piling user-named workspaces into it would put that at risk.
+- **Relationship to `session.json`:** `session.json` remains the *live* window state (its
+  rollback mirror untouched); `workspaces.json` holds the *saved* named sets. Switching
+  writes the current live set into its workspace slot, then loads the target into the live
+  window — so nothing is lost on switch.
+- **Never exported by sync.** Sync is Personal-only and does not carry workspaces; workspaces
+  stay device-local in this project (v2-sync-carries-workspaces is future work).
+- **Deleted with the profile.** Because `workspaces.json` lives under the profile directory,
+  the existing profile-deletion path (which drops the profile dir and its saved state)
+  removes it automatically.
+- **Private tabs are never captured** into a workspace (consistent with their exclusion from
+  session persistence).
+
+### Workspace runtime (Blanc has many windows)
+
+- **Single-window binding.** A named workspace is bound to **at most one window at a time.**
+  Opening a workspace already active in another window **focuses that window** instead of
+  double-binding it. This removes concurrent-edit conflict *by construction* — no two windows
+  ever write the same slot.
+- **Scratch windows.** A window not bound to a named workspace is a **scratch** session — the
+  ordinary live `session.json` state that exists today. It persists across restart exactly as
+  now, and never writes into a named slot until the user explicitly **"Save as workspace."**
+- **Autosave, continuous.** A window bound to a workspace **continuously mirrors** its live
+  tab set into that workspace's `workspaces.json` slot (debounced, exactly as session
+  persistence already debounces). So the bound workspace is always current — "nothing is lost
+  on switch" means *autosave-on-change*, not save-only-at-switch: the outgoing workspace is
+  already saved before the incoming one loads.
+- **Delete / lapse.** Deleting a workspace unbinds any window showing it (that window becomes
+  scratch). On Patron lapse, existing workspaces stay openable/switchable; only *creating new*
+  ones is gated — **no free-tier floor** (decided this round).
+
+**Shape (to be detailed at plan time):** a workspace = a named, persisted set of
+`{urls, groups, groupIds, pinned, activeIndex, meta}` (the fields `EMPTY_ENTRY` already
+models), tagged with its `profileId`. Management UI (create / rename / switch / delete /
+save-current-as) reached from the Island's ⌘L panel. Persistence in a versioned
+`workspaces.json` with its own migration path.
+
+## Entitlement mapping & legacy cutoff
+
+A single boolean "has a Polar key" is unsafe: it cannot tell a $19 Supporter key from a
+Patron key, so a **newly sold $19 key could silently grant permanent (founding-grade)
+Patron** for $19. The mapping must be explicit and the legacy product retired at the source.
+
+- **Per-environment `benefit_id` allowlist.** Maintain a constant map (separate sandbox and
+  production tables, mirroring the existing `app.isPackaged` API-base switch) from Polar
+  `benefit_id` → entitlement kind:
+
+  | Polar benefit | Kind |
+  |---|---|
+  | the $19 one-time Supporter benefit | `founding` |
+  | Patron annual benefit | `subscription` |
+  | Patron monthly benefit | `subscription` |
+  | Patron lifetime benefit *(reserved; no product sold at launch)* | `lifetime` |
+
+  On activate and on validate, read `benefit_id` from Polar's response and resolve the kind
+  from this map. **An unrecognized `benefit_id` grants nothing** (fail closed on mapping —
+  the one place we fail closed rather than open).
+
+- **Setup invariant: each product uses a *distinct* license-key benefit.** The allowlist is
+  only sound if the $19 Supporter, the monthly, and the annual products each attach a
+  **different** license-key benefit (distinct `benefit_id`). Polar itself recommends this —
+  *"Offering more than one type of license key? Be sure to validate their unique
+  `benefit_id`."* **Verify the distinct `benefit_id`s in sandbox before the production
+  cutover** ([Polar guide](https://polar.sh/docs/features/benefits/license-keys)).
+
+- **Retire the $19 checkout at launch.** Close/archive the $19 product's *checkout* so **no
+  new $19 keys can be minted** — this is the actual protection against "a newly sold $19 key
+  becomes a Patron," because none can be sold.
+
+- **Preserve existing keys, including late first-activations.** Keep the $19 benefit_id in
+  the allowlist mapped to `founding` **permanently**. The cutoff is "no new sales," **not an
+  activation-date cutoff** — a customer who bought before launch but first activates on a new
+  device months later still validates against that benefit_id and resolves to `founding`.
+  Since the checkout is retired, this preserves real customers without leaving a path to buy
+  founding status cheaply.
+
+- **Already-activated legacy records.** An on-device `supporter` record predates the mapping
+  and stores no `benefit_id` (the activate flow only kept `{key, activationId, activatedAt}`).
+  These migrate directly to `{kind:'founding', benefitId: null, …}` — trusted as-is, no
+  re-validation, consistent with "trust forever." Only *fresh* activations/validations (which
+  do return a `benefit_id`) are subject to the allowlist.
+
+## Entitlement model — reconciling a subscription with "no DRM, works offline"
+
+The existing model (`isSupporterActive() === !!settings.supporter` — true forever once set)
+was built for a **one-time** purchase and cannot represent a lapsing subscription.
+
+**Guiding rule:** preserve the no-DRM spirit through **graceful degradation, never lockout**,
+and **never touch user data**. Validation is minimal, off the critical path, offline-tolerant,
+and non-punitive.
+
+### Entitlement record — `patron` is the single canonical record
+
+`patron` (new) is authoritative. The legacy `supporter` key is demoted to a **downgrade
+mirror** only (below). Target rule: **no Patron-era entitlement check may read `supporter`** —
+`patron` is authoritative, and `supporter` exists only as the compatible downgrade mirror.
+(Today's `isSupporterActive()` still reads `supporter`; that read is *replaced* by
+`isPatronActive()`, which is part of this work.) Both records are written **only** by the
+activation/validation flow (the generic `setSettings()` whitelist must ignore **both**, as it
+ignores `supporter` today), and both are **device-local, never synced** (outside
+`SYNCED_KEYS`).
+
+```
+patron: null
+  | { kind: 'founding' | 'lifetime',  key, activationId, benefitId, activatedAt }
+  | { kind: 'subscription',           key, activationId, benefitId, activatedAt,
+      lastValidatedAt, lastAttemptedAt, lastStatus }
+```
+
+`isPatronActive()`: unconditionally true for `founding`/`lifetime`; for `subscription`, true
+while the validation model says active (active period **or** offline-grace window).
+
+**Renderer projection — required edit.** Today `getSettings()` strips only `supporter`. It
+must strip **both `supporter` and `patron`** and expose only the derived boolean
+`patronActive` (a superset of today's `supporterActive`) plus at most a coarse label —
+otherwise a raw `patron` record (key, activation id) leaks to the privileged renderer. This
+is a mandatory change, not optional.
+
+**Migration (upgrade).** On first run of a Patron build, if `supporter` is non-null and
+`patron` is null, create `patron = { kind:'founding', benefitId: null, … }` from it (see the
+legacy-record note under Entitlement mapping). Idempotent; runs once.
+
+**Downgrade mirror + the subscription hazard.** For `founding`/`lifetime` only, keep the
+legacy `supporter` record populated, so a user who rolls back to a pre-Patron build still has
+their permanent grant honored (old code reads `!!supporter`). **A `subscription` is *never*
+written to `supporter`** — an old build interprets any non-null `supporter` as a *permanent*
+grant, so mirroring a subscription there would hand a lapsing subscriber free cosmetics
+forever on the old binary. So on downgrade: founding/lifetime survive; a subscription is
+simply not a concept the old build knows, and its cosmetic reverts there — correct.
+
+### Validation model (subscription kind only; founding/lifetime never validate)
+
+Uses Polar's **public customer-portal validate endpoint** — no server secret:
+`POST {API_BASE}/v1/customer-portal/license-keys/validate` with
+`{ organization_id, key, activation_id }` (the `activation_id` is required because the
+activation limit is enabled). Polar **automatically revokes the key when its backing
+subscription is cancelled**, so the key's own status is authoritative — we do not track
+subscription periods ourselves. (Doc:
+[Polar license-key guide](https://polar.sh/docs/features/benefits/license-keys); the former
+API-reference deep link 404s and is not cited.)
+
+**Expiration is a field, not a status.** The response carries a `status` **plus a separate
+`expires_at`**. Do not treat `expired` as a status value. Handle three status classes
+distinctly:
+- **`granted`** and (`expires_at` null or in the future) → **active**; set
+  `lastValidatedAt = now`.
+- **known terminal statuses** (`revoked`; `disabled` if returned), or `granted` with a
+  *past* `expires_at` → **confirmed terminal lapse** → graceful degradation immediately (the
+  customer had Polar's own renewal window before revocation; confirmed non-payment gets no
+  extra grace).
+- **any unknown status** → treat as **ambiguous**, exactly like an unreachable network: stay
+  active, do **not** advance `lastValidatedAt`, subject to the offline grace. Never revoke on
+  a status we do not recognize.
+
+**`benefit_id` location differs by endpoint** — the activate payload nests the key under
+`activation.license_key`, while validate returns the key at the response root. Resolve
+`benefit_id` **defensively** (check the root, then `license_key.benefit_id`, then
+`activation.license_key.benefit_id`) and **pin the exact paths during sandbox setup** (see
+the distinct-benefits invariant).
+
+- **Cadence:** at most once per day, guarded by `lastAttemptedAt` (written on every attempt,
+  success or failure, so we never hammer Polar); backgrounded on idle after launch; never on
+  the critical path; never blocks UI.
+- **Offline grace:** the 30-day clock runs from `lastValidatedAt`. **Bootstrap
+  `lastValidatedAt` at activation time** — activation is itself an online success — otherwise
+  a subscription that goes offline immediately after activating has no valid grace origin. If
+  `now − lastValidatedAt > 30 days` **and** the latest outcome is still ambiguous/unreachable,
+  degrade (grace exhausted).
+- **Only a confirmed terminal status revokes.** Network failure, ambiguity, and unknown
+  status never revoke — they ride the 30-day offline grace.
+
+### Graceful degradation on confirmed lapse
+
+A lapsed Patron **never loses access to their own data and is never locked out of the
+browser.**
+
+- **Cosmetic colorway** reverts to the free default. This already works exactly:
+  `isAppIconAllowed()` returns false for a supporter colorway when supporter is inactive, and
+  on the **read** path `getSettings()` sanitizes an unauthorized `appIcon` back to
+  `DEFAULTS.appIcon` (which is **`paper`**), while on the **write** path an unauthorized
+  `appIcon` is simply **ignored** (not copied into the cleaned partial). The Patron check
+  extends this same predicate — no new mechanism.
+- **Named Workspaces**: existing workspaces stay fully **openable, switchable, and
+  restorable** — saved sets are never lost. Only **creating new** workspaces is Patron-gated;
+  **no free-tier floor** (a lapsed Patron keeps everything they built, just can't add more).
+- **Custom commands / keybindings**: previously configured ones keep working (or degrade to
+  read-only); no new ones while lapsed.
+- **Re-activation** restores full capability immediately; nothing was destroyed.
+
+## Pricing
+
+**Decided: launch monthly + annual only; no paid lifetime plan at launch.** This best
+matches the recurring-income goal and avoids a lifetime option cannibalizing the subscription
+while the audience is small; a limited **$150+ superfan lifetime** stays available to
+introduce later. Benchmarked against Orion+ ($5/mo · $50/yr ·
+[$150 lifetime](https://europe-west.kagi.com/onboarding?p=orion_plan)); Blanc prices under it,
+annual-preferred (annual reduces churn and matches the indie preference for infrequent
+billing):
+
+- **Annual — $30/yr** (headline, ~$2.50/mo) — provisional number, tunable at setup, not
+  blocking.
+- **Monthly — $4/mo** — provisional; offered but de-emphasized (monthly churns).
+- **No lifetime product at launch.**
+- **Founding Patrons:** existing $19 Supporters → **permanent (lifetime-equivalent) Patron,
+  free** — the one lifetime-shaped grant that ships, and it costs nothing to honor.
+
+The `lifetime` entitlement kind stays in the model (founding grants are lifetime-equivalent,
+and it reserves the future superfan option), but **no `lifetime` product is sold at launch.**
+Framing everywhere: transparent, "this funds an independent developer and the servers,"
+never premium pressure.
+
+## Polar integration
+
+- Keep the existing one-time product **but retire its checkout** (see legacy cutoff); its
+  keys and benefit_id live on for founding Patrons.
+- **Add** Polar **annual + monthly** subscription products (no lifetime product at launch),
+  each with its **own distinct license-key benefit** (the setup invariant above), under the
+  same org (`bnfy`, `POLAR_ORGANIZATION_ID` already in `supporter.js`).
+- Activation reuses the existing customer-portal license-key **activate** path; the
+  **validate** path (above) is added for the subscription kind.
+- Dev continues to hit `sandbox-api.polar.sh`; packaged hits production — the existing
+  `app.isPackaged` switch (and the per-environment benefit_id map) are the only environment
+  seams.
+- Account/product setup is **user-side** (as in Phase 1); the assistant does not create
+  products or handle keys.
+
+## Brand & privacy guardrails (must all hold)
+
+1. Core browsing and **all of today's sync** stay free, forever.
+2. **No browsing-data collection and no ad-tech.** (Not "no data collection" — see #6.)
+3. No hard lockout and **no user-data loss** on lapse — degrade, never punish.
+4. Entitlement is device-local, never synced; renderers see only a boolean.
+5. **30-day offline grace, not "fail open."** A network failure, ambiguous response, or
+   unknown status keeps Patron active *within* the 30-day grace window (measured from the
+   last successful validation); only a **confirmed terminal status** revokes, and prolonged
+   unreachability degrades **after** the grace window. The one fail-*closed* path is an
+   unrecognized `benefit_id` at activation (grants nothing).
+6. **Disclose the validation call plainly.** Activating, and — for subscriptions —
+   periodically validating, sends the license key + activation id to Polar, and Polar
+   receives normal request metadata (e.g. IP). It is the **only outbound identifier
+   introduced by Patron** — Blanc already has opt-out telemetry and opt-in sync; Patron adds
+   no browsing data to any path — it runs off the critical path, and it is disclosed in the
+   Patron settings copy and the privacy page. Overclaiming absolute privacy would itself be a
+   betrayal.
+
+## Implementation phases (decomposition for the plan)
+
+One coherent product, built in dependency order — the plan (writing-plans) details each:
+
+1. **Entitlement layer (foundation).** The `patron` record and the three kinds; the
+   per-environment `benefit_id` allowlist; migrate existing `supporter` records to
+   `founding`; retire the $19 checkout (user-side) while preserving its mapping; Polar
+   activate + the subscription-only validate/grace/degradation model; renderer-facing
+   `patronActive` boolean. Re-gate the three colorways under Patron (grandfathered for
+   founding). Nothing else gates until this exists.
+2. **Named Workspaces (the anchor).** Profile-scoped `workspaces.json` (new `JsonStore` per
+   profile); lift `session-workspace.js` entry shape to first-class user-named workspaces;
+   management UI in the ⌘L panel; versioned persistence + migration; Patron-gated *creation*
+   with graceful lapse behavior; deletion-with-profile.
+3. **Supporting bundle.** Custom slash commands / keybindings; Patron badge in Settings.
+4. **Site + copy.** A restrained Patron section (voice per `site/CLAUDE.md`) with the plain
+   validation disclosure; the app remains free in JSON-LD (`offers` price 0 unchanged) —
+   Patron is a separate product, not an app price.
+
+## Out of scope (deliberate)
+
+- **v2 authenticated sync** (Durable Objects) — its own reviewed project; the future flagship.
+- **Patron-only early-access / RC update channel** — its own project (artifact, update
+  metadata, signing, rollback, and access-control design); not a light perk.
+- The "real income at scale" second leg (search rev-share / adjacent product).
+- Mobile Patron perks (no mobile app ships yet).
+- Windows/Linux cosmetic colorway parity (the Dock swap is macOS-only today — known Phase 1
+  limitation, unchanged).
+- Any anti-piracy / revalidation-on-launch / lockout mechanism.
+- Cross-profile or synced workspaces (single-profile, device-local in this project).
+- Polar account and product setup (user-side).
+
+## Decisions resolved this round (your calls)
+
+1. **No paid lifetime at launch** — monthly + annual only; the founding $19 grant stays; a
+   $150+ superfan lifetime is reserved for later. Folded into Pricing.
+2. **Existing-workspaces-only on lapse** — no one-workspace floor; every saved workspace is
+   preserved, only creation is gated. Folded into the runtime and degradation sections.
+
+**No open decisions remain in the design.** The only provisional items are the exact
+$30 / $4 numbers, tunable at Polar-setup time; they do not block the plan.

--- a/settings-schema/schema.json
+++ b/settings-schema/schema.json
@@ -46,7 +46,8 @@
     "usagePing": true,
     "tabSleep": "1h",
     "onboardingVersion": 0,
-    "supporter": null
+    "supporter": null,
+    "patron": null
   },
   "$internalDefaults": "Keys present in settings.js DEFAULTS that are intentionally desktop-only (not mobile-parity settings); settings:check allowlists these instead of requiring them in the schema.",
   "internalDefaults": ["tabLayout", "verticalTabsWidth", "onboardingVersion", "_syncMeta"],
@@ -64,6 +65,7 @@
     { "key": "adblockExceptions", "type": "string[]", "default": [], "normalize": "trim, lowercase, strip leading www., dedupe" },
     { "key": "usagePing", "type": "boolean", "default": true },
     { "key": "tabSleep", "type": "enum", "enum": "tabSleepDelays", "default": "1h", "note": "device-local; not synced; 'off' stops future quieting and never wakes an already-quiet tab" },
-    { "key": "supporter", "type": "opaque", "default": null, "note": "written only by the Polar activation flow (setSupporter), never generic setSettings" }
+    { "key": "supporter", "type": "opaque", "default": null, "note": "written only by the Polar activation flow (setSupporter), never generic setSettings" },
+    { "key": "patron", "type": "opaque", "default": null, "note": "canonical entitlement record; written only by the Polar activation flow (setPatron), never generic setSettings; supersedes supporter for entitlement" }
   ]
 }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -4317,7 +4317,8 @@ function registerIpcHandlers() {
     if (['bookmarks', 'history', 'downloads', 'settings'].includes(name)) {
       // Deep-link into a page section via URL fragment — allowlisted only,
       // never interpolated from renderer-supplied text (privileged URL).
-      const fragment = name === 'settings' && section === 'blocking' ? '#group-privacy' : '';
+      const sectionMap = { blocking: '#group-privacy', patron: '#group-patron' };
+      const fragment = name === 'settings' && sectionMap[section] ? sectionMap[section] : '';
       openInternalPage(`blanc://${name}/${fragment}`);
     }
   });
@@ -4667,6 +4668,7 @@ const SLASH_COMMANDS = [
   ['/block-ads', 'Block ads here, or toggle blocking everywhere'],
   ['/allow-ads', 'Allow ads on this site'],
   ['/theme [system|light|dark]', 'Cycle appearance, or switch directly to system, light, or dark'],
+  ['/patron', 'Support Blanc with a Patron subscription'],
 ];
 
 // A hand-picked subset of the full inventory (blanc://shortcuts/, via
@@ -5675,6 +5677,10 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
         searchSuggestions: current.searchSuggestions,
         usagePing: current.usagePing,
       },
+      // Drives the start page's Patron callout. Broadcast on every
+      // settings change (below), and setPatron() fires those listeners, so
+      // an activation mid-session hides the callout without a reload.
+      patronActive: settings.isPatronActive(),
     };
   };
   const broadcastStartPageStatus = () => {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -73,6 +73,7 @@ const {
 const { attachAddressMenu } = require('./address-menu');
 const { promptForCredentials } = require('./auth-dialog');
 const settings = require('./settings');
+const patron = require('./patron');
 const bookmarks = require('./bookmarks');
 const { groupFavoritesForMenu } = require('./bookmark-data');
 const history = require('./history');
@@ -6177,6 +6178,14 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
     pendingExternalUrls.push(...urlsFromArgv(process.argv.slice(1)));
     withWindowRuntime(focusedRuntime, flushExternalUrls);
     maybeSendLaunchPing();
+
+    // Patron subscription revalidation — off the critical path, after the
+    // navigation gate is released and session restore is done. The model's
+    // own once-per-day cadence guard makes a too-frequent call a no-op.
+    setImmediate(() => {
+      patron.validateIfDue().catch(() => {});
+      setInterval(() => patron.validateIfDue().catch(() => {}), 24 * 60 * 60 * 1000);
+    });
   };
 
   const attachAdblockToAllProfileSessions = () => {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -4318,7 +4318,7 @@ function registerIpcHandlers() {
       // Deep-link into a page section via URL fragment — allowlisted only,
       // never interpolated from renderer-supplied text (privileged URL).
       const sectionMap = { blocking: '#group-privacy', patron: '#group-patron' };
-      const fragment = name === 'settings' && sectionMap[section] ? sectionMap[section] : '';
+      const fragment = name === 'settings' && Object.prototype.hasOwnProperty.call(sectionMap, section) ? sectionMap[section] : '';
       openInternalPage(`blanc://${name}/${fragment}`);
     }
   });

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -6190,7 +6190,7 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
     // own once-per-day cadence guard makes a too-frequent call a no-op.
     setImmediate(() => {
       patron.validateIfDue().catch(() => {});
-      setInterval(() => patron.validateIfDue().catch(() => {}), 24 * 60 * 60 * 1000);
+      setInterval(() => patron.validateIfDue().catch(() => {}), patron.DAY_MS);
     });
   };
 

--- a/src/main/pages.js
+++ b/src/main/pages.js
@@ -11,6 +11,7 @@ const history = require('./history');
 const downloads = require('./downloads');
 const settings = require('./settings');
 const supporter = require('./supporter');
+const patron = require('./patron');
 const sync = require('./sync');
 const telemetry = require('./telemetry');
 const { listDecisions, removeDecision } = require('./permissions');
@@ -171,10 +172,11 @@ function setupPages(hooks = {}) {
   // derived booleans. Internal pages are privileged, but least-privilege
   // anyway (same reasoning as the preload's protocol re-check).
   const clientSettings = () => {
-    const { supporter: record, _syncMeta, ...rest } = settings.getSettings();
+    const { supporter: record, patron, _syncMeta, ...rest } = settings.getSettings();
     return {
       ...rest,
-      supporterActive: !!record,
+      patronActive: settings.isPatronActive(),
+      supporterActive: settings.isPatronActive(), // temporary alias until Phase 4 renames renderer refs
       supporterActivatedAt: record?.activatedAt ?? null,
     };
   };
@@ -194,7 +196,7 @@ function setupPages(hooks = {}) {
     // raw getSettings() — that includes the supporter key.
     return clientSettings();
   });
-  handle('pages:settings:supporter-activate', 'settings', (key) => supporter.activateSupporter(key));
+  handle('pages:settings:supporter-activate', 'settings', (key) => patron.activate(key));
 
   // Local-profile identity and destructive confirmation stay in main. The
   // renderer receives only opaque ids, display names, and result messages.

--- a/src/main/pages.js
+++ b/src/main/pages.js
@@ -172,7 +172,10 @@ function setupPages(hooks = {}) {
   // derived booleans. Internal pages are privileged, but least-privilege
   // anyway (same reasoning as the preload's protocol re-check).
   const clientSettings = () => {
-    const { supporter: record, patron, _syncMeta, ...rest } = settings.getSettings();
+    // Strip both entitlement records out of `rest` (the renderer sees only
+    // derived booleans). `patron:` is aliased to `_patron` so it does not
+    // shadow the module-level `patron` (the network module) inside this scope.
+    const { supporter: record, patron: _patron, _syncMeta, ...rest } = settings.getSettings();
     return {
       ...rest,
       patronActive: settings.isPatronActive(),
@@ -242,9 +245,9 @@ function setupPages(hooks = {}) {
     // Least-privilege projection for the onboarding dialog: only the two
     // settings it can change, so a replay shows what is actually saved.
     onboarding: hooks.startPage?.onboardingState?.() ?? null,
-    // Whether to show the start-page Patron callout on initial load — mirrored
-    // by startPageStatus() below so a later pages:start:status push agrees.
-    patronActive: settings.isPatronActive(),
+    // patronActive (for the start-page Patron callout) comes from the spread
+    // below: startPageStatus() supplies it, and the same function feeds the
+    // later pages:start:status push, so initial load and live updates agree.
     ...hooks.startPage?.status?.(),
   }));
   // The footer layout switcher. The value is enum-validated by setSettings,

--- a/src/main/pages.js
+++ b/src/main/pages.js
@@ -242,6 +242,9 @@ function setupPages(hooks = {}) {
     // Least-privilege projection for the onboarding dialog: only the two
     // settings it can change, so a replay shows what is actually saved.
     onboarding: hooks.startPage?.onboardingState?.() ?? null,
+    // Whether to show the start-page Patron callout on initial load — mirrored
+    // by startPageStatus() below so a later pages:start:status push agrees.
+    patronActive: settings.isPatronActive(),
     ...hooks.startPage?.status?.(),
   }));
   // The footer layout switcher. The value is enum-validated by setSettings,

--- a/src/main/patron-model.js
+++ b/src/main/patron-model.js
@@ -3,6 +3,8 @@
 // pattern of tabsync-model.js / session-workspace.js so every branch is unit-testable.
 
 const KINDS = new Set(['founding', 'lifetime', 'subscription']);
+const GRACE_MS = 30 * 24 * 60 * 60 * 1000;
+const TERMINAL = new Set(['revoked', 'disabled']);
 
 function readBenefitId(payload) {
   if (!payload || typeof payload !== 'object') return null;
@@ -27,4 +29,35 @@ function resolveKind(benefitId, allowlist) {
   return KINDS.has(kind) ? kind : null;
 }
 
-module.exports = { readBenefitId, resolveKind, parseExpiresAt };
+function isRecordActive(record, now) {
+  if (!record) return false;
+  if (record.kind === 'founding' || record.kind === 'lifetime') return true;
+  if (record.kind !== 'subscription') return false;
+  return record.lastStatus === 'granted' && (now - (record.lastValidatedAt ?? 0)) <= GRACE_MS;
+}
+
+function evaluateValidation({ outcome, record, now }) {
+  const next = { ...record };
+  if (outcome.kind === 'ok') {
+    next.lastAttemptedAt = now;
+    const granted = outcome.status === 'granted';
+    if (outcome.expiresAt === false && granted) {
+      // malformed expiry — ambiguous, not terminal; leave record unchanged (ride grace)
+    } else if (granted && (outcome.expiresAt === null || outcome.expiresAt > now) && outcome.benefitOk) {
+      next.lastStatus = 'granted';
+      next.lastValidatedAt = now;
+    } else if (TERMINAL.has(outcome.status)) {
+      next.lastStatus = outcome.status;               // confirmed terminal
+    } else if (granted && (outcome.expiresAt !== null && outcome.expiresAt <= now)) {
+      next.lastStatus = 'expired';                    // derived terminal
+    } else if (granted && !outcome.benefitOk) {
+      next.lastStatus = 'benefit_mismatch';           // derived terminal
+    }
+    // else: unknown, non-terminal status → leave lastStatus/lastValidatedAt untouched (ride grace)
+  } else {
+    next.lastAttemptedAt = now;                       // unreachable → ride grace, unchanged otherwise
+  }
+  return { active: isRecordActive(next, now), record: next };
+}
+
+module.exports = { readBenefitId, resolveKind, parseExpiresAt, GRACE_MS, isRecordActive, evaluateValidation };

--- a/src/main/patron-model.js
+++ b/src/main/patron-model.js
@@ -60,4 +60,17 @@ function evaluateValidation({ outcome, record, now }) {
   return { active: isRecordActive(next, now), record: next };
 }
 
-module.exports = { readBenefitId, resolveKind, parseExpiresAt, GRACE_MS, isRecordActive, evaluateValidation };
+function migrateSupporter({ supporter, patron, now }) {
+  if (!supporter || patron) return null;
+  return { patron: {
+    kind: 'founding', key: supporter.key, activationId: supporter.activationId ?? null,
+    benefitId: null, activatedAt: supporter.activatedAt ?? now,
+  } };
+}
+
+function downgradeMirror(patron) {
+  if (!patron || (patron.kind !== 'founding' && patron.kind !== 'lifetime')) return null;
+  return { key: patron.key, activationId: patron.activationId ?? null, activatedAt: patron.activatedAt };
+}
+
+module.exports = { readBenefitId, resolveKind, parseExpiresAt, GRACE_MS, isRecordActive, evaluateValidation, migrateSupporter, downgradeMirror };

--- a/src/main/patron-model.js
+++ b/src/main/patron-model.js
@@ -21,6 +21,29 @@ function parseExpiresAt(raw) {
   return Number.isNaN(ms) ? false : ms;              // unparseable string — malformed
 }
 
+// Polar's activate response nests the license key (payload.license_key or
+// payload.activation.license_key); its validate response returns the key at the
+// top level. These readers accept either shape so a wire-format difference can
+// never silently drop the status/expiry a validation depends on — the same
+// defensive three-path lookup readBenefitId uses.
+function readLicenseStatus(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  const status = payload.status
+    ?? payload.license_key?.status
+    ?? payload.activation?.license_key?.status;
+  return typeof status === 'string' ? status : null;
+}
+
+function readExpiresAt(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  return parseExpiresAt(
+    payload.expires_at
+    ?? payload.license_key?.expires_at
+    ?? payload.activation?.license_key?.expires_at
+    ?? null,
+  );
+}
+
 function resolveKind(benefitId, allowlist) {
   if (typeof benefitId !== 'string' || benefitId === '') return null;
   if (!allowlist || typeof allowlist !== 'object') return null;
@@ -73,4 +96,4 @@ function downgradeMirror(patron) {
   return { key: patron.key, activationId: patron.activationId ?? null, activatedAt: patron.activatedAt };
 }
 
-module.exports = { readBenefitId, resolveKind, parseExpiresAt, GRACE_MS, isRecordActive, evaluateValidation, migrateSupporter, downgradeMirror };
+module.exports = { readBenefitId, resolveKind, parseExpiresAt, readLicenseStatus, readExpiresAt, GRACE_MS, isRecordActive, evaluateValidation, migrateSupporter, downgradeMirror };

--- a/src/main/patron-model.js
+++ b/src/main/patron-model.js
@@ -1,0 +1,30 @@
+// src/main/patron-model.js
+// Pure entitlement decisions — NO require('electron'). Mirrors the Electron-free
+// pattern of tabsync-model.js / session-workspace.js so every branch is unit-testable.
+
+const KINDS = new Set(['founding', 'lifetime', 'subscription']);
+
+function readBenefitId(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  return payload.benefit_id
+    ?? payload.license_key?.benefit_id
+    ?? payload.activation?.license_key?.benefit_id
+    ?? null;
+}
+
+function parseExpiresAt(raw) {
+  if (raw == null || raw === '') return null;        // absent — no expiry set
+  if (typeof raw !== 'string') return false;         // present but wrong type — malformed
+  const ms = Date.parse(raw);
+  return Number.isNaN(ms) ? false : ms;              // unparseable string — malformed
+}
+
+function resolveKind(benefitId, allowlist) {
+  if (typeof benefitId !== 'string' || benefitId === '') return null;
+  if (!allowlist || typeof allowlist !== 'object') return null;
+  if (!Object.prototype.hasOwnProperty.call(allowlist, benefitId)) return null; // own-property only
+  const kind = allowlist[benefitId];
+  return KINDS.has(kind) ? kind : null;
+}
+
+module.exports = { readBenefitId, resolveKind, parseExpiresAt };

--- a/src/main/patron.js
+++ b/src/main/patron.js
@@ -1,0 +1,80 @@
+const { app, net } = require('electron');
+const settings = require('./settings');
+const model = require('./patron-model');
+
+const PRODUCTION_ORG_ID = '6f675077-6cb1-4965-8db8-15838e5fdb38';
+const SANDBOX_ORG_ID = 'a6ffc65a-8ba3-4973-8a2a-e057aa811f9f';
+const API_BASE = app.isPackaged ? 'https://api.polar.sh' : 'https://sandbox-api.polar.sh';
+const ORG_ID = app.isPackaged ? PRODUCTION_ORG_ID : SANDBOX_ORG_ID;
+const MAX_KEY_LENGTH = 200;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const BENEFIT_ALLOWLIST = app.isPackaged
+  ? {
+      '2ffaf466-652d-4e45-b92f-560fc25d3c53': 'founding',      // Blanc Supporter License
+      'df98506e-a88a-4364-b4c9-cc424dda01f0': 'subscription',  // Blanc Patron Monthly License
+      'ed1cce8c-d87e-4d27-b9d7-d30bda2de402': 'subscription',  // Blanc Patron Annual License
+    }
+  : {
+      'de6e9525-3cc4-4232-b96f-f459d56afb19': 'founding',      // sandbox Blanc Supporter License
+      '2f5e210c-7d63-4ba6-8818-45f3b7fc9b93': 'subscription',  // sandbox Blanc Patron Monthly License
+      '27ecc7d8-f31e-4951-8235-22dda51327c4': 'subscription',  // sandbox Blanc Patron Annual License
+    };
+
+async function readJson(res) { try { return await res.json(); } catch { return null; } }
+
+async function activate(key) {
+  const trimmed = String(key ?? '').trim();
+  if (!trimmed) return { ok: false, message: 'Enter a license key.' };
+  if (trimmed.length > MAX_KEY_LENGTH) return { ok: false, message: 'That key is too long.' };
+  let res;
+  try {
+    res = await net.fetch(API_BASE + '/v1/customer-portal/license-keys/activate', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: trimmed, organization_id: ORG_ID, label: 'Blanc' }),
+    });
+  } catch { return { ok: false, message: 'Could not reach Polar. Check your connection and try again.' }; }
+  if (!res.ok) return { ok: false, message: 'That license key could not be activated.' };
+  const payload = await readJson(res);
+  const benefitId = model.readBenefitId(payload);
+  const kind = model.resolveKind(benefitId, BENEFIT_ALLOWLIST);
+  if (!payload || !kind) return { ok: false, message: 'That license key is not recognized.' };
+  if (kind === 'subscription') {
+    const lk = payload.license_key ?? payload.activation?.license_key ?? {};
+    const lkStatus = lk.status;
+    const lkExpiry = model.parseExpiresAt(lk.expires_at);
+    if (lkStatus !== 'granted') return { ok: false, message: 'That subscription is not currently active.' };
+    if (lkExpiry === false) return { ok: false, message: 'That subscription has an invalid expiry.' };
+    if (typeof lkExpiry === 'number' && lkExpiry <= Date.now()) return { ok: false, message: 'That subscription has expired.' };
+  }
+  const now = Date.now();
+  const activationId = payload.activation?.id ?? payload.id ?? null;
+  const record = { kind, key: trimmed, activationId, benefitId, activatedAt: now,
+    ...(kind === 'subscription' ? { lastValidatedAt: now, lastAttemptedAt: now, lastStatus: 'granted' } : {}) };
+  settings.setPatron(record);
+  return { ok: true, kind };
+}
+
+async function validateIfDue() {
+  const p = settings.getPatronRecord();
+  if (!p || p.kind !== 'subscription') return;
+  if (Date.now() - (p.lastAttemptedAt ?? 0) < DAY_MS) return;
+  let outcome;
+  try {
+    const res = await net.fetch(`${API_BASE}/v1/customer-portal/license-keys/validate`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ organization_id: ORG_ID, key: p.key, activation_id: p.activationId }),
+    });
+    const body = res.ok ? await readJson(res) : null;
+    if (!body || typeof body.status !== 'string') {
+      outcome = { kind: 'unreachable' };                 // non-ok OR malformed successful JSON → ambiguous
+    } else {
+      const benefitOk = model.resolveKind(model.readBenefitId(body), BENEFIT_ALLOWLIST) === 'subscription';
+      outcome = { kind: 'ok', status: body.status, expiresAt: model.parseExpiresAt(body.expires_at), benefitOk };
+    }
+  } catch { outcome = { kind: 'unreachable' }; }
+  const { record } = model.evaluateValidation({ outcome, record: p, now: Date.now() });
+  settings.setPatron(record);
+}
+
+module.exports = { activate, validateIfDue };

--- a/src/main/patron.js
+++ b/src/main/patron.js
@@ -40,9 +40,10 @@ async function activate(key) {
   const kind = model.resolveKind(benefitId, BENEFIT_ALLOWLIST);
   if (!payload || !kind) return { ok: false, message: 'That license key is not recognized.' };
   if (kind === 'subscription') {
-    const lk = payload.license_key ?? payload.activation?.license_key ?? {};
-    const lkStatus = lk.status;
-    const lkExpiry = model.parseExpiresAt(lk.expires_at);
+    // Defensive readers accept the license key at the top level or nested,
+    // so the check holds whichever shape Polar's activate response uses.
+    const lkStatus = model.readLicenseStatus(payload);
+    const lkExpiry = model.readExpiresAt(payload);
     if (lkStatus !== 'granted') return { ok: false, message: 'That subscription is not currently active.' };
     if (lkExpiry === false) return { ok: false, message: 'That subscription has an invalid expiry.' };
     if (typeof lkExpiry === 'number' && lkExpiry <= Date.now()) return { ok: false, message: 'That subscription has expired.' };
@@ -66,15 +67,22 @@ async function validateIfDue() {
       body: JSON.stringify({ organization_id: ORG_ID, key: p.key, activation_id: p.activationId }),
     });
     const body = res.ok ? await readJson(res) : null;
-    if (!body || typeof body.status !== 'string') {
-      outcome = { kind: 'unreachable' };                 // non-ok OR malformed successful JSON → ambiguous
+    // Read status defensively (top-level or nested) so a validate response that
+    // wraps the license key can't be misread as an unparseable body.
+    const status = model.readLicenseStatus(body);
+    if (!body || status === null) {
+      outcome = { kind: 'unreachable' };                 // non-ok, malformed, or no readable status → ambiguous
     } else {
       const benefitOk = model.resolveKind(model.readBenefitId(body), BENEFIT_ALLOWLIST) === 'subscription';
-      outcome = { kind: 'ok', status: body.status, expiresAt: model.parseExpiresAt(body.expires_at), benefitOk };
+      outcome = { kind: 'ok', status, expiresAt: model.readExpiresAt(body), benefitOk };
     }
   } catch { outcome = { kind: 'unreachable' }; }
   const { record } = model.evaluateValidation({ outcome, record: p, now: Date.now() });
+  // Guard the lost-update race: if a concurrent activate() replaced data.patron
+  // during the await above, its fresh authoritative record wins — don't clobber
+  // it with this result derived from the stale pre-fetch snapshot.
+  if (settings.getPatronRecord() !== p) return;
   settings.setPatron(record);
 }
 
-module.exports = { activate, validateIfDue };
+module.exports = { activate, validateIfDue, DAY_MS };

--- a/src/main/settings.js
+++ b/src/main/settings.js
@@ -9,6 +9,7 @@ const {
 } = require('./chrome-layout');
 const APP_ICON_ASSETS = require('./app-icon-assets');
 const { normalizeHomepage } = require('./top-level-url-policy');
+const { migrateSupporter, downgradeMirror, isRecordActive } = require('./patron-model');
 
 const SEARCH_ENGINES = {
   duckduckgo: { label: 'DuckDuckGo', url: (q) => `https://duckduckgo.com/?q=${encodeURIComponent(q)}` },
@@ -116,7 +117,14 @@ const DEFAULTS = {
   // Blanc Supporter license — null, or { key, activationId, activatedAt }.
   // Written only by setSupporter() (the Polar activation flow), never by
   // the generic setSettings() path. Once set, trusted forever — offline OK.
+  // Superseded by `patron` below; kept as its founding/lifetime downgrade
+  // mirror so pre-Patron builds reading this file still see a valid grant.
   supporter: null,
+  // Blanc Patron entitlement record — null, or { kind, key, activationId,
+  // benefitId, activatedAt, lastStatus?, lastValidatedAt?, lastAttemptedAt? }.
+  // Written only by setPatron() (the activation/validation flow), never by
+  // the generic setSettings() path. See patron-model.js for the state machine.
+  patron: null,
   // Per-key last-write timestamps for sync's LWW merge; only SYNCED_KEYS are
   // ever stamped or transmitted. See exportForSync/mergeFromSync.
   _syncMeta: {},
@@ -161,6 +169,15 @@ function ensureStore() {
       // launch from mistaking that interrupted first run for a legacy profile.
       store.flush();
     }
+    // A legacy settings.json carrying only `supporter` gains the equivalent
+    // `patron` record on next launch. Mutates the persisted store directly
+    // (not a getSettings() copy) so the migration survives every future
+    // ensureStore() short-circuit, not just the current process.
+    const migrated = migrateSupporter({ supporter: store.data.supporter, patron: store.data.patron, now: Date.now() });
+    if (migrated) {
+      store.data.patron = migrated.patron;      // supporter left intact — it is the downgrade mirror for founding
+      store.flush();                            // synchronous, like the onboarding-marker flushes above
+    }
   }
   return store;
 }
@@ -190,12 +207,14 @@ function getSettings() {
 }
 
 function isAppIconAllowed(id) {
-  return APP_ICONS.includes(id) || (SUPPORTER_ICONS.includes(id) && isSupporterActive());
+  return APP_ICONS.includes(id) || (SUPPORTER_ICONS.includes(id) && isPatronActive());
 }
 
 /** Validate a partial settings patch against the whitelist, returning only
  * the accepted keys. Shared by setSettings (user writes) and mergeFromSync
- * (remote writes) so a tampered sync blob can't inject unvalidated values. */
+ * (remote writes) so a tampered sync blob can't inject unvalidated values.
+ * `supporter` and `patron` are deliberately absent — both are activation-flow-only,
+ * written solely by setSupporter()/setPatron(), never through this whitelist. */
 function sanitize(partial) {
   const clean = {};
   if (typeof partial.searchEngine === 'string' && SEARCH_ENGINES[partial.searchEngine]) {
@@ -321,6 +340,25 @@ function setSupporter(record) {
   for (const fn of listeners) fn(getSettings());
 }
 
+function isPatronActive() {
+  return isRecordActive(ensureStore().data.patron, Date.now());
+}
+
+// The activation flow's private write path — setSettings()'s whitelist has no `patron`.
+function setPatron(record) {
+  ensureStore().update((data) => {
+    data.patron = record;
+    data.supporter = downgradeMirror(record); // founding/lifetime mirror; subscription/null → null
+  });
+  for (const fn of listeners) fn(getSettings()); // reapplies applyAppIcon + live UI, like setSupporter
+}
+
+// Main-process only; NEVER exposed to a renderer (the settings-page IPC
+// projection sends only derived booleans — see pages.js's clientSettings()).
+function getPatronRecord() {
+  return ensureStore().data.patron;
+}
+
 // Snapshot the synced keys plus their per-key timestamps for the sync engine
 // to encrypt. Only SYNCED_KEYS cross the wire — supporter, tabLayout, appIcon,
 // searchSuggestions, usagePing, and _syncMeta's non-synced entries never leave.
@@ -386,6 +424,9 @@ module.exports = {
   isSupporterActive,
   isAppIconAllowed,
   setSupporter,
+  isPatronActive,
+  setPatron,
+  getPatronRecord,
   exportForSync,
   mergeFromSync,
 };

--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -513,7 +513,7 @@ function install(refs) {
     secureDnsTemplate() { return settings.getSettings().secureDnsTemplate; },
     webrtcPolicy() { return settings.getSettings().webrtcPolicy; },
     setSecureDns(dns, template = '') { settings.setSettings({ secureDns: dns, secureDnsTemplate: template }); },
-    clearSupporter() { settings.setSupporter(null); },
+    clearSupporter() { settings.setPatron(null); },
     addException(h) {
       const cur = settings.getSettings().adblockExceptions;
       settings.setSettings({ adblockExceptions: [...cur, h] });
@@ -667,7 +667,7 @@ function install(refs) {
       return true;
     },
 
-    setSupporterActive() { settings.setSupporter({ key: 'test', activationId: 'test', activatedAt: 0 }); },
+    setSupporterActive() { settings.setPatron({ kind: 'founding', key: 'test', activationId: 'test', benefitId: null, activatedAt: 0 }); },
 
     // ---- address-bar context menu (F19-2/F19-3) ----
     // A native Menu.popup() can't be driven by Playwright, so these bind the
@@ -1348,7 +1348,7 @@ function install(refs) {
         // leak that seed into later scenarios.
         usagePing: false,
       });
-      settings.setSupporter(null);
+      settings.setPatron(null);
       clearTestSearchSuggestionFixture();
       setTestSearchNavigationCapture(false);
       broadcastTabs();

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -775,6 +775,7 @@
       const requested = (input ?? '').replace(/^\/theme\s*/, '').trim();
       window.browserAPI.cycleTheme(requested || null);
     } },
+    { cmd: '/patron', hint: 'Support Blanc with a Patron subscription', run: () => window.browserAPI.openPage('settings', 'patron') },
   ];
 
   function runCommand(command) {

--- a/src/renderer/pages/newtab.html
+++ b/src/renderer/pages/newtab.html
@@ -36,6 +36,10 @@
       <div class="ledger-label">on your other devices</div>
       <div id="remoteList" class="ledger-list"></div>
     </section>
+
+    <p id="patron-callout" class="ledger-patron" hidden>
+      <a href="blanc://settings/#group-patron">Support Blanc</a>
+    </p>
   </main>
 
   <!-- The three alternative layouts (design system, "New tab v2" handoff).

--- a/src/renderer/pages/newtab.html
+++ b/src/renderer/pages/newtab.html
@@ -37,7 +37,7 @@
       <div id="remoteList" class="ledger-list"></div>
     </section>
 
-    <p id="patron-callout" class="ledger-patron" hidden>
+    <p id="patron-callout" class="ledger-patron js-patron-callout" hidden>
       <a href="blanc://settings/#group-patron">Support Blanc</a>
     </p>
   </main>
@@ -54,6 +54,9 @@
     <div id="bbBlocked" class="bb-blocked"></div>
     <div id="bbFavorites" class="bb-favs"></div>
     <div id="bbGroups" class="bb-groups"></div>
+    <p class="bb-patron js-patron-callout" hidden>
+      <a href="blanc://settings/#group-patron">Support Blanc</a>
+    </p>
   </main>
 
   <main class="shelf" id="layoutShelf">
@@ -75,6 +78,9 @@
         </div>
       </div>
     </div>
+    <p class="shelf-patron js-patron-callout" hidden>
+      <a href="blanc://settings/#group-patron">Support Blanc</a>
+    </p>
   </main>
 
   <main class="tally" id="layoutTally">
@@ -85,6 +91,9 @@
       <div id="tlFavorites" class="ledger-list"></div>
       <div class="ledger-label tally-label tally-label-groups">pick up where you left off</div>
       <div id="tlGroups" class="tally-chiprow"></div>
+      <p class="tally-patron js-patron-callout" hidden>
+        <a href="blanc://settings/#group-patron">Support Blanc</a>
+      </p>
     </div>
     <div class="tally-right">
       <div class="ledger-label">blocked this week</div>

--- a/src/renderer/pages/newtab.js
+++ b/src/renderer/pages/newtab.js
@@ -56,13 +56,13 @@ function renderLaunchStatus({ startup, privacy } = {}) {
   window.blancOnboarding?.maybeShow({ startup, privacy }, state.onboarding);
 }
 
-// Quiet, understated Patron callout below the favorites grid — hidden
-// outright once the user is a Patron. Driven from both the initial
-// pages:start:data load and every later pages:start:status push, so
-// activating mid-session hides it on an already-open start page.
+// Quiet, understated Patron callout — one per start-page layout (ledger,
+// billboard, shelf, tally), hidden outright once the user is a Patron. Driven
+// from both the initial pages:start:data load and every later
+// pages:start:status push, so activating mid-session hides it on an
+// already-open start page, whichever layout is active.
 function renderPatronCallout(patronActive) {
-  const el = document.getElementById('patron-callout');
-  if (el) el.hidden = !!patronActive;
+  for (const el of document.querySelectorAll('.js-patron-callout')) el.hidden = !!patronActive;
 }
 
 startupRetry.addEventListener('click', async () => {
@@ -455,7 +455,7 @@ window.bowserPages?.start.onRemoteTabs(renderRemote);
 window.bowserPages?.start.onStatus((status) => {
   renderLaunchStatus(status);
   if (status?.layout && status.layout !== state.layout) applyLayout(status.layout);
-  if ('patronActive' in status) renderPatronCallout(status.patronActive);
+  if (status && 'patronActive' in status) renderPatronCallout(status.patronActive);
 });
 
 // The pill's caret says keystrokes land somewhere. They do: a printable

--- a/src/renderer/pages/newtab.js
+++ b/src/renderer/pages/newtab.js
@@ -56,6 +56,15 @@ function renderLaunchStatus({ startup, privacy } = {}) {
   window.blancOnboarding?.maybeShow({ startup, privacy }, state.onboarding);
 }
 
+// Quiet, understated Patron callout below the favorites grid — hidden
+// outright once the user is a Patron. Driven from both the initial
+// pages:start:data load and every later pages:start:status push, so
+// activating mid-session hides it on an already-open start page.
+function renderPatronCallout(patronActive) {
+  const el = document.getElementById('patron-callout');
+  if (el) el.hidden = !!patronActive;
+}
+
 startupRetry.addEventListener('click', async () => {
   startupRetry.disabled = true;
   startupContinue.disabled = true;
@@ -430,6 +439,7 @@ const dataReady = window.bowserPages?.start.data().then((data) => {
     onboarding: data.onboarding ?? null,
   });
   renderLaunchStatus({ startup: data.startup, privacy: data.privacy });
+  renderPatronCallout(data.patronActive);
   if (!isPrivate) {
     document.getElementById('footerLeft').textContent =
       `${state.blockedThisWeek.toLocaleString()} ads blocked this week`;
@@ -445,6 +455,7 @@ window.bowserPages?.start.onRemoteTabs(renderRemote);
 window.bowserPages?.start.onStatus((status) => {
   renderLaunchStatus(status);
   if (status?.layout && status.layout !== state.layout) applyLayout(status.layout);
+  if ('patronActive' in status) renderPatronCallout(status.patronActive);
 });
 
 // The pill's caret says keystrokes land somewhere. They do: a printable

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -671,12 +671,17 @@ a.ledger-label:hover { color: var(--accent); }
 
 .ledger-empty { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim); }
 
-/* Quiet, one-line Patron callout below the favorites grid — matches the
-   understated .ledger-empty hint rather than the bolder .launch-card, since
-   this is an optional upsell, not something the page needs from the user. */
-.ledger-patron { margin-top: 50px; font-family: var(--font-mono); font-size: 11.5px; }
-.ledger-patron a { color: var(--text-dim); text-decoration: none; }
-.ledger-patron a:hover { color: var(--accent); }
+/* Quiet, one-line Patron callout — one per start-page layout, hidden once the
+   user is a Patron. Matches the understated .ledger-empty hint rather than the
+   bolder .launch-card, since this is an optional upsell. The shared link look
+   lives on .js-patron-callout; each layout only sets its own spacing. */
+.js-patron-callout { font-family: var(--font-mono); font-size: 11.5px; }
+.js-patron-callout a { color: var(--text-dim); text-decoration: none; }
+.js-patron-callout a:hover { color: var(--accent); }
+.ledger-patron { margin-top: 50px; }
+.bb-patron { margin-top: 28px; text-align: center; }
+.shelf-patron { margin-top: 20px; }
+.tally-patron { margin-top: 28px; }
 
 .ledger-footer {
   /* Pinned to the viewport bottom by the auto margin while the ledger is

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -337,8 +337,8 @@ button.danger:hover { color: var(--on-danger); background: var(--danger); border
 .icon-swatch.active { color: var(--text); }
 .icon-swatch.active img { outline: 2px solid var(--accent); }
 
-/* Supporter-only colorways render locked until a license is activated —
-   dimmed tile plus a quiet tag; clicking scrolls to the Supporter section. */
+/* Patron-only colorways render locked until a license is activated —
+   dimmed tile plus a quiet tag; clicking scrolls to the Patron section. */
 .icon-swatch.locked img { opacity: 0.4; filter: none; }
 .icon-swatch.locked span { color: var(--text-dim); }
 .icon-swatch .tag {

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -671,6 +671,13 @@ a.ledger-label:hover { color: var(--accent); }
 
 .ledger-empty { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim); }
 
+/* Quiet, one-line Patron callout below the favorites grid — matches the
+   understated .ledger-empty hint rather than the bolder .launch-card, since
+   this is an optional upsell, not something the page needs from the user. */
+.ledger-patron { margin-top: 50px; font-family: var(--font-mono); font-size: 11.5px; }
+.ledger-patron a { color: var(--text-dim); text-decoration: none; }
+.ledger-patron a:hover { color: var(--accent); }
+
 .ledger-footer {
   /* Pinned to the viewport bottom by the auto margin while the ledger is
      short; once it overflows, the padding keeps the footer one section's

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -23,7 +23,7 @@
         <a href="#group-profiles" data-group="profiles">Profiles</a>
         <a href="#group-privacy" data-group="privacy">Privacy &amp; Security</a>
         <a href="#group-sync" data-group="sync">Sync</a>
-        <a href="#group-supporter" data-group="supporter">Supporter</a>
+        <a href="#group-patron" data-group="patron">Patron</a>
       </nav>
 
       <div class="settings-content">
@@ -141,7 +141,7 @@
           <h2 class="group-title">Profiles</h2>
           <div class="settings-card">
             <p class="section-hint">
-              Named profiles keep separate cookies, site data, Favorites, history, downloads, and remembered permissions. Device settings and Supporter status stay shared; Profile Sync belongs to Personal only.
+              Named profiles keep separate cookies, site data, Favorites, history, downloads, and remembered permissions. Device settings and Patron status stay shared; Profile Sync belongs to Personal only.
             </p>
             <div class="toolbar-row">
               <input id="newProfileName" type="text" placeholder="New profile name" maxlength="40" autocomplete="off" />
@@ -279,18 +279,21 @@
           </div>
         </section>
 
-        <section class="settings-group" id="group-supporter">
-          <h2 class="group-title" id="supporterTitle">Supporter</h2>
+        <section class="settings-group" id="group-patron">
+          <h2 class="group-title" id="patronTitle">Blanc Patron</h2>
           <div class="settings-card">
             <p class="section-hint">
-              Supporting Blanc unlocks three extra icon colorways — ember, plum, and gold.
-              One purchase, activated once; Blanc never phones home afterwards.
+              Blanc Patron unlocks three extra icon colorways — ember, plum, and gold. A
+              one-time founding license activates once, with no further contact. A monthly
+              or annual subscription checks in with Polar about once a day — your license
+              key and activation id only, never browsing data — to confirm it’s still
+              active; on a lapse, colorways quietly revert to Paper.
             </p>
-            <div class="toolbar-row" id="supporterActivateRow">
-              <input id="supporterKey" type="text" placeholder="License key" autocomplete="off" spellcheck="false" maxlength="200" />
-              <button id="supporterActivate">Activate</button>
+            <div class="toolbar-row" id="patronActivateRow">
+              <input id="patronKey" type="text" placeholder="License key" autocomplete="off" spellcheck="false" maxlength="200" />
+              <button id="patronActivate">Activate</button>
             </div>
-            <p class="section-hint" id="supporterStatus" role="status"></p>
+            <p class="section-hint" id="patronStatus" role="status"></p>
           </div>
         </section>
       </div>

--- a/src/renderer/pages/settings.js
+++ b/src/renderer/pages/settings.js
@@ -192,12 +192,14 @@
   }
 
   // --- App icon colorways (macOS Dock only) ---
-  // These four bindings stay in IIFE scope unconditionally because the Supporter
-  // section below reads `supporterActive` and calls `renderAppIconGrid`. The
+  // These four bindings stay in IIFE scope unconditionally because the Patron
+  // section below reads `patronActive` and calls `renderAppIconGrid`. The
   // function/const definitions are inert until called; only the executable tail
   // (render vs. remove) is gated.
   const appIconSetting = document.getElementById('appIconSetting');
-  let supporterActive = settings.supporterActive ?? false;
+  // `patronActive` is the durable projection field; `supporterActive` is only a
+  // temporary alias to the same boolean (see pages.js's clientSettings()).
+  let patronActive = settings.patronActive ?? false;
   const appIconGrid = document.getElementById('appIconGrid');
   // Tracked directly rather than re-derived from the DOM on every render —
   // ids/labels come from main (settings.js APP_ICON_LABELS/SUPPORTER_ICON_LABELS)
@@ -216,7 +218,7 @@
     appIconGrid.replaceChildren();
     const entries = [
       ...Object.entries(appIcons).map(([id, label]) => [id, label, false]),
-      ...Object.entries(supporterIcons).map(([id, label]) => [id, label, !supporterActive]),
+      ...Object.entries(supporterIcons).map(([id, label]) => [id, label, !patronActive]),
     ];
     for (const [id, label, locked] of entries) {
       const btn = document.createElement('button');
@@ -233,13 +235,13 @@
       if (locked) {
         const tag = document.createElement('span');
         tag.className = 'tag';
-        tag.textContent = 'supporter';
+        tag.textContent = 'patron';
         btn.append(tag);
-        // A locked tile points at the Supporter section instead of
+        // A locked tile points at the Patron section instead of
         // silently failing (main would reject the id anyway).
         btn.addEventListener('click', () => {
-          document.getElementById('supporterTitle').scrollIntoView({ behavior: 'smooth' });
-          document.getElementById('supporterKey').focus({ preventScroll: true });
+          document.getElementById('patronTitle').scrollIntoView({ behavior: 'smooth' });
+          document.getElementById('patronKey').focus({ preventScroll: true });
         });
       } else {
         btn.addEventListener('click', async () => {
@@ -281,48 +283,55 @@
     renderAppIconGrid();
   }
 
-  // --- Supporter activation ---
+  // --- Patron activation ---
+  // Capability key stays 'supporter' — guarded by
+  // test/unit/app-icon.test.js's literal-string match; Phase 4 renames it.
   if (supports('supporter') && supportsNativeAppIcon) {
-    const supporterActivateRow = document.getElementById('supporterActivateRow');
-    const supporterKey = document.getElementById('supporterKey');
-    const supporterActivateBtn = document.getElementById('supporterActivate');
-    const supporterStatus = document.getElementById('supporterStatus');
+    const patronActivateRow = document.getElementById('patronActivateRow');
+    const patronKey = document.getElementById('patronKey');
+    const patronActivateBtn = document.getElementById('patronActivate');
+    const patronStatus = document.getElementById('patronStatus');
 
-    function renderSupporterState() {
-      if (!supporterActive) return;
-      supporterActivateRow.hidden = true;
+    function renderPatronState() {
+      if (!patronActive) return;
+      patronActivateRow.hidden = true;
+      // Never gate on this date's presence — it's null for active subscribers
+      // (only founding/lifetime carry a mirror date). Show it when present,
+      // but the row above is already driven by the `patronActive` boolean.
       const when = settings.supporterActivatedAt
         ? new Date(settings.supporterActivatedAt).toLocaleDateString()
         : null;
-      supporterStatus.textContent = when
-        ? `You’re a supporter — thank you. Activated ${when}.`
-        : 'You’re a supporter — thank you.';
+      patronStatus.textContent = when
+        ? `You’re a Patron — thank you. Activated ${when}.`
+        : 'You’re a Patron — thank you.';
     }
-    renderSupporterState();
+    renderPatronState();
 
-    async function activateSupporter() {
+    async function activatePatron() {
       // Also guards the Enter-keydown listener below — without this, OS
       // key-repeat while holding Enter fires concurrent activation requests.
-      if (supporterActivateBtn.disabled) return;
-      supporterActivateBtn.disabled = true;
-      supporterStatus.textContent = 'Activating…';
-      const result = await window.bowserPages.settings.activateSupporter(supporterKey.value);
-      supporterActivateBtn.disabled = false;
+      if (patronActivateBtn.disabled) return;
+      patronActivateBtn.disabled = true;
+      patronStatus.textContent = 'Activating…';
+      const result = await window.bowserPages.settings.activateSupporter(patronKey.value);
+      patronActivateBtn.disabled = false;
       if (result.ok) {
-        supporterActive = true;
-        settings.supporterActivatedAt = result.activatedAt;
-        renderSupporterState();
+        // The response is only `{ ok, kind }` — no activatedAt to mirror
+        // here; `settings.supporterActivatedAt` (if any) stays whatever it
+        // was at page load, and renderPatronState() shows it only when set.
+        patronActive = true;
+        renderPatronState();
         if (navigator.platform.startsWith('Mac')) renderAppIconGrid();
       } else {
-        supporterStatus.textContent = result.message;
+        patronStatus.textContent = result.message;
       }
     }
-    supporterActivateBtn.addEventListener('click', activateSupporter);
-    supporterKey.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') activateSupporter();
+    patronActivateBtn.addEventListener('click', activatePatron);
+    patronKey.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') activatePatron();
     });
   } else {
-    document.getElementById('group-supporter')?.remove();
+    document.getElementById('group-patron')?.remove();
   }
 
   // --- Local profiles ---
@@ -710,7 +719,7 @@
 
     // Score each group by how much of *itself* is on screen, highest wins.
     // (A fixed trigger line — the usual scroll-spy trick — fails here:
-    // Privacy & Security's card is taller than Sync + Supporter combined, so
+    // Privacy & Security's card is taller than Sync + Patron combined, so
     // near the page bottom there's no scroll room left for their headers to
     // ever cross the line, and they'd be skipped.) On a positive tie (two
     // short trailing sections both fully visible) the later one wins, so
@@ -730,8 +739,8 @@
 
     // A sidebar click pins its target through the smooth-scroll animation.
     // Otherwise clicking a short trailing section (Sync) — whose scrollIntoView
-    // clamps at the page bottom, leaving it tied with Supporter — would let the
-    // scorer settle the highlight on Supporter instead.
+    // clamps at the page bottom, leaving it tied with Patron — would let the
+    // scorer settle the highlight on Patron instead.
     let pinnedUntil = 0;
     let ticking = false;
     window.addEventListener('scroll', () => {

--- a/src/renderer/pages/settings.js
+++ b/src/renderer/pages/settings.js
@@ -313,7 +313,16 @@
       if (patronActivateBtn.disabled) return;
       patronActivateBtn.disabled = true;
       patronStatus.textContent = 'Activating…';
-      const result = await window.bowserPages.settings.activateSupporter(patronKey.value);
+      let result;
+      try {
+        result = await window.bowserPages.settings.activateSupporter(patronKey.value);
+      } catch {
+        // A rejected IPC (an unexpected main-process throw) must still
+        // re-enable the button — never leave it stuck on "Activating…".
+        patronActivateBtn.disabled = false;
+        patronStatus.textContent = 'Something went wrong. Please try again.';
+        return;
+      }
       patronActivateBtn.disabled = false;
       if (result.ok) {
         // The response is only `{ ok, kind }` — no activatedAt to mirror

--- a/src/renderer/pages/shortcuts.js
+++ b/src/renderer/pages/shortcuts.js
@@ -23,6 +23,7 @@ const SLASH_COMMANDS = [
   ['/block-ads', 'Block ads here, or toggle blocking everywhere'],
   ['/allow-ads', 'Allow ads on this site'],
   ['/theme [system|light|dark]', 'Cycle appearance, or switch directly to system, light, or dark'],
+  ['/patron', 'Support Blanc with a Patron subscription'],
 ];
 
 /** One titled section of label/keys rows. */

--- a/test/unit/patron-model.test.js
+++ b/test/unit/patron-model.test.js
@@ -1,0 +1,46 @@
+// test/unit/patron-model.test.js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { readBenefitId, resolveKind, parseExpiresAt } = require('../../src/main/patron-model');
+
+const ALLOW = { ben_supporter: 'founding', ben_annual: 'subscription', ben_monthly: 'subscription', ben_lifetime: 'lifetime' };
+
+test('readBenefitId reads root, nested license_key, and nested activation', () => {
+  assert.equal(readBenefitId({ benefit_id: 'a' }), 'a');
+  assert.equal(readBenefitId({ license_key: { benefit_id: 'b' } }), 'b');
+  assert.equal(readBenefitId({ activation: { license_key: { benefit_id: 'c' } } }), 'c');
+  assert.equal(readBenefitId({}), null);
+  assert.equal(readBenefitId(null), null);
+});
+
+test('resolveKind maps known benefits', () => {
+  assert.equal(resolveKind('ben_supporter', ALLOW), 'founding');
+  assert.equal(resolveKind('ben_annual', ALLOW), 'subscription');
+  assert.equal(resolveKind('ben_lifetime', ALLOW), 'lifetime');
+});
+
+test('resolveKind fails closed on unknown, empty, non-string, and inherited props', () => {
+  assert.equal(resolveKind('ben_unknown', ALLOW), null);
+  assert.equal(resolveKind('', ALLOW), null);
+  assert.equal(resolveKind(null, ALLOW), null);
+  assert.equal(resolveKind(42, ALLOW), null);
+  // prototype-property inputs must NOT resolve to a truthy inherited value
+  assert.equal(resolveKind('toString', ALLOW), null);
+  assert.equal(resolveKind('constructor', ALLOW), null);
+  assert.equal(resolveKind('__proto__', ALLOW), null);
+  // a benefit mapped to a NON-kind value must not leak through
+  assert.equal(resolveKind('x', { x: 'not_a_kind' }), null);
+});
+
+test('parseExpiresAt: three states — null (absent), number (valid), false (malformed)', () => {
+  // absent / falsy → null (no expiry set)
+  assert.strictEqual(parseExpiresAt(null), null);
+  assert.strictEqual(parseExpiresAt(undefined), null);
+  assert.strictEqual(parseExpiresAt(''), null);
+  // valid ISO string → epoch-ms
+  assert.strictEqual(parseExpiresAt('2026-12-31T00:00:00Z'), Date.parse('2026-12-31T00:00:00Z'));
+  // present but malformed → false
+  assert.strictEqual(parseExpiresAt('not-a-date'), false);  // Date.parse returns NaN
+  assert.strictEqual(parseExpiresAt(12345), false);          // wrong type
+  assert.strictEqual(parseExpiresAt(true), false);           // wrong type
+});

--- a/test/unit/patron-model.test.js
+++ b/test/unit/patron-model.test.js
@@ -44,3 +44,58 @@ test('parseExpiresAt: three states — null (absent), number (valid), false (mal
   assert.strictEqual(parseExpiresAt(12345), false);          // wrong type
   assert.strictEqual(parseExpiresAt(true), false);           // wrong type
 });
+
+const { evaluateValidation, isRecordActive, GRACE_MS } = require('../../src/main/patron-model');
+
+const sub = (over = {}) => ({
+  kind: 'subscription', key: 'k', activationId: 'a', benefitId: 'ben_annual',
+  activatedAt: 0, lastValidatedAt: 1000, lastAttemptedAt: 1000, lastStatus: 'granted', ...over,
+});
+
+test('isRecordActive: founding/lifetime always active; subscription needs granted + within grace', () => {
+  assert.equal(isRecordActive({ kind: 'founding' }, 9e15), true);
+  assert.equal(isRecordActive({ kind: 'lifetime' }, 9e15), true);
+  assert.equal(isRecordActive(null, 0), false);
+  // restart with a granted record still within grace → active WITHOUT any network call
+  assert.equal(isRecordActive(sub({ lastValidatedAt: 1000 }), 1000 + GRACE_MS), true);
+  // past grace → inactive
+  assert.equal(isRecordActive(sub({ lastValidatedAt: 1000 }), 1000 + GRACE_MS + 1), false);
+  // last confirmed status not granted → inactive regardless of grace
+  assert.equal(isRecordActive(sub({ lastStatus: 'revoked', lastValidatedAt: 9e15 }), 9e15), false);
+});
+
+test('granted + unexpired + benefitOk → active, advances lastValidatedAt', () => {
+  const now = 5000;
+  const r = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: now + 1, benefitOk: true }, record: sub(), now });
+  assert.equal(r.active, true);
+  assert.equal(r.record.lastValidatedAt, now);
+  assert.equal(r.record.lastStatus, 'granted');
+});
+
+test('revoked, expired, and benefit mismatch each degrade', () => {
+  const now = 5000;
+  assert.equal(evaluateValidation({ outcome: { kind: 'ok', status: 'revoked', expiresAt: null, benefitOk: true }, record: sub(), now }).active, false);
+  assert.equal(evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: now - 1, benefitOk: true }, record: sub(), now }).active, false);
+  const mismatch = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: now + 1, benefitOk: false }, record: sub(), now });
+  assert.equal(mismatch.active, false);
+  assert.equal(mismatch.record.lastStatus, 'benefit_mismatch');
+});
+
+test('malformed expiry (false) is ambiguous, not a terminal expired state', () => {
+  const now = 5000;
+  const malformed = evaluateValidation({ outcome: { kind: 'ok', status: 'granted', expiresAt: false, benefitOk: true }, record: sub(), now });
+  assert.equal(malformed.active, true);
+  assert.equal(malformed.record.lastValidatedAt, 1000); // unchanged — treated as ambiguous
+  assert.equal(malformed.record.lastStatus, 'granted'); // unchanged — rides grace
+});
+
+test('unknown status and unreachable ride the grace, do not advance lastValidatedAt', () => {
+  const withinNow = 1000 + GRACE_MS;
+  const unknown = evaluateValidation({ outcome: { kind: 'ok', status: 'weird_new', expiresAt: null, benefitOk: true }, record: sub(), now: withinNow });
+  assert.equal(unknown.active, true);
+  assert.equal(unknown.record.lastValidatedAt, 1000); // unchanged
+  assert.equal(unknown.record.lastStatus, 'granted'); // unchanged
+  assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: sub(), now: withinNow }).active, true);
+  assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: sub(), now: 1000 + GRACE_MS + 1 }).active, false);
+  assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: sub(), now: withinNow }).record.lastAttemptedAt, withinNow);
+});

--- a/test/unit/patron-model.test.js
+++ b/test/unit/patron-model.test.js
@@ -99,3 +99,20 @@ test('unknown status and unreachable ride the grace, do not advance lastValidate
   assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: sub(), now: 1000 + GRACE_MS + 1 }).active, false);
   assert.equal(evaluateValidation({ outcome: { kind: 'unreachable' }, record: sub(), now: withinNow }).record.lastAttemptedAt, withinNow);
 });
+
+const { migrateSupporter, downgradeMirror } = require('../../src/main/patron-model');
+
+test('migrateSupporter creates a founding patron once, idempotently', () => {
+  const supporter = { key: 'k', activationId: 'a', activatedAt: 42 };
+  const out = migrateSupporter({ supporter, patron: null, now: 99 });
+  assert.deepEqual(out.patron, { kind: 'founding', key: 'k', activationId: 'a', benefitId: null, activatedAt: 42 });
+  assert.equal(migrateSupporter({ supporter, patron: out.patron, now: 99 }), null); // already migrated
+  assert.equal(migrateSupporter({ supporter: null, patron: null, now: 99 }), null); // nothing to migrate
+});
+
+test('downgradeMirror mirrors founding/lifetime, NEVER a subscription', () => {
+  assert.deepEqual(downgradeMirror({ kind: 'founding', key: 'k', activationId: 'a', activatedAt: 42 }), { key: 'k', activationId: 'a', activatedAt: 42 });
+  assert.deepEqual(downgradeMirror({ kind: 'lifetime', key: 'k', activationId: 'a', activatedAt: 7 }), { key: 'k', activationId: 'a', activatedAt: 7 });
+  assert.equal(downgradeMirror({ kind: 'subscription', key: 'k', activationId: 'a', activatedAt: 1 }), null);
+  assert.equal(downgradeMirror(null), null);
+});

--- a/test/unit/patron-model.test.js
+++ b/test/unit/patron-model.test.js
@@ -116,3 +116,33 @@ test('downgradeMirror mirrors founding/lifetime, NEVER a subscription', () => {
   assert.equal(downgradeMirror({ kind: 'subscription', key: 'k', activationId: 'a', activatedAt: 1 }), null);
   assert.equal(downgradeMirror(null), null);
 });
+
+const { readLicenseStatus, readExpiresAt } = require('../../src/main/patron-model');
+
+test('readLicenseStatus reads top-level (validate) and nested (activate) shapes', () => {
+  // validate response: license key at the top level
+  assert.equal(readLicenseStatus({ status: 'granted' }), 'granted');
+  // activate response: license key nested (either depth)
+  assert.equal(readLicenseStatus({ license_key: { status: 'revoked' } }), 'revoked');
+  assert.equal(readLicenseStatus({ activation: { license_key: { status: 'disabled' } } }), 'disabled');
+  // top-level wins when present (validate shape), never the nested one
+  assert.equal(readLicenseStatus({ status: 'granted', license_key: { status: 'revoked' } }), 'granted');
+  // no readable status → null (caller treats as ambiguous/unreachable)
+  assert.equal(readLicenseStatus({}), null);
+  assert.equal(readLicenseStatus({ status: 42 }), null);
+  assert.equal(readLicenseStatus(null), null);
+  assert.equal(readLicenseStatus('nope'), null);
+});
+
+test('readExpiresAt reads both shapes and keeps parseExpiresAt three-state', () => {
+  const iso = '2026-12-31T00:00:00Z';
+  assert.strictEqual(readExpiresAt({ expires_at: iso }), Date.parse(iso));                       // validate: top-level
+  assert.strictEqual(readExpiresAt({ license_key: { expires_at: iso } }), Date.parse(iso));      // activate: nested
+  assert.strictEqual(readExpiresAt({ activation: { license_key: { expires_at: iso } } }), Date.parse(iso));
+  // top-level wins when both present (validate shape), never the nested one
+  assert.strictEqual(readExpiresAt({ expires_at: iso, license_key: { expires_at: '2000-01-01T00:00:00Z' } }), Date.parse(iso));
+  assert.strictEqual(readExpiresAt({}), null);            // absent → null (no expiry)
+  assert.strictEqual(readExpiresAt({ expires_at: null }), null);
+  assert.strictEqual(readExpiresAt({ expires_at: 'not-a-date' }), false);  // present but malformed → false
+  assert.strictEqual(readExpiresAt(null), null);
+});


### PR DESCRIPTION
## Summary

- Locked design spec for Blanc Patron — recurring supporter tier with Named Workspaces as anchor feature, founding-Patron migration for existing $19 Supporters, and a fail-closed entitlement model.
- Phase 1 implementation plan (entitlement layer): 8 tasks covering pure `patron-model.js`, Polar activation + daily validation, settings migration, pages.js projection, and Settings UI re-gating.
- Three review rounds on the spec and two on the plan, each fixing real correctness/implementation bugs.

## Key decisions (spec)

- **Free/paid line:** everything shipped today stays free forever, including all current Profile Sync. Patron only adds.
- **Anchor feature:** Named Workspaces (Phase 2, own plan after this lands).
- **Entitlement model:** `patron` record with three kinds (founding/lifetime/subscription), 30-day offline grace, fail-closed benefit_id allowlist, per-environment org ID, NaN-safe expiry parsing.
- **Pricing:** $30/yr, $4/mo (provisional). No lifetime at launch.

## Plan review fixes

- Persisted-record-derived activity (no volatile in-memory flag)
- Migration inside `ensureStore()` with synchronous flush
- Own-property allowlist check (rejects inherited `toString`/`__proto__`)
- Projection/IPC correctly in `pages.js`, `setPatron` fires `listeners`
- Per-validation benefit re-check
- Per-environment `PRODUCTION_ORG_ID` / `SANDBOX_ORG_ID`
- Activation inspects nested license-key status + expiry before bootstrapping grace
- `parseExpiresAt` helper prevents NaN from classifying as expired terminal
- Task 7 names the real seam: `setImmediate` after `releaseStartup()`

## Test plan

- [ ] Read through spec and plan for completeness
- [ ] Confirm plan's code samples are consistent with each other and with the spec's constraints
- [ ] Implementation is a separate effort, gated on Polar product setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)