### PR TITLE
Record Blanc 1.7.0 in the public changelog

### DIFF
--- a/site/src/data/release-feature-names.json
+++ b/site/src/data/release-feature-names.json
@@ -1,4 +1,5 @@
 {
+  "1.7.0": ["Right-click menus", "Reliable Windows updates"],
   "1.6.0": ["Return to previous tab", "Calmer Island motion", "Dim-only quiet tabs"],
   "1.5.0": ["Reopen Closed Tab", "Closed-tab picker", "Group close undo", "New-tab prompt", "Start page layouts", "First-run setup"],
   "1.4.0": ["Glance"],

--- a/site/src/data/releases.json
+++ b/site/src/data/releases.json
@@ -1,5 +1,84 @@
 [
   {
+    "tag": "v1.7.0",
+    "version": "1.7.0",
+    "name": "1.7.0",
+    "publishedAt": "2026-08-19T07:36:50.000Z",
+    "humanDate": "August 19, 2026",
+    "machineDate": "2026-08-19",
+    "url": "https://github.com/bnfy/blanc/releases/tag/v1.7.0",
+    "anchor": "v1-7-0",
+    "compareUrl": null,
+    "sections": [
+      {
+        "heading": "Added",
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Right-click now opens a menu where it used to do nothing. Right-click the resting command pill for the active tab's actions; right-click a tab — whether in the ⌘L panel or the vertical tab rail — for that tab's actions, with Open in Glance and Quiet This Tab Now added for background tabs; and on macOS, right-click Blanc's Dock icon for the frontmost tab plus New Window and New Private Window."
+                  }
+                ],
+                "url": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Changed",
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Tab grouping moved off the tab row and into that right-click menu. The per-row group chip and its inline picker — the main thing that crowded long tab titles — are gone; you now group a tab, or start a new group, from the tab's right-click menu."
+                  }
+                ],
+                "url": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Fixed",
+        "blocks": [
+          {
+            "type": "list",
+            "items": [
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "Windows updates install reliably again. An update could previously download and then just sit there, sometimes for a very long time, without ever offering to restart. Blanc now fetches the update in one straight download instead of a slow block-by-block transfer, no longer trips over a too-short signature-verification timeout, and shows a taskbar progress bar while it downloads — then surfaces the restart prompt once the update is ready."
+                  }
+                ],
+                "url": null
+              },
+              {
+                "spans": [
+                  {
+                    "type": "text",
+                    "value": "The command pill expands from its own centre again. After you resized the window, the pill-to-panel animation could grow out of the left or right edge instead of the middle; Blanc now re-measures the pill's position when the window resizes, so it always opens from centre."
+                  }
+                ],
+                "url": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     "tag": "v1.6.0",
     "version": "1.6.0",
     "name": "1.6.0",


### PR DESCRIPTION
Post-release changelog for v1.7.0: regenerated `releases.json` from the published release body + the feature-name overlay entry. Site changelog test 20/20; freshness check current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)