### PR TITLE
Island morph anchors to the pill's current centre after window resizes

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -6160,7 +6160,7 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
       // (electronApp.evaluate() reaches straight into the main process) —
       // test-hook.js wraps every installed method with this at install time.
       bindRoot: (fn) => bindWindowRuntime(primaryRuntime, fn),
-      tabs, getTabOrder: () => rt().tabOrder, getGroups: () => rt().groups, getActiveTabId: () => rt().activeTabId, clusterSlots,
+      tabs, getTabOrder: () => rt().tabOrder, getGroups: () => rt().groups, getActiveTabId: () => rt().activeTabId, getIslandRect: () => rt().islandRect, clusterSlots,
       createTab, setActiveTab, closeTab, duplicateTab, toggleTabPinned, toggleTabMuted,
       setGlanceTab, closeGlance, promoteGlance, resizeGlanceAt, resetGlanceRatio,
       getGlanceTabId: () => rt().glanceTabId,

--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -38,6 +38,7 @@ function install(refs) {
     getTabOrder,
     getGroups,
     getActiveTabId,
+    getIslandRect,
     runBlockAdsCommand,
     runAllowAdsCommand,
     clusterSlots,
@@ -189,6 +190,10 @@ function install(refs) {
     },
     profileTabSession(id) { return profileTabSessionSnapshot(String(id)); },
     startupReady() { return isSessionPersistenceReady(); },
+    /** The strip-reported island rect (window coords) — geometry only. Lets
+     * tests assert the morph/proximity anchor tracks the real pill (it went
+     * stale across window resizes when only a pill ResizeObserver fed it). */
+    islandRect() { const r = getIslandRect(); return r ? { ...r } : null; },
     state() {
       const list = [];
       for (const [id, t] of tabs) {

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -872,6 +872,11 @@
     });
   };
   new ResizeObserver(reportIslandRect).observe(islandPill);
+  // The observer only sees the pill's SIZE change. A window resize re-centers
+  // the pill without resizing it, which left this rect stale — and the ⌘L
+  // morph (and proximity glow) anchored to where the centre USED to be,
+  // visibly growing out of the left or right instead of the pill.
+  window.addEventListener('resize', reportIslandRect);
   requestAnimationFrame(reportIslandRect);
 
   window.browserAPI.onIslandProximity(({ k }) => {


### PR DESCRIPTION
## Summary

User-reported (macOS and Windows): the pill→panel expand animation sometimes grows out of the left or right instead of the island's centre.

**Root cause:** the strip re-reports the island rect only from a `ResizeObserver` on `#islandPill` — which fires when the pill's *size* changes, never on the position-only re-centring a window resize causes. The stored rect kept the old centre, so `--morph-x` (and the proximity glow, which shares the same rect) anchored off-centre by half the resize delta until the pill next changed size.

**Fix:** also re-report on window `resize`. One measured `getBoundingClientRect` + IPC send per resize frame — same cost class as the existing proximity stream.

## Verification

Playwright repro (main-process evaluate through the test hook): shrink the window 400px, compare the reported rect centre to the true half-width.

- Before fix: `delta=200.0px` (stale — bug reproduced)
- After fix: `delta=0.0px` (tracked exactly)

The test hook gains a read-only `islandRect()` accessor for this. 870 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)