### PR TITLE
Render and guard synced favicons across remote-tab surfaces

### DIFF
--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -150,6 +150,14 @@ function install(refs) {
       title: 'Remote press needle',
       groupId: null,
       pinned: false,
+      // A REAL synced-icon payload: 32x32 (tabicons-model ICON_SIZE),
+      // produced by the production rasterizer (nativeImage.resize + toPNG,
+      // tabicons.js:143) and accepted by validIconData(). A smaller PNG is
+      // rejected there, so a hand-rolled 1x1 would exercise a payload sync
+      // could never deliver. Without any favicon, setFavicon takes its
+      // no-icon branch and a broken synced favicon looks identical to a
+      // working one.
+      favicon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAABr0lEQVR4nLTWsUrDQBgH8O/7cmpr1aFj8Rmq+BSiaAdBqnZQfAlx8EnsIO1UcKhDfQkdbJd20EFBUKgFO0TTXM7vEhDR1ia55JZLLnC/u/93kBPKb57nSSkPj4+a9UZn5iQ3IhcUAYJxEzw7+k0IUT2vZmwcXvaXREG6nwrQXEBeu+5QPxASePC6feG0OpZYVK4EYwN5B9wpTyFpA7WJ/VLNbrUTMWivsm+POA1dBiJiTZHKNyvZjaJ0hygsHlAQv1kPnd5j935zp8TrRAVs6AkRsuWie/vi9J5IZEDHGHMfVnf2dLXjzd0McuUVfWq45okatOBYy1bho9V+K9VB11uHpQ39Ecyz4vPuOdLhetrpGIQ6F+TTkpKhp/CTTcugoEvPoO+nlAz6+ZKGQb/eEzfo71CyBo0dTdCgCeOJGROBpIz/gESMKYC5MR0wNEIBJkZYILYRAYhnRANiGJGBsMZVJbvOxnscIJSBmG8ezJfW8BnOIG7zz4niHDgNzoSTCWrKRnCTg6hFnr4Pxf94DGYPrtVGwBhjqwaOhOAuisY7GGNc3w12GzCS4C+fjS8AAAD///R8eLkAAAAGSURBVAMAqMIc5gOIAroAAAAASUVORK5CYII=',
     }],
   }];
 
