### PR TITLE
Release Blanc 1.7.0

### DIFF
--- a/docs/press/release-notes/v1.7.0.md
+++ b/docs/press/release-notes/v1.7.0.md
@@ -1,0 +1,15 @@
+# Blanc 1.7.0
+
+## Added
+
+- Right-click now opens a menu where it used to do nothing. Right-click the resting command pill for the active tab's actions; right-click a tab — whether in the ⌘L panel or the vertical tab rail — for that tab's actions, with Open in Glance and Quiet This Tab Now added for background tabs; and on macOS, right-click Blanc's Dock icon for the frontmost tab plus New Window and New Private Window.
+
+## Changed
+
+- Tab grouping moved off the tab row and into that right-click menu. The per-row group chip and its inline picker — the main thing that crowded long tab titles — are gone; you now group a tab, or start a new group, from the tab's right-click menu.
+
+## Fixed
+
+- Windows updates install reliably again. An update could previously download and then just sit there, sometimes for a very long time, without ever offering to restart. Blanc now fetches the update in one straight download instead of a slow block-by-block transfer, no longer trips over a too-short signature-verification timeout, and shows a taskbar progress bar while it downloads — then surfaces the restart prompt once the update is ready.
+
+- The command pill expands from its own centre again. After you resized the window, the pill-to-panel animation could grow out of the left or right edge instead of the middle; Blanc now re-measures the pill's position when the window resizes, so it always opens from centre.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.2",
@@ -16,7 +16,7 @@
         "@cucumber/cucumber": "^13.2.1",
         "@electron/asar": "3.4.1",
         "@ghostery/adblocker": "^2.18.2",
-        "electron": "^43.4.0",
+        "electron": "^43.4.1",
         "electron-builder": "^26.15.3",
         "playwright": "^1.62.1",
         "sharp": "^0.35.3"
@@ -2500,9 +2500,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "43.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.0.tgz",
-      "integrity": "sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==",
+      "version": "43.4.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.1.tgz",
+      "integrity": "sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==",
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",
@@ -50,7 +50,7 @@
     "@cucumber/cucumber": "^13.2.1",
     "@electron/asar": "3.4.1",
     "@ghostery/adblocker": "^2.18.2",
-    "electron": "^43.4.0",
+    "electron": "^43.4.1",
     "electron-builder": "^26.15.3",
     "playwright": "^1.62.1",
     "sharp": "^0.35.3"

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -6,7 +6,7 @@ import MemoryChart from '../components/MemoryChart.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 import releaseData from '../data/releases.json';
 
-const VERSION = '1.6.0';
+const VERSION = '1.7.0';
 const TAG = `v${VERSION}`;
 /* Wherever this page states a version and a date together, the date is that
    version's own ship date — read from the generated changelog data rather than

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.6.0');
+  assert.equal(packageVersion, '1.7.0');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
# Blanc 1.7.0

## Added

- Right-click now opens a menu where it used to do nothing. Right-click the resting command pill for the active tab's actions; right-click a tab — whether in the ⌘L panel or the vertical tab rail — for that tab's actions, with Open in Glance and Quiet This Tab Now added for background tabs; and on macOS, right-click Blanc's Dock icon for the frontmost tab plus New Window and New Private Window.

## Changed

- Tab grouping moved off the tab row and into that right-click menu. The per-row group chip and its inline picker — the main thing that crowded long tab titles — are gone; you now group a tab, or start a new group, from the tab's right-click menu.

## Fixed

- Windows updates install reliably again. An update could previously download and then just sit there, sometimes for a very long time, without ever offering to restart. Blanc now fetches the update in one straight download instead of a slow block-by-block transfer, no longer trips over a too-short signature-verification timeout, and shows a taskbar progress bar while it downloads — then surfaces the restart prompt once the update is ready.

- The command pill expands from its own centre again. After you resized the window, the pill-to-panel animation could grow out of the left or right edge instead of the middle; Blanc now re-measures the pill's position when the window resizes, so it always opens from centre.

---
Version + Electron bump, checked-in release notes, press-page version, and press-kit test pin — the prep commit for cutting v1.7.0. 910 unit tests pass; substrate check + production npm audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)