### PR TITLE
Update site Island demos: drop retired group chip, add blank-tab "/" beat

### DIFF
--- a/site/src/components/PressIslandDemo.astro
+++ b/site/src/components/PressIslandDemo.astro
@@ -4,25 +4,25 @@ const tabSections = [
     name: 'pinned',
     showCount: false,
     tabs: [
-      { title: 'Gmail', domain: 'mail.google.com', favicon: 'gmail.com', shield: 2, group: '', page: '/shots/desktop/gmail.jpg', pinned: true },
-      { title: 'Notion', domain: 'notion.so', favicon: 'notion.so', shield: 1, group: '', page: '/shots/desktop/notion.jpg', pinned: true },
+      { title: 'Gmail', domain: 'mail.google.com', favicon: 'gmail.com', shield: 2, page: '/shots/desktop/gmail.jpg', pinned: true },
+      { title: 'Notion', domain: 'notion.so', favicon: 'notion.so', shield: 1, page: '/shots/desktop/notion.jpg', pinned: true },
     ],
   },
   {
     name: 'tech news',
     showCount: true,
     tabs: [
-      { title: 'The Verge', domain: 'theverge.com', favicon: 'theverge.com', shield: 12, group: 'tech news', page: '/shots/desktop/theverge.jpg', active: true },
-      { title: '9to5Mac', domain: '9to5mac.com', favicon: '9to5mac.com', shield: 8, group: 'tech news', page: '/shots/desktop/9to5mac.jpg' },
-      { title: 'CNET', domain: 'cnet.com', favicon: 'cnet.com', shield: 15, group: 'tech news', page: '/shots/desktop/cnet.png' },
+      { title: 'The Verge', domain: 'theverge.com', favicon: 'theverge.com', shield: 12, page: '/shots/desktop/theverge.jpg', active: true },
+      { title: '9to5Mac', domain: '9to5mac.com', favicon: '9to5mac.com', shield: 8, page: '/shots/desktop/9to5mac.jpg' },
+      { title: 'CNET', domain: 'cnet.com', favicon: 'cnet.com', shield: 15, page: '/shots/desktop/cnet.png' },
     ],
   },
   {
     name: 'research',
     showCount: true,
     tabs: [
-      { title: 'MDN Web Docs', domain: 'developer.mozilla.org', favicon: 'developer.mozilla.org', shield: 4, group: 'research', page: '/shots/desktop/mdn.jpg' },
-      { title: 'Hacker News', domain: 'news.ycombinator.com', favicon: 'news.ycombinator.com', shield: 3, group: 'research', page: '/shots/desktop/hacker-news.jpg' },
+      { title: 'MDN Web Docs', domain: 'developer.mozilla.org', favicon: 'developer.mozilla.org', shield: 4, page: '/shots/desktop/mdn.jpg' },
+      { title: 'Hacker News', domain: 'news.ycombinator.com', favicon: 'news.ycombinator.com', shield: 3, page: '/shots/desktop/hacker-news.jpg' },
     ],
   },
 ];
