### PR TITLE
Heal favorites whose favicon record was never filled

### DIFF
--- a/src/main/bookmark-data.js
+++ b/src/main/bookmark-data.js
@@ -179,7 +179,39 @@ function groupFavoritesForMenu(items) {
   return { folders, ungrouped };
 }
 
+function originOf(url) {
+  try { return new URL(url).origin; } catch { return null; }
+}
+
+/** Which favorites a resolved favicon may write to, and why the two rules are
+ * asymmetric.
+ *
+ * Exact URL is authoritative: it sets OR clears, because that record is
+ * unambiguously about this page.
+ *
+ * Same origin is FILL-ONLY, and only onto a favorite that currently has no
+ * icon. Dashboards redirect — you favorite the short URL, the icon resolves on
+ * the redirect target, and an exact-match-only rule never fires, so the
+ * favorite keeps its letter with nothing left to heal it. Fill-only means a
+ * page in the origin that declares no favicon can never erase an icon another
+ * page already earned, and a good icon is never silently replaced.
+ *
+ * Returns the next items array plus `changed`, in the shape the other
+ * apply* helpers use. */
+function applyFaviconUpdate(items, { url, favicon }) {
+  const origin = favicon == null ? null : originOf(url);
+  const matches = (b) => b.url === url
+    || (origin !== null && b.favicon == null && originOf(b.url) === origin);
+  if (!items.some((b) => matches(b) && b.favicon !== favicon)) {
+    return { items, changed: false };
+  }
+  return {
+    items: items.map((b) => (matches(b) ? { ...b, favicon } : b)),
+    changed: true,
+  };
+}
+
 module.exports = {
-  addImported, applySaveFavorite, applySetFolder, applyRenameFolder, applyRemoveFolder, canonicalizeFolders,
+  addImported, applySaveFavorite, applyFaviconUpdate, applySetFolder, applyRenameFolder, applyRemoveFolder, canonicalizeFolders,
   groupFavoritesForMenu,
 };

--- a/src/main/bookmark-data.js
+++ b/src/main/bookmark-data.js
@@ -211,7 +211,17 @@ function applyFaviconUpdate(items, { url, favicon }) {
   };
 }
 
+/** Whether a tab's newly sanitized favicon may write into Favorites.
+ * Bookmarked is deliberately NOT required — the redirect heal fills a
+ * different URL on the same origin, where the tab's own flag is false.
+ * Private is required: Favorites sync-exports, and private browsing must
+ * never drive that store. */
+function mayWriteFavoriteFavicon(tab, sanitized) {
+  return !!sanitized && !tab?.private;
+}
+
 module.exports = {
-  addImported, applySaveFavorite, applyFaviconUpdate, applySetFolder, applyRenameFolder, applyRemoveFolder, canonicalizeFolders,
+  addImported, applySaveFavorite, applyFaviconUpdate, mayWriteFavoriteFavicon,
+  applySetFolder, applyRenameFolder, applyRemoveFolder, canonicalizeFolders,
   groupFavoritesForMenu,
 };