@@ -829,17 +837,45 @@ function install(refs) {
         return true;
       })()`);
     },
+    // faviconDecoded is deliberately the decoded pixel size, not a boolean: a
+    // synced icon whose bytes are corrupt still yields a `has-icon` class and a
+    // non-empty background-image, so only an actual decode separates a rendered
+    // favicon from a broken one.
     async addressResultRows() {
       const wc = getOverlayWebContents();
       if (!wc) return [];
-      return wc.executeJavaScript(`[...document.querySelectorAll('#islandList .island-row')].map((row) => ({
-        title: row.querySelector('.row-title')?.textContent ?? '',
-        tag: row.querySelector('.row-tag')?.textContent ?? '',
-        label: row.querySelector('.row-primary')?.getAttribute('aria-label') ?? '',
-        quiet: row.classList.contains('quiet'),
-        active: row.classList.contains('active'),
-        enter: !!row.querySelector('.row-enter')
-      }))`);
+      return wc.executeJavaScript(`(async () => {
+        const rows = [...document.querySelectorAll('#islandList .island-row')];
+        return Promise.all(rows.map(async (row) => {
+          const fav = row.querySelector('.favicon');
+          const raw = fav ? getComputedStyle(fav).backgroundImage : '';
+          let url = '';
+          if (raw && raw.indexOf('url(') === 0) {
+            url = raw.slice(4, raw.length - 1);
+            if (url[0] === '"' || url[0] === "'") url = url.slice(1, -1);
+          }
+          let faviconDecoded = null;
+          if (url) {
+            faviconDecoded = await new Promise((resolve) => {
+              const img = new Image();
+              img.onload = () => resolve(img.naturalWidth + 'x' + img.naturalHeight);
+              img.onerror = () => resolve(false);
+              img.src = url;
+            });
+          }
+          return {
+            title: row.querySelector('.row-title')?.textContent ?? '',
+            tag: row.querySelector('.row-tag')?.textContent ?? '',
+            label: row.querySelector('.row-primary')?.getAttribute('aria-label') ?? '',
+            quiet: row.classList.contains('quiet'),
+            active: row.classList.contains('active'),
+            enter: !!row.querySelector('.row-enter'),
+            faviconClass: fav ? fav.className : '',
+            faviconHasIcon: !!(fav && fav.classList.contains('has-icon')),
+            faviconDecoded
+          };
+        }));
+      })()`);
     },
     async addressCommandNotice() {
       const wc = getOverlayWebContents();
@@ -1050,16 +1086,43 @@ function install(refs) {
       return structuredClone(remoteFixture);
     },
     clearRemoteDevices() { pushRemoteDevices([]); },
+    // Mirrors addressResultRows' favicon reporting so the start page and the
+    // Quick Switcher are guarded to the same standard: the tile letter is
+    // replaced by the icon only once the bytes actually decode.
     async remoteStartPageRows() {
       const rows = [];
       for (const tab of tabs.values()) {
         if (!urlOf(tab).startsWith('blanc://newtab')) continue;
         try {
           const rendered = await tab.view.webContents.executeJavaScript(
-            `[...document.querySelectorAll('#remoteList a')].map((row) => ({
-              title: row.querySelector('.name')?.textContent ?? '',
-              href: row.href
-            }))`
+            `(async () => {
+              const items = [...document.querySelectorAll('#remoteList a')];
+              return Promise.all(items.map(async (row) => {
+                const tile = row.querySelector('.tile');
+                const raw = tile ? getComputedStyle(tile).backgroundImage : '';
+                let url = '';
+                if (raw && raw.indexOf('url(') === 0) {
+                  url = raw.slice(4, raw.length - 1);
+                  if (url[0] === '"' || url[0] === "'") url = url.slice(1, -1);
+                }
+                let faviconDecoded = null;
+                if (url) {
+                  faviconDecoded = await new Promise((resolve) => {
+                    const img = new Image();
+                    img.onload = () => resolve(img.naturalWidth + 'x' + img.naturalHeight);
+                    img.onerror = () => resolve(false);
+                    img.src = url;
+                  });
+                }
+                return {
+                  title: row.querySelector('.name')?.textContent ?? '',
+                  href: row.href,
+                  tileLetter: tile ? tile.textContent : '',
+                  faviconHasIcon: !!(tile && tile.classList.contains('has-icon')),
+                  faviconDecoded
+                };
+              }));
+            })()`
           );
           rows.push(...rendered);
         } catch { /* page may still be committing; caller polls */ }

--- a/src/renderer/pages/newtab.js
+++ b/src/renderer/pages/newtab.js
@@ -112,14 +112,28 @@ const shortLabel = (url, title) => {
   return (parts[parts.length - 1] || (title || '').trim().split(/\s+/)[0] || '·').toLowerCase();
 };
 
+// Synced icons are the ONE thing this page draws from another device. The sync
+// design guarantees them as inert `data:image/png` payloads resolved by the
+// PUBLISHING device (2026-07-21-tab-sync-design.md), so rendering them adds no
+// data flow — but only if we refuse anything that isn't that exact shape.
+const SYNCED_ICON_PREFIX = 'data:image/png;base64,';
+
 /** Letter first, favicon when it loads — never a blank tile while a (maybe
  * slow) icon request is in flight. Private tabs skip the favicon entirely:
  * fetching a bookmarked site's icon on every new private tab would be a live
- * network trace, which private mode otherwise avoids. */
-function decorateTile(tile, item) {
+ * network trace, which private mode otherwise avoids.
+ *
+ * mode 'synced' is for tabs open on ANOTHER device, and differs twice:
+ * it accepts only the inert PNG data URL above (a remote http(s) value would
+ * turn this page into the network client the sync design exists to avoid), and
+ * it never clears a favicon on failure — a synced tab is not a bookmark, so
+ * clearFavicon would reach into whichever bookmark merely shares its URL. */
+function decorateTile(tile, item, { mode = 'local' } = {}) {
   const host = hostOf(item.url);
   tile.textContent = (host || item.title || '').trim().charAt(0).toLowerCase() || '·';
   if (isPrivate || !item.favicon) return;
+  const synced = mode === 'synced';
+  if (synced && !item.favicon.toLowerCase().startsWith(SYNCED_ICON_PREFIX)) return;
   const probe = new Image();
   probe.onload = () => {
     tile.textContent = '';
@@ -127,8 +141,11 @@ function decorateTile(tile, item) {
     tile.style.backgroundImage = `url("${item.favicon.replace(/["\\]/g, '\\$&')}")`;
   };
   // A stored favicon URL can go stale (site changed/removed it) — clear it so