@@ -43,6 +43,20 @@ const tabSections = [
   <div class="press-island-stage" tabindex="0" aria-label="Interactive recreation of the Blanc Island. Click the Island to expand or collapse it; type in the open field to filter tabs and commands.">
     <img class="press-island-page" id="pressIslandPage" src="/shots/desktop/theverge.jpg" width="1280" height="720" alt="" aria-hidden="true" />
     <div class="press-island-strip" aria-hidden="true"></div>
+    <div class="demo-newtab" id="pressIslandStart" hidden aria-hidden="true">
+      <span class="demo-bb-date" id="pressIslandStartDate"></span>
+      <div class="demo-bb-clock-row">
+        <span class="demo-bb-clock" id="pressIslandStartClock"></span>
+        <span class="demo-bb-meridiem" id="pressIslandStartMeridiem"></span>
+      </div>
+      <span class="demo-bb-blocked" id="pressIslandStartBlocked"></span>
+      <div class="demo-bb-favs">
+        <span class="demo-bb-fav"><span class="tile" style="background-image:url('/favicons/gmail.com.ico')"></span><span class="label">gmail</span></span>
+        <span class="demo-bb-fav"><span class="tile" style="background-image:url('/favicons/notion.so.ico')"></span><span class="label">notion</span></span>
+        <span class="demo-bb-fav"><span class="tile" style="background-image:url('/favicons/theverge.com.ico')"></span><span class="label">the verge</span></span>
+        <span class="demo-bb-fav"><span class="tile" style="background-image:url('/favicons/github.com.ico')"></span><span class="label">github</span></span>
+      </div>
+    </div>
     <span class="press-island-connector press-island-connector--island" aria-hidden="true"></span>
     <span class="press-island-connector press-island-connector--session" aria-hidden="true"></span>
     <span class="press-island-connector press-island-connector--groups" aria-hidden="true"></span>
@@ -57,6 +71,7 @@ const tabSections = [
         <span class="dots" aria-hidden="true"><span></span><span class="cur"></span><span></span></span>
         <span class="pill-fav" style="background-image:url('/favicons/theverge.com.ico')" aria-hidden="true"></span>
         <span class="domain" id="pressIslandDomain">theverge.com</span>
+        <span class="pill-slash" id="pressIslandSlash" title="Commands (/)" aria-hidden="true" hidden>/</span>
         <span class="shield" id="pressIslandShield">
           <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.8l5 1.9v3.8c0 3.1-2.1 5.3-5 6.7-2.9-1.4-5-3.6-5-6.7V3.7z" /><path d="M4.4 11.47 12.61 3.55" /></svg>
           <span class="shield-count" id="pressIslandShieldCount">12</span>
@@ -98,7 +113,6 @@ const tabSections = [
                   data-domain={tab.domain}
                   data-favicon={tab.favicon}
                   data-shield={tab.shield}
-                  data-group={tab.group}
                   data-page={tab.page}
                   data-pinned={String(Boolean(tab.pinned))}
                 >
@@ -107,7 +121,6 @@ const tabSections = [
                   <button class:list={['row-pin', { on: tab.pinned }]} type="button" aria-label={tab.pinned ? 'Unpin tab' : 'Pin tab'} aria-pressed={String(Boolean(tab.pinned))} title={tab.pinned ? 'Unpin tab' : 'Pin tab'}>
                     <svg viewBox="0 0 16 16"><path d="M5 3h6l-1 5 2 2v1H4v-1l2-2z" /><path d="M8 11v3" /></svg>
                   </button>
-                  <button class="row-grp" type="button" aria-label="Move to group" title="Move to group">{tab.group || 'group'}</button>
                   <button class="row-close" type="button" aria-label="Close tab" title="Close tab">
                     <svg viewBox="0 0 16 16"><path d="M4.75 4.75l6.5 6.5M11.25 4.75l-6.5 6.5" /></svg>
                   </button>
@@ -118,7 +131,7 @@ const tabSections = [
         </div>
 
         <div class="foot-bar">
-          <button class="foot-new" type="button"><svg viewBox="0 0 16 16"><path d="M8 3.25v9.5M3.25 8h9.5" /></svg><span>new tab</span><span class="foot-kbd">⌘T</span></button>
+          <button class="foot-new" id="pressIslandNewTab" type="button"><svg viewBox="0 0 16 16"><path d="M8 3.25v9.5M3.25 8h9.5" /></svg><span>new tab</span><span class="foot-kbd">⌘T</span></button>
           <button class="foot-new private" type="button"><svg viewBox="0 0 16 16"><path d="M8 3.25v9.5M3.25 8h9.5" /></svg><span>private</span><span class="foot-kbd">⌘⇧N</span></button>
           <span class="foot-spacer"></span>
           <button class="foot-act" type="button" aria-label="Favorites"><svg viewBox="0 0 16 16"><path d="M4.25 2.75h7.5v10.5L8 10.5l-3.75 2.75z" /></svg></button>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -92,6 +92,20 @@ const graph = {
       <div class="bar w4"></div>
     </div>
     <img class="demo-shot" id="demoShot" alt="" aria-hidden="true">
+    <div class="demo-newtab" id="demoNewtab" hidden aria-hidden="true">
+      <span class="demo-bb-date" id="demoBbDate"></span>
+      <div class="demo-bb-clock-row">
+        <span class="demo-bb-clock" id="demoBbClock"></span>
+        <span class="demo-bb-meridiem" id="demoBbMeridiem"></span>
+      </div>
+      <span class="demo-bb-blocked" id="demoBbBlocked"></span>
+      <div class="demo-bb-favs">
+        <span class="demo-bb-fav"><span class="tile" style="background-image:url('/favicons/gmail.com.ico')"></span><span class="label">gmail</span></span>
+        <span class="demo-bb-fav"><span class="tile" style="background-image:url('/favicons/notion.so.ico')"></span><span class="label">notion</span></span>
+        <span class="demo-bb-fav"><span class="tile" style="background-image:url('/favicons/github.com.ico')"></span><span class="label">github</span></span>
+        <span class="demo-bb-fav"><span class="tile" style="background-image:url('/favicons/netflix.com.ico')"></span><span class="label">netflix</span></span>
+      </div>
+    </div>
     <div class="demo-island" id="demoIsland">
       <div class="pill">
         <div class="pnav">
@@ -101,6 +115,7 @@ const graph = {
         <div class="dots" id="demoDots"></div>
         <span class="pill-fav" id="demoFav"></span>
         <span class="domain" id="demoDomain"></span>
+        <span class="pill-slash" id="demoSlash" hidden>/</span>
         <span class="shield" id="demoShield"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.8l5 1.9v3.8c0 3.1-2.1 5.3-5 6.7-2.9-1.4-5-3.6-5-6.7V3.7z"/><path d="M4.4 11.47 12.61 3.55"/></svg><span class="shield-count" id="demoShieldCount"></span></span>
         <span class="priv-chip">private <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4.75 4.75l6.5 6.5M11.25 4.75l-6.5 6.5"/></svg></span>
         <span class="psep"></span>

--- a/site/src/scripts/demo.js
+++ b/site/src/scripts/demo.js
@@ -58,6 +58,8 @@
   const dotsEl = document.getElementById('demoDots');
   const favEl = document.getElementById('demoFav');
   const domainEl = document.getElementById('demoDomain');
+  const slashEl = document.getElementById('demoSlash');
+  const newtabEl = document.getElementById('demoNewtab');
   const shieldEl = document.getElementById('demoShield');
   const shieldCountEl = document.getElementById('demoShieldCount');
   const shieldHostEl = document.getElementById('demoShieldHost');
@@ -67,6 +69,24 @@
   const footEl = document.getElementById('demoFoot');
   const capEl = document.getElementById('demoCaption');
   const heartEl = document.getElementById('demoHeart');
+
+  // The blank-tab beat renders a miniature of the "billboard" start page. The
+  // date, clock, and meridiem use the app's own formats; the blocked line is
+  // illustrative, like the demo's per-site shield counts.
+  function fillBillboard(ids, blockedText) {
+    const now = new Date();
+    document.getElementById(ids.date).textContent = now
+      .toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' })
+      .toLowerCase();
+    const time = now.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+    document.getElementById(ids.clock).textContent = time.replace(/\s?[AP]M$/i, '');
+    document.getElementById(ids.meridiem).textContent = (time.match(/[AP]M$/i) || [''])[0].toLowerCase();
+    document.getElementById(ids.blocked).textContent = blockedText;
+  }
+  fillBillboard(
+    { date: 'demoBbDate', clock: 'demoBbClock', meridiem: 'demoBbMeridiem', blocked: 'demoBbBlocked' },
+    '2,412 ads blocked this week · nothing followed you home'
+  );
 
   /* ---- island motion (1.1.0) ----
      Two effects, both reproducing the app's own numbers rather than
@@ -225,6 +245,10 @@
     msnow:    { title: 'MS NOW',    domain: 'msnow.com',       fav: 'msnbc.com',    shield: 14 },
     netflix:  { title: 'Netflix',   domain: 'netflix.com',     fav: 'netflix.com',  shield: 3 },
     github:   { title: 'GitHub',    domain: 'github.com',      fav: 'github.com',   shield: 0 },
+    // A blank tab. No domain puts the pill in placeholder mode: the prompt
+    // label, the Blanc-mark favicon, the "/" chip, and no shield (the app
+    // hides it entirely on internal pages) — matching the real app's state.
+    newtab:   { title: 'New Tab',   domain: '',                fav: null,           shield: 0, internal: true },
   };
 
   const ICON_BASE = '/favicons/';
@@ -320,6 +344,13 @@
       pinned: ['gmail', 'notion'],
       groups: [{ name: 'social', ids: ['youtube', 'threads'] }],
       loose: ['scroll', 'nintendo', 'msnow', 'netflix', 'github'],
+    },
+    // base plus a just-opened blank tab. A plain new tab always launches
+    // ungrouped, so it joins the loose set — the dots the pill shows for it.
+    fresh: {
+      pinned: ['gmail', 'notion'],
+      groups: [{ name: 'social', ids: ['youtube', 'threads'] }],
+      loose: ['scroll', 'nintendo', 'msnow', 'netflix', 'github', 'newtab'],
     },
     pinned: {
       pinned: ['gmail', 'notion', 'scroll'],
@@ -473,8 +504,17 @@
     dotsEl.innerHTML = dots;
 
     const t = TABS[current];
-    favEl.style.backgroundImage = t.fav ? `url('${ICON_BASE}${t.fav}.ico')` : 'none';
-    domainEl.textContent = t.domain;
+    // No domain = the app's placeholder mode (1.6.0): the prompt label with
+    // its wash, the "/" chip, the Blanc-mark favicon, and no shield at all —
+    // internal pages hide the shield entirely, unlike a protected site with
+    // zero blocked (which keeps a quiet shield).
+    const blank = !t.domain;
+    favEl.classList.toggle('internal', blank);
+    favEl.style.backgroundImage = blank ? '' : (t.fav ? `url('${ICON_BASE}${t.fav}.ico')` : 'none');
+    domainEl.textContent = blank ? 'Search or type a URL' : t.domain;
+    domainEl.classList.toggle('placeholder', blank);
+    slashEl.hidden = !blank;
+    shieldEl.hidden = blank;
     // Protected with nothing blocked yet is a state of its own in the app — a
     // dimmed shield with no badge, not a missing one. The shield is a permanent
     // landmark in the pill; only the badge comes and goes.
@@ -522,6 +562,9 @@
     // An invitation rather than a claim: the pill only reacts to a real cursor,
     // so the caption points at something the visitor can go and do.
     { view: 'rest',  layout: 'base',    current: 'github',  hold: 3400, cap: 'Move your pointer toward it — the island leans your way.' },
+    // The blank-tab beat: the pill drops to its placeholder ("Search or type
+    // a URL" + the "/" chip), the state the app shows only on a new tab.
+    { view: 'rest',  layout: 'fresh',   current: 'newtab',  hold: 3600, cap: 'A blank tab shows where to type — and / lists every command.' },
     { view: 'panel', layout: 'base',    current: 'github',  hold: 3300, cap: 'Open it and the panel grows out of the island itself.' },
     { view: 'panel', layout: 'base',    current: 'github',  panel: 'switcher', typed: 'scr', hold: 3400, cap: 'A few letters jumps from GitHub to Scroll.' },
     { view: 'rest',  layout: 'base',    current: 'scroll',  hold: 2800, cap: 'Scroll fills the window while the island stays small.' },
@@ -540,10 +583,10 @@
   // at the start of one and jumps playback there.
   const CHAPTERS = [
     { label: 'the island', scene: 0 },
-    { label: 'command bar', scene: 3 },
-    { label: 'tab groups', scene: 7 },
-    { label: 'blanc blocker', scene: 11 },
-    { label: 'private tabs', scene: 13 },
+    { label: 'command bar', scene: 4 },
+    { label: 'tab groups', scene: 8 },
+    { label: 'blanc blocker', scene: 12 },
+    { label: 'private tabs', scene: 14 },
   ];
   // A scene's on-screen duration: typing scenes run for the keystrokes plus a
   // read beat, everything else uses its authored hold. The scrub fill and the
@@ -571,6 +614,9 @@
 
     renderPill(s.layout, current, s);
     showShot(s.priv ? PRIVATE_SHOT : current); // private scene shows a page browsed privately
+    // The blank tab shows a miniature of the ledger start page instead of a
+    // site render — the surface the quiet pill actually rests over in the app.
+    newtabEl.hidden = !TABS[current].internal || !!s.priv;
     // Color-match the top strip to the page now behind it, so the Island reads
     // as floating in the page's top margin rather than on a browser bar.
     stage.style.setProperty('--demo-strip-bg', s.priv ? PRIVATE_TOP : (SHOT_TOP[current] || ''));

--- a/site/src/scripts/press-island.js
+++ b/site/src/scripts/press-island.js
@@ -13,8 +13,25 @@
   const hint = document.getElementById('pressIslandHint');
   const favicon = toggle?.querySelector('.pill-fav');
   const page = document.getElementById('pressIslandPage');
+  const slash = document.getElementById('pressIslandSlash');
+  const start = document.getElementById('pressIslandStart');
+  const newTab = document.getElementById('pressIslandNewTab');
 
-  if (!demo || !island || !toggle || !state || !stateLabel || !input || !list || !domain || !shield || !shieldCount || !hint || !favicon || !page) return;
+  if (!demo || !island || !toggle || !state || !stateLabel || !input || !list || !domain || !shield || !shieldCount || !hint || !favicon || !page || !slash || !start || !newTab) return;
+
+  // The blank tab renders a miniature of the "billboard" start page. Date,
+  // clock, and meridiem use the app's own formats; the blocked line is
+  // illustrative, matching the demo's per-site shield counts.
+  (function fillBillboard() {
+    const now = new Date();
+    document.getElementById('pressIslandStartDate').textContent = now
+      .toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' })
+      .toLowerCase();
+    const time = now.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+    document.getElementById('pressIslandStartClock').textContent = time.replace(/\s?[AP]M$/i, '');
+    document.getElementById('pressIslandStartMeridiem').textContent = (time.match(/[AP]M$/i) || [''])[0].toLowerCase();
+    document.getElementById('pressIslandStartBlocked').textContent = '2,412 ads blocked this week · nothing followed you home';
+  })();
 
   const originalMarkup = list.innerHTML;
   const commands = [
@@ -81,11 +98,41 @@
     }
   }
 
+  // The blank-tab state (the "new tab" footer button): the island collapses to
+  // the quiet placeholder pill — prompt label, Blanc-mark favicon, the "/"
+  // chip, no shield (the app hides it entirely on internal pages) — resting
+  // over a miniature of the ledger start page.
+  function enterBlankTab() {
+    interact();
+    selectedDomain = '';
+    domain.textContent = 'Search or type a URL';
+    domain.classList.add('placeholder');
+    favicon.style.backgroundImage = '';
+    favicon.classList.remove('press-island-blanc-favicon');
+    favicon.classList.add('internal');
+    shield.hidden = true;
+    slash.hidden = false;
+    start.hidden = false;
+    delete demo.dataset.site;
+    input.value = '';
+    restoreTabs();
+    setOpen(false);
+  }
+
+  function leaveBlankTab() {
+    domain.classList.remove('placeholder');
+    favicon.classList.remove('internal');
+    shield.hidden = false;
+    slash.hidden = true;
+    start.hidden = true;
+  }
+
   function chooseRow(row) {
     const nextDomain = row.dataset.domain;
     const selectedFavicon = row.dataset.favicon;
     const selectedShield = row.dataset.shield;
     interact();
+    leaveBlankTab();
     selectedDomain = nextDomain;
     domain.textContent = nextDomain;
     favicon.style.backgroundImage = selectedFavicon ? `url('/favicons/${selectedFavicon}.ico')` : 'none';
@@ -119,16 +166,6 @@
         hint.textContent = pinned ? `${row.dataset.title} pinned` : `${row.dataset.title} unpinned`;
       });
 
-      const group = row.querySelector('.row-grp');
-      group?.addEventListener('click', (event) => {
-        event.stopPropagation();
-        group.classList.toggle('open');
-        group.setAttribute('aria-expanded', String(group.classList.contains('open')));
-        hint.textContent = group.classList.contains('open')
-          ? `move ${row.dataset.title} to another group`
-          : 'esc to dismiss · type / for commands · choose a row to switch';
-      });
-
       row.querySelector('.row-close')?.addEventListener('click', (event) => {
         event.stopPropagation();
         row.classList.add('is-closing');
@@ -150,10 +187,23 @@
     clearTimeout(introTimer);
   }
 
-  toggle.addEventListener('click', () => {
+  toggle.addEventListener('click', (event) => {
     interact();
-    setOpen(!island.classList.contains('open'), !island.classList.contains('open'));
+    const open = island.classList.contains('open');
+    // The "/" chip opens the panel already showing the command list, exactly
+    // like the app's own chip — a bare "/" cannot say what it does, so
+    // clicking it shows you. (The chip is a decorative span inside the pill
+    // button, so its clicks arrive here by delegation.)
+    if (!open && event.target === slash) {
+      input.value = '/';
+      renderCommands('/');
+      setOpen(true);
+      requestAnimationFrame(() => input.focus());
+      return;
+    }
+    setOpen(!open, !open);
   });
+  newTab.addEventListener('click', enterBlankTab);
   state.addEventListener('click', () => {
     interact();
     setOpen(!island.classList.contains('open'), !island.classList.contains('open'));

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -261,6 +261,48 @@ body.has-consent footer { padding-bottom: calc(56px + var(--consent-h)); }
 /* Protected but nothing blocked here yet: a quiet landmark, not a badge. */
 .demo-island .shield-quiet { color: var(--text-dim); }
 .demo-island .shield[hidden] { display: none; }
+
+/* The blank-tab resting state (app 1.6.0: #pillDomain.placeholder + the "/"
+   chip, shown only when the pill has no domain — never beside a real site).
+   The wash animation and reduced-motion fallback reproduce the app's own
+   numbers from styles.css rather than approximating the look of them. */
+.demo-island .pill-slash { flex: 0 0 auto; padding: 0 5px; color: var(--text-dim); background: transparent; border: 1px solid var(--border); border-radius: 5px; font-family: var(--font-mono); font-size: 10px; line-height: 15px; cursor: pointer; transition: color 120ms ease, border-color 120ms ease; }
+.demo-island .pill-slash:hover { color: var(--accent); border-color: var(--accent); }
+.demo-island .pill-slash[hidden] { display: none; }
+.demo-island .pill-fav.internal { background: #fff url('/logo.png') center / cover no-repeat; box-shadow: inset 0 0 0 1px var(--border); }
+.demo-island .domain.placeholder {
+  color: var(--text-dim);
+  background-image: linear-gradient(90deg, var(--text-dim) 0%, var(--text-dim) 35%, var(--text) 50%, var(--text-dim) 65%, var(--text-dim) 100%);
+  background-size: 300% 100%;
+  background-repeat: repeat;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: pill-placeholder-wash 2.6s linear infinite;
+}
+@keyframes pill-placeholder-wash {
+  from { background-position: 130% 0; }
+  to { background-position: -30% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .demo-island .domain.placeholder { animation: none; background-image: none; -webkit-text-fill-color: currentColor; color: color-mix(in srgb, var(--text) 65%, var(--text-dim)); }
+}
+/* A miniature of the "billboard" start page (design system "New tab v2"): a
+   date line, a large clock, the week's blocked count, and favorite tiles,
+   centered — shown behind the quiet pill while the demo is on a blank tab.
+   Sits above the page render and below the island (z-index 5). The clock and
+   tile sizes are scaled down from pages.css to fit the demo stage. */
+.demo-newtab { position: absolute; inset: 0; z-index: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; background: var(--bg); user-select: none; }
+.demo-newtab[hidden] { display: none; }
+.demo-bb-date { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); letter-spacing: 0.18em; }
+.demo-bb-clock-row { display: flex; align-items: baseline; gap: 9px; margin-top: 10px; }
+.demo-bb-clock { font-family: var(--font-mono); font-size: clamp(52px, 9vw, 76px); font-weight: 700; letter-spacing: -0.04em; line-height: 1; font-variant-numeric: tabular-nums; color: var(--text); }
+.demo-bb-meridiem { font-family: var(--font-mono); font-size: 15px; color: var(--text-dim); }
+.demo-bb-blocked { max-width: 92%; margin-top: 13px; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); text-align: center; }
+.demo-bb-favs { display: flex; gap: clamp(18px, 3vw, 30px); margin-top: 30px; }
+.demo-bb-fav { display: flex; flex-direction: column; align-items: center; gap: 7px; }
+.demo-bb-fav .tile { width: 30px; height: 30px; border-radius: 6px; background: var(--surface) center / 19px no-repeat; border: 1px solid var(--border); }
+.demo-bb-fav .label { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
 .demo-island .priv-chip { display: none; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 11.5px; padding: 2px 5px 2px 9px; border-radius: 999px; border: 1px dashed var(--accent); color: var(--accent); }
 /* The chip's ✕ is the app's own 16-grid glyph, drawn small — it used to be a
    bespoke cross on a 12 grid, the one shape in the demos outside the app's
@@ -1169,21 +1211,14 @@ body[data-page="press"] > .legal-top { display: none; }
 .press-island-live .row-close svg { display: block; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; }
 .press-island-live .row-pin svg { width: 14px; height: 14px; stroke-width: 1.25; }
 .press-island-live .row-close svg { width: 12px; height: 12px; stroke-width: 1.75; }
-.press-island-live .row-grp { height: 18px; padding: 0 7px; flex: 0 0 auto; color: var(--text-dim); background: transparent; border: 1px solid var(--border); border-radius: 999px; font-family: var(--font-mono); font-size: 10px; opacity: 0; cursor: pointer; transition: opacity 120ms ease, color 120ms ease, border-color 120ms ease; }
 .press-island-live .trow:hover .row-pin,
 .press-island-live .trow:hover .row-close,
-.press-island-live .trow:hover .row-grp,
 .press-island-live .trow:focus-within .row-pin,
 .press-island-live .trow:focus-within .row-close,
-.press-island-live .trow:focus-within .row-grp,
 .press-island-live .row-pin:focus-visible,
-.press-island-live .row-close:focus-visible,
-.press-island-live .row-grp:focus-visible,
-.press-island-live .row-grp.open { opacity: 1; }
+.press-island-live .row-close:focus-visible { opacity: 1; }
 .press-island-live .row-pin:hover,
 .press-island-live .row-close:hover { color: var(--text); background: var(--border); }
-.press-island-live .row-grp:hover,
-.press-island-live .row-grp.open { color: var(--accent); border-color: var(--accent); }
 .press-island-live .row-pin.on { color: var(--accent); background: var(--accent-dim); }
 .press-island-live .sec-head,
 .press-island-live .trow .kbd,

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -121,8 +121,26 @@ test('the public press page keeps its release links, indexability, and no-analyt
   assert.match(islandDemo, /page: '\/shots\/desktop\/9to5mac\.jpg'/);
   assert.match(islandDemo, /page: '\/shots\/desktop\/cnet\.png'/);
   assert.match(islandDemo, /class:list=\{\['row-pin'/);
-  assert.match(islandDemo, /class="row-grp"/);
   assert.match(islandDemo, /class="row-close"/);
+  // Grouping moved into the right-click context menu (app commit a9f1dba), so
+  // the retired per-row group chip must not reappear in the demo rows.
+  assert.doesNotMatch(islandDemo, /class="row-grp"/);
+  assert.doesNotMatch(islandDemo, /data-group=/);
+  // The blank-tab state (app 1.6.0's "/" chip, #141): the chip lives in the
+  // pill but only shows in placeholder mode — never beside a real domain —
+  // and the quiet pill rests over a miniature "billboard" start page (date +
+  // clock + blocked line + favorites).
+  assert.match(islandDemo, /id="pressIslandSlash"[^>]*hidden/);
+  assert.match(islandDemo, /id="pressIslandNewTab"/);
+  assert.match(islandDemo, /id="pressIslandStart"[^>]*hidden/);
+  assert.match(islandDemo, /class="demo-bb-clock"/);
+  assert.match(islandDemo, /class="demo-bb-favs"/);
+  assert.match(islandScript, /Search or type a URL/);
+  assert.match(islandScript, /enterBlankTab/);
+  assert.match(islandScript, /ads blocked this week/);
+  assert.match(siteStyles, /pill-placeholder-wash/);
+  assert.match(siteStyles, /\.demo-island \.pill-slash\[hidden\]/);
+  assert.match(siteStyles, /\.demo-bb-clock \{/);
   assert.doesNotMatch(islandDemo, /class="tag">active/);
   assert.doesNotMatch(islandDemo, /pressIslandPageFallback|press-island-cnet-card/);
   assert.doesNotMatch(islandDemo, /<span>launch<\/span>/);
@@ -145,8 +163,8 @@ test('the public press page keeps its release links, indexability, and no-analyt
   assert.match(islandScript, /syncActiveRow/);
   assert.match(islandScript, /preloadPages/);
   assert.match(islandScript, /querySelector\('\.row-pin'\)/);
-  assert.match(islandScript, /querySelector\('\.row-grp'\)/);
   assert.match(islandScript, /querySelector\('\.row-close'\)/);
+  assert.doesNotMatch(islandScript, /querySelector\('\.row-grp'\)/);
   const islandPageRule = siteStyles.match(/\.press-island-page \{([^}]*)\}/)?.[1] || '';
   assert.doesNotMatch(islandPageRule, /opacity|filter/);
   assert.match(siteStyles, /data-site="cnet\.com"[^}]*object-position: 24% top/);


### PR DESCRIPTION
The marketing site's interactive Island demos had drifted from the shipped app. This brings both the press-kit demo and the home hero demo back in line with the current Island.

## Why
- Tab grouping moved out of the ⌘L rows into the right-click context menu ([#165](https://github.com/bnfy/blanc/pull/165), app commit a9f1dba), but the press-kit demo still rendered the retired per-row group chip — advertising an affordance the app no longer has.
- The app's blank-tab pill gained a `/` command chip ([#141](https://github.com/bnfy/blanc/pull/141)); the demos never showed that state.

## What changed
**Retired group chip removed** (`PressIslandDemo.astro`, `press-island.js`, `site.css`)
- Dropped `.row-grp` and its inline picker from the demo rows, JS, and CSS. Rows now carry favicon + title + pin/close only.
- The named-groups concept stays via the section headers (pinned / tech news / research), not a per-row control.
- Also removed the now-dead `data-group` attribute and `group:` data fields.

**Blank-tab beat added** (both demos)
- The `/` chip lives in the pill but shows **only** in placeholder mode ("Search or type a URL") — never beside a real domain, matching the app.
- Home hero demo: a new self-playing blank-tab scene between "the island" and "command bar" (scrub chapter anchors re-indexed).
- Press demo: enter via the **new tab** footer button; the `/` chip opens the command list; choosing any row returns to a normal site pill.

**Billboard start page** behind the quiet pill (shared `.demo-newtab` block)
- A miniature of the design system's "billboard" new-tab layout: date line, large clock + meridiem, blocked-this-week line, favorite tiles. Date/time use the app's own formats.

## Notes for reviewers
- These remain **live CSS "demo-island" figures**, not screenshots (per the site figure conventions) — nothing was rasterized.
- The **billboard is not the app's default** new tab (the default is the "ledger" page). It was chosen deliberately for the demos' visual; easy to switch the press demo back to ledger if preferred.
- The **"2,412 ads blocked this week"** count is illustrative, consistent with the demo's existing per-site shield counts — not a product-wide stat claim.
- Rebased onto latest `main` (now includes #165/#166). No file overlap with those commits.

## Verification
- `npm run test:unit` → **870/870 pass** (`press-kit.test.js` updated to guard: group chip absent, `/` chip + billboard present).
- Both states rendered and verified in-browser at `/` and `/press` (Playwright): quiet pill (Blanc-mark favicon, placeholder, `/` chip, no shield) over the billboard; `/` chip opens the command list; row selection restores the site pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)