--- a/src/main/bookmarks.js
+++ b/src/main/bookmarks.js
@@ -91,10 +91,11 @@ function saveFavorite(url, title, favicon, folder) {
 function updateFavicon(url, favicon) {
   const validated = validFavicon(favicon);
   const s = ensureStore();
-  if (!s.data.items.some((b) => b.url === url && b.favicon !== validated)) return;
+  // Match policy (exact-URL authoritative, same-origin fill-only) lives in
+  // bookmark-data so it is unit-testable without a store.
+  if (!data.applyFaviconUpdate(s.data.items, { url, favicon: validated }).changed) return;
   s.update((d) => {
-    const item = d.items.find((b) => b.url === url);
-    if (item) item.favicon = validated;
+    d.items = data.applyFaviconUpdate(d.items, { url, favicon: validated }).items;
   });
 }
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -4538,8 +4538,6 @@ function toggleBookmarkForActiveTab() {
   if (rt().activeTabId) toggleBookmarkForTab(rt().activeTabId);
 }
 
-/** Per-tab favorite toggle for the context menu; same guards as the active-tab
- * version (private tabs never populate synced Favorites). */
 /** Favoriting samples tab.favicon at click time. When it hasn't resolved yet —
  * or an earlier attempt failed on a page that has since settled — the favorite
  * keeps a null icon indefinitely, because the only other writer is a LATER
@@ -4560,6 +4558,8 @@ function healFaviconForTab(tab) {
   }).catch(() => {});
 }
 
+/** Per-tab favorite toggle for the context menu; same guards as the active-tab
+ * version (private tabs never populate synced Favorites). */
 function toggleBookmarkForTab(id) {
   const tab = tabs.get(id);
   if (!tab || tab.private || !/^https?:\/\//.test(tab.url)) return;
@@ -4579,6 +4579,7 @@ function saveActiveTabAsFavorite(folder) {
   tab.bookmarked = bookmarks.isBookmarked(tab.url);
   broadcastTabs();
   scheduleMenuRebuild();
+  if (tab.bookmarked && !tab.favicon) healFaviconForTab(tab);
 }
 
 /** "Add All Open Tabs to Favorites" — mirrors toggleBookmarkForActiveTab's
@@ -4591,6 +4592,7 @@ function addAllTabsToFavorites() {
     if (!/^https?:\/\//.test(tab.url)) continue;
     if (bookmarks.isBookmarked(tab.url)) continue;
     tab.bookmarked = bookmarks.toggleBookmark(tab.url, tab.title, tab.favicon);
+    if (tab.bookmarked && !tab.favicon) healFaviconForTab(tab);
   }
   broadcastTabs();
   scheduleMenuRebuild();

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -61,7 +61,7 @@ const tabsync = require('./tabsync');
 const tabicons = require('./tabicons');
 const iconRaster = require('./icon-raster');
 const { sanitizeFavicon } = require('./favicon-sanitizer');
-const { resolvedFavicon } = require('./favicon-policy');
+const { resolvedFavicon, updateFaviconAfterDomReady } = require('./favicon-policy');
 const { effectiveTabMuted, revealTabAudio } = require('./tab-audio');
 const { validFavicon } = require('./bookmark-validate');
 const {
@@ -2898,7 +2898,11 @@ async function setTabFavicon(tab, source) {
   if (!sanitized) tab.faviconSource = previousSource;
   const changed = tab.favicon !== next;
   tab.favicon = next;
-  if (sanitized && tab.bookmarked) bookmarks.updateFavicon(tab.url, sanitized);
+  // Not gated on tab.bookmarked: the favorite that needs healing is often a
+  // DIFFERENT url on the same origin (you favorited the short one, this is the
+  // redirect target), so the tab's own bookmarked flag is false exactly when the
+  // heal is needed. updateFavicon no-ops when nothing matches.
+  if (sanitized) bookmarks.updateFavicon(tab.url, sanitized);
   if (changed) scheduleBroadcastTabs();
   if (sanitized) sync.captureTabIcon(tab).catch(() => {});
   return true;
@@ -4536,12 +4540,33 @@ function toggleBookmarkForActiveTab() {
 
 /** Per-tab favorite toggle for the context menu; same guards as the active-tab
  * version (private tabs never populate synced Favorites). */
+/** Favoriting samples tab.favicon at click time. When it hasn't resolved yet —
+ * or an earlier attempt failed on a page that has since settled — the favorite
+ * keeps a null icon indefinitely, because the only other writer is a LATER
+ * favicon event, and a settled page never emits one. So: wait out any in-flight
+ * attempt, then make exactly one fresh attempt from the page's declared links.
+ * setTabFavicon's own heal writes the result through; nothing here touches the
+ * store directly. Fire-and-forget — a favorite is saved either way. */
+function healFaviconForTab(tab) {
+  const wc = liveContents(tab);
+  if (!wc) return;
+  Promise.resolve(tab.faviconPending).catch(() => {}).then(() => {
+    if (!tabs.has(tab.id) || tab.private) return null;
+    if (tab.favicon) {
+      bookmarks.updateFavicon(tab.url, tab.favicon);
+      return null;
+    }
+    return updateFaviconAfterDomReady(tab, wc, { setTabFavicon });
+  }).catch(() => {});
+}
+
 function toggleBookmarkForTab(id) {
   const tab = tabs.get(id);
   if (!tab || tab.private || !/^https?:\/\//.test(tab.url)) return;
   tab.bookmarked = bookmarks.toggleBookmark(tab.url, tab.title, tab.favicon);
   broadcastTabs();
   scheduleMenuRebuild();
+  if (tab.bookmarked && !tab.favicon) healFaviconForTab(tab);
 }
 
 /** The `/save [folder]` command: add-only favorite of the active tab, into an

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -81,7 +81,7 @@ const { promptForCredentials } = require('./auth-dialog');
 const settings = require('./settings');
 const patron = require('./patron');
 const bookmarks = require('./bookmarks');
-const { groupFavoritesForMenu } = require('./bookmark-data');
+const { groupFavoritesForMenu, mayWriteFavoriteFavicon } = require('./bookmark-data');
 const history = require('./history');
 const { JsonStore, discardProfileStoreEntries } = require('./store');
 const { persistableEntries, sessionTabMeta } = require('./session-snapshot');
@@ -2898,13 +2898,10 @@ async function setTabFavicon(tab, source) {
   if (!sanitized) tab.faviconSource = previousSource;
   const changed = tab.favicon !== next;
   tab.favicon = next;
-  // Not gated on tab.bookmarked: the favorite that needs healing is often a
-  // DIFFERENT url on the same origin (you favorited the short one, this is the
-  // redirect target), so the tab's own bookmarked flag is false exactly when the
-  // heal is needed. Still refuse private tabs — Favorites is a sync-exported
-  // store and private browsing must not write it. updateFavicon no-ops when
-  // nothing matches.
-  if (sanitized && !tab.private) bookmarks.updateFavicon(tab.url, sanitized);
+  // Write decision lives in mayWriteFavoriteFavicon: not gated on
+  // tab.bookmarked (redirect heal), but private tabs never write Favorites.
+  // updateFavicon no-ops when nothing matches.
+  if (mayWriteFavoriteFavicon(tab, sanitized)) bookmarks.updateFavicon(tab.url, sanitized);
   if (changed) scheduleBroadcastTabs();
   if (sanitized) sync.captureTabIcon(tab).catch(() => {});
   return true;

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2901,8 +2901,10 @@ async function setTabFavicon(tab, source) {
   // Not gated on tab.bookmarked: the favorite that needs healing is often a
   // DIFFERENT url on the same origin (you favorited the short one, this is the
   // redirect target), so the tab's own bookmarked flag is false exactly when the
-  // heal is needed. updateFavicon no-ops when nothing matches.
-  if (sanitized) bookmarks.updateFavicon(tab.url, sanitized);
+  // heal is needed. Still refuse private tabs — Favorites is a sync-exported
+  // store and private browsing must not write it. updateFavicon no-ops when
+  // nothing matches.
+  if (sanitized && !tab.private) bookmarks.updateFavicon(tab.url, sanitized);
   if (changed) scheduleBroadcastTabs();
   if (sanitized) sync.captureTabIcon(tab).catch(() => {});
   return true;

--- a/src/renderer/pages/newtab.js
+++ b/src/renderer/pages/newtab.js
@@ -140,12 +140,11 @@ function decorateTile(tile, item, { mode = 'local' } = {}) {
     tile.classList.add('has-icon');
     tile.style.backgroundImage = `url("${item.favicon.replace(/["\\]/g, '\\$&')}")`;
   };
-  // A stored favicon URL can go stale (site changed/removed it) — clear it so
-  // future loads stop retrying a dead request. The letter set above survives
-  // either way, so a failed decode degrades instead of blanking the tile.
-  probe.onerror = synced
-    ? () => {}
-    : () => window.bowserPages?.bookmarks.clearFavicon(item.url);
+  // A failed decode does NOT clear the stored icon. Stored favicons are already
+  // validated PNG data URLs, so a failure here means corrupt bytes, not a dead
+  // remote request — and there is no re-fetch path, so clearing was a one-way
+  // ratchet toward a permanent letter tile. The letter set above is enough.
+  probe.onerror = () => {};
   probe.src = item.favicon;
 }
 

--- a/test/unit/bookmark-favicon-heal.test.js
+++ b/test/unit/bookmark-favicon-heal.test.js
@@ -8,7 +8,12 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { applyFaviconUpdate } = require('../../src/main/bookmark-data');
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  applyFaviconUpdate,
+  mayWriteFavoriteFavicon,
+} = require('../../src/main/bookmark-data');
 
 const PNG = 'data:image/png;base64,AAAA';
 const OTHER = 'data:image/png;base64,BBBB';
@@ -91,4 +96,41 @@ test('re-applying the same icon reports unchanged', () => {
     url: 'https://a.example/x', favicon: PNG,
   });
   assert.equal(out.changed, false, 'idempotent — no needless store write or fsync');
+});
+
+// The write decision that used to hide behind `tab.bookmarked`. Private tabs
+// can never be bookmarked, so that gate was also the private firewall. Once
+// bookmarked was dropped for the redirect heal, this predicate is what keeps
+// private-session icons out of the sync-exported Favorites store. Live browser
+// tests cannot currently reach it (private tabs never resolve a favicon in
+// practice), so the decision is unit-tested here — and positive-controlled:
+// flipping `private` to false on the private case must allow the write.
+
+test('a normal tab with a sanitized icon may write Favorites', () => {
+  assert.equal(mayWriteFavoriteFavicon({ private: false }, PNG), true);
+});
+
+test('a private tab with a sanitized icon must NOT write Favorites', () => {
+  assert.equal(mayWriteFavoriteFavicon({ private: true }, PNG), false);
+});
+
+test('no sanitized icon means no write, private or not', () => {
+  assert.equal(mayWriteFavoriteFavicon({ private: false }, null), false);
+  assert.equal(mayWriteFavoriteFavicon({ private: true }, null), false);
+  assert.equal(mayWriteFavoriteFavicon({ private: false }, undefined), false);
+});
+
+test('bookmarked is deliberately ignored — the redirect heal needs that', () => {
+  // A non-bookmarked tab on the redirect target is exactly when the fill fires.
+  assert.equal(mayWriteFavoriteFavicon({ private: false, bookmarked: false }, PNG), true);
+  assert.equal(mayWriteFavoriteFavicon({ private: true, bookmarked: true }, PNG), false);
+});
+
+test('setTabFavicon uses mayWriteFavoriteFavicon for the store write', () => {
+  // Wiring guard: the predicate is load-bearing only if the hot path calls it.
+  const main = fs.readFileSync(path.join(__dirname, '../../src/main/main.js'), 'utf8');
+  const setter = main.match(/async function setTabFavicon\(tab, source\) \{[\s\S]*?\n\}/)?.[0];
+  assert.ok(setter, 'setTabFavicon not found');
+  assert.match(setter, /mayWriteFavoriteFavicon\(tab,\s*sanitized\)/);
+  assert.doesNotMatch(setter, /if \(sanitized && !tab\.private\)/);
 });

--- a/test/unit/bookmark-favicon-heal.test.js
+++ b/test/unit/bookmark-favicon-heal.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+// Favorites were showing letter tiles because their favicon record was null,
+// not because a renderer forgot to paint one. The store could only be written
+// by a favicon event whose URL matched the favorite EXACTLY, so a dashboard
+// that redirects (favorite the short URL, icon resolves on the long one) never
+// got its icon, and a settled page never emits a second event to try again.
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { applyFaviconUpdate } = require('../../src/main/bookmark-data');
+
+const PNG = 'data:image/png;base64,AAAA';
+const OTHER = 'data:image/png;base64,BBBB';
+const fav = (url, favicon = null) => ({ id: url, url, title: url, favicon });
+
+test('an exact URL match sets the icon', () => {
+  const items = [fav('https://a.example/x')];
+  const out = applyFaviconUpdate(items, { url: 'https://a.example/x', favicon: PNG });
+  assert.equal(out.changed, true);
+  assert.equal(out.items[0].favicon, PNG);
+  assert.equal(items[0].favicon, null, 'input must not be mutated');
+});
+
+test('an exact URL match is authoritative enough to CLEAR', () => {
+  const out = applyFaviconUpdate([fav('https://a.example/x', PNG)], {
+    url: 'https://a.example/x', favicon: null,
+  });
+  assert.equal(out.changed, true);
+  assert.equal(out.items[0].favicon, null);
+});
+
+test('a same-origin favorite with no icon is filled — the redirect case', () => {
+  // Favorited the short URL; the icon resolved on the redirect target.
+  const out = applyFaviconUpdate([fav('https://search.google.com/')], {
+    url: 'https://search.google.com/search-console/inspect?resource_id=x',
+    favicon: PNG,
+  });
+  assert.equal(out.changed, true);
+  assert.equal(out.items[0].favicon, PNG);
+});
+
+test('a same-origin favorite that ALREADY has an icon is never replaced', () => {
+  const out = applyFaviconUpdate([fav('https://a.example/one', OTHER)], {
+    url: 'https://a.example/two', favicon: PNG,
+  });
+  assert.equal(out.changed, false);
+  assert.equal(out.items[0].favicon, OTHER);
+});
+
+test('a null update never travels across the origin — it cannot erase', () => {
+  // A page in the origin declaring no favicon must not wipe a good stored icon,
+  // which is the ratchet that emptied these records in the first place.
+  const out = applyFaviconUpdate([fav('https://a.example/one', PNG)], {
+    url: 'https://a.example/two', favicon: null,
+  });
+  assert.equal(out.changed, false);
+  assert.equal(out.items[0].favicon, PNG);
+});
+
+test('a different origin is never touched', () => {
+  const out = applyFaviconUpdate([fav('https://b.example/x')], {
+    url: 'https://a.example/x', favicon: PNG,
+  });
+  assert.equal(out.changed, false);
+});
+
+test('http and https are different origins', () => {
+  const out = applyFaviconUpdate([fav('http://a.example/x')], {
+    url: 'https://a.example/x', favicon: PNG,
+  });
+  assert.equal(out.changed, false, 'scheme is part of the origin');
+});
+
+test('an unparseable favorite URL is skipped, not crashed on', () => {
+  const out = applyFaviconUpdate([fav('not a url'), fav('https://a.example/x')], {
+    url: 'https://a.example/y', favicon: PNG,
+  });
+  assert.equal(out.changed, true);
+  assert.equal(out.items[0].favicon, null);
+  assert.equal(out.items[1].favicon, PNG);
+});
+
+test('no matching favorite reports unchanged so the store never writes', () => {
+  const out = applyFaviconUpdate([], { url: 'https://a.example/x', favicon: PNG });
+  assert.equal(out.changed, false);
+});
+
+test('re-applying the same icon reports unchanged', () => {
+  const out = applyFaviconUpdate([fav('https://a.example/x', PNG)], {
+    url: 'https://a.example/x', favicon: PNG,
+  });
+  assert.equal(out.changed, false, 'idempotent — no needless store write or fsync');
+});


### PR DESCRIPTION
## Summary
- Start-page letter tiles for favorites were empty `bookmarks.json` data, not a missing paint path — all four tile renderers already call `decorateTile()`.
- Same-origin **fill-only** favicon updates (exact URL still sets/clears) so a redirect target can heal the short URL you favorited, without letting a no-icon page erase an icon another page earned.
- `setTabFavicon` writes through regardless of `tab.bookmarked` (still refuses private tabs); favoriting / `/save` / Add All kick one state-driven resolve when the icon is still null; `decorateTile` no longer clears on decode failure.

## Test plan
- [x] `npm run test:unit` (994 pass, +10 heal cases)
- [x] `npm run substrate:check`
- [x] `npm run test:acceptance:dry`
- [ ] Packaged profile: open a previously iconless favorite URL (e.g. App Store Connect) and confirm the start-page tile fills after the tab icon resolves
- [ ] Favorite a short URL that redirects; confirm the favorite gains the icon from the redirect target
- [ ] Confirm a same-origin page with no favicon does **not** clear an existing favorite icon
- [ ] Confirm a private tab on a favorited origin does not write Favorites icons


Made with [Cursor](https://cursor.com)