-  // future loads stop retrying a dead request.
-  probe.onerror = () => window.bowserPages?.bookmarks.clearFavicon(item.url);
+  // future loads stop retrying a dead request. The letter set above survives
+  // either way, so a failed decode degrades instead of blanking the tile.
+  probe.onerror = synced
+    ? () => {}
+    : () => window.bowserPages?.bookmarks.clearFavicon(item.url);
   probe.src = item.favicon;
 }
 
@@ -204,7 +221,9 @@ function renderRemote(remoteDevices) {
       const host = hostOf(t.url);
       const tile = document.createElement('span');
       tile.className = 'tile';
-      tile.textContent = (host || t.title || '').trim().charAt(0).toLowerCase() || '·';
+      // The same letter-then-icon treatment favorites get; 'synced' restricts it
+      // to the inert PNG payload and skips the bookmark-clearing error path.
+      decorateTile(tile, t, { mode: 'synced' });
       const name = document.createElement('span');
       name.className = 'name';
       name.textContent = t.title || t.url;

--- a/test/desktop/steps/vertical-tabs.steps.js
+++ b/test/desktop/steps/vertical-tabs.steps.js
@@ -8,6 +8,10 @@ const TEST_FAVICON =
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+// The sync icon size the assertion below checks against — read from the model
+// so a change to ICON_SIZE surfaces here instead of silently passing.
+const { ICON_SIZE: SYNC_ICON_SIZE } = require('../../../src/main/tabicons-model');
+
 const poll = require('./../support/poll');
 // Rail scenarios drive real window resizes/animations, so they keep a longer
 // default deadline than the shared helper's 5s — semantics live in support/poll.
@@ -971,10 +975,20 @@ Then('remote-device tabs do not appear in the rail', async function () {
 
 Then('remote-device tabs remain available in the Quick Switcher and start page', async function () {
   await this.call('injectRemoteDevices');
+  // The start page draws the same synced icon the Quick Switcher does, and is
+  // held to the same standard: the letter tile must give way to an icon whose
+  // bytes decode. The icon is part of what we WAIT for, not something asserted
+  // afterwards — decorateTile applies has-icon inside probe.onload, so a poll
+  // that stopped at the title could return while the letter was still showing
+  // and fail intermittently. (The Quick Switcher needs no such wait: setFavicon
+  // applies its class synchronously during the render.)
   await waitForValue(
     () => this.call('remoteStartPageRows'),
-    (rows) => rows.some((row) => row.title === 'Remote press needle'),
-    'remote tab on start page'
+    (rows) => rows.some((row) =>
+      row.title === 'Remote press needle'
+      && row.faviconHasIcon
+      && row.faviconDecoded === `${SYNC_ICON_SIZE}x${SYNC_ICON_SIZE}`),
+    'decoded synced favicon on start page'
   );
 
   await this.call('openPalette');
@@ -988,10 +1002,21 @@ Then('remote-device tabs remain available in the Quick Switcher and start page',
   await sleep(100);
   await this.call('injectRemoteDevices');
   assert.equal(await this.call('editAddressInput', 'Remote press needle'), true);
-  await waitForValue(
+  const switcherRows = await waitForValue(
     () => this.call('addressResultRows'),
     (rows) => rows.some((row) => row.title === 'Remote press needle'),
     'remote tab in Quick Switcher'
+  );
+  // The synced favicon rides in the sync payload as a rasterized PNG; the
+  // receiver never refetches it from the remote site. Asserting the DECODE, not
+  // just the class, is what makes a corrupt icon fail here instead of rendering
+  // as a silently empty box.
+  const remoteRow = switcherRows.find((row) => row.title === 'Remote press needle');
+  assert.equal(remoteRow.faviconHasIcon, true, 'synced tab should render its favicon');
+  assert.equal(
+    remoteRow.faviconDecoded,
+    `${SYNC_ICON_SIZE}x${SYNC_ICON_SIZE}`,
+    'synced tab favicon bytes should decode at the sync icon size'
   );
   await this.call('closeOverlay');
   await this.call('activateTab', this.canonicalRail.workRegular, true);


### PR DESCRIPTION
Tabs open on another device show up in two places — the ⌘L Quick Switcher and the start page. The start page silently ignored their favicons, and **neither surface was guarded at all**.

## The start page drew a letter when it already had the icon

`decorateTile()` in `newtab.js` does letter-then-favicon and `favRow()` uses it, but `renderRemote()` hand-rolled the letter instead — so remote tabs were the one place on that page skipping the page's own convention. It now calls `decorateTile()` in a new `'synced'` mode that states the policy rather than implying it:

- **Only `data:image/png;base64,`**, matched case-insensitively. A synced payload is the one thing this page renders from another device, and the [sync design](docs/superpowers/specs/2026-07-21-tab-sync-design.md) guarantees inert PNG pixels resolved by the *publishing* device. Refusing anything else stops a remote `http(s)` value turning the start page into the network client that design exists to avoid.
- **Never `clearFavicon()`.** A synced tab isn't a bookmark; clearing on failure would reach into whichever bookmark merely shares its URL.
- **Letter fallback and the private-page skip are unchanged**, so a missing or undecodable icon degrades instead of blanking the tile.

No new data flow: the start page already receives the validated data URL alongside the more sensitive URL and title.

## Neither surface was guarded

The acceptance fixture carried no favicon, so `setFavicon` and `decorateTile` both took their no-icon branches — a broken synced icon was indistinguishable from a working one, and reverting either would have left the suite green.

The fixture now carries a **32×32 PNG produced by the production rasterizer itself** (`nativeImage.resize` + `toPNG`, `tabicons.js:143`), accepted by `validIconData()`. A hand-rolled 1×1 is rejected there outright and would have represented a payload sync could never deliver.

`addressResultRows()` and `remoteStartPageRows()` now report `faviconHasIcon` and `faviconDecoded`. **`faviconDecoded` is the decoded pixel size, not a boolean, deliberately** — a corrupt icon still yields a `has-icon` class and a non-empty `background-image`, so only a real decode separates it from a working one. `ICON_SIZE` is read from `tabicons-model` so a change surfaces here.

### The two surfaces are guarded differently, on purpose

The Quick Switcher **asserts**, because `setFavicon` applies its class synchronously during the render. The start page **waits** on the decoded icon, because `decorateTile` only applies `has-icon` inside `probe.onload` — a poll stopping at the title could return while the letter was still showing and fail intermittently.

## Positive controls

Each injected regression fails with its own message:

| injected | caught by |
|---|---|
| `has-icon` suppressed | *synced tab should render its favicon* |
| class intact, **bytes corrupted** | *…bytes should decode at the sync icon size* |
| `decorateTile` dropped from `renderRemote` | timeout: *decoded synced favicon on start page* |
| non-`data:` payload | same timeout — proves the policy is enforced |

The start-page control reports `tileLetter: "r", faviconHasIcon: false` — the failure mode stated plainly.

## Verification

`@F28-6` 15/15 · 984/984 unit · `substrate:check` clean · acceptance dry-run resolves 696 steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)