### PR TITLE
Fix favicon recovery and external URL activation

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -305,7 +305,7 @@ echo "==> Smoke-testing packaged release regressions"
 BLANC_PACKAGED_EXECUTABLE="$PWD/dist/$NATIVE_MAC_DIR/Blanc.app/Contents/MacOS/Blanc" \
   npm run test:packaged:regressions
 
-echo "==> Checking live favicon compatibility — primary 25-site matrix"
+echo "==> Checking live favicon compatibility — primary 26-site matrix"
 BLANC_FAVICON_MATRIX=primary \
   BLANC_PACKAGED_EXECUTABLE="$PWD/dist/$NATIVE_MAC_DIR/Blanc.app/Contents/MacOS/Blanc" \
   npm run test:packaged:favicons-live

--- a/src/main/favicon-network.js
+++ b/src/main/favicon-network.js
@@ -4,8 +4,9 @@ const dns = require('node:dns');
 const http = require('node:http');
 const https = require('node:https');
 const net = require('node:net');
+const model = require('./tabicons-model');
 
-const MAX_BYTES = 256 * 1024;
+const MAX_BYTES = model.MAX_SOURCE_BYTES;
 const MAX_REDIRECTS = 5;
 const TIMEOUT_MS = 3000;
 const FAVICON_REQUEST_HEADERS = Object.freeze({
@@ -158,9 +159,8 @@ async function readIconBytesOnce(source, { signal, lookup } = {}) {
           response.resume();
           return done(null);
         }
-        const contentType = String(response.headers['content-type'] ?? '')
-          .split(';', 1)[0].trim().toLowerCase();
-        if (!/^image\/[a-z0-9][a-z0-9.+-]*$/.test(contentType)) {
+        const declaredContentType = String(response.headers['content-type'] ?? '');
+        if (!model.canReadFaviconResponse(declaredContentType, target.url.href)) {
           response.resume();
           return done(null);
         }
@@ -176,7 +176,15 @@ async function readIconBytesOnce(source, { signal, lookup } = {}) {
           if (total > MAX_BYTES) response.destroy(new Error('favicon too large'));
           else chunks.push(chunk);
         });
-        response.on('end', () => done({ contentType, bytes: Buffer.concat(chunks, total) }));
+        response.on('end', () => {
+          const bytes = Buffer.concat(chunks, total);
+          const contentType = model.faviconResponseMediaType(
+            declaredContentType,
+            target.url.href,
+            bytes,
+          );
+          done(contentType ? { contentType, bytes } : null);
+        });
         response.on('error', () => done(null));
       });
     } catch {

--- a/src/main/favicon-sanitizer.js
+++ b/src/main/favicon-sanitizer.js
@@ -81,11 +81,16 @@ async function readSameOriginSessionIcon(source, pageUrl, browsingSession, signa
     });
     if (!response.ok || requestSignal.aborted) return null;
     if (response.url && new URL(response.url).origin !== page.origin) return null;
-    const contentType = response.headers?.get?.('content-type')
-      ?.split(';', 1)[0]?.trim()?.toLowerCase();
-    if (!model.isImageMediaType(contentType)) return null;
+    const declaredContentType = response.headers?.get?.('content-type');
+    if (!model.canReadFaviconResponse(declaredContentType, current.href)) return null;
     const bytes = await readBoundedResponse(response);
-    return requestSignal.aborted || !bytes ? null : { contentType, bytes };
+    if (requestSignal.aborted || !bytes) return null;
+    const contentType = model.faviconResponseMediaType(
+      declaredContentType,
+      current.href,
+      bytes,
+    );
+    return contentType ? { contentType, bytes } : null;
   } catch {
     return null;
   } finally {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -61,7 +61,11 @@ const tabsync = require('./tabsync');
 const tabicons = require('./tabicons');
 const iconRaster = require('./icon-raster');
 const { sanitizeFavicon } = require('./favicon-sanitizer');
-const { resolvedFavicon, updateFaviconAfterDomReady } = require('./favicon-policy');
+const {
+  resolvedFavicon,
+  shouldClearFaviconOnNavigate,
+  updateFaviconAfterDomReady,
+} = require('./favicon-policy');
 const { effectiveTabMuted, revealTabAudio } = require('./tab-audio');
 const { validFavicon } = require('./bookmark-validate');
 const {
@@ -153,6 +157,7 @@ const {
 } = require('./platform-main-menu');
 const { showAboutPanel } = require('./about-panel');
 const { externalUrlActivationPlan, webUrlsFromArgv } = require('./startup-urls');
+const { bringExternalWindowToFront } = require('./window-activation');
 const { isForbiddenTopLevelUrl } = require('./top-level-url-policy');
 const {
   holdEligibility, sanitizeSnapshot, buildTabEntry, buildGroupEntry, buildBatchEntry,
@@ -318,8 +323,7 @@ if (!app.requestSingleInstanceLock()) {
     withWindowRuntime(runtime, () => {
       openExternalUrls(urlsFromArgv(commandLine));
       if (rt().window && !rt().window.isDestroyed()) {
-        if (rt().window.isMinimized()) rt().window.restore();
-        rt().window.focus();
+        bringExternalWindowToFront(app, rt().window);
       }
     });
   });
@@ -437,8 +441,7 @@ function openExternalUrl(url, { activate = true } = {}) {
   const id = createTab(url);
   if (activate) {
     setActiveTab(id);
-    if (rt().window.isMinimized()) rt().window.restore();
-    rt().window.focus();
+    bringExternalWindowToFront(app, rt().window);
   }
 }
 
@@ -2892,7 +2895,7 @@ async function setTabFavicon(tab, source) {
     !tabs.has(tab.id) ||
     tab.faviconEpoch !== epoch ||
     tab.faviconSource !== candidate ||
-    tab.url !== urlAtStart
+    (tab.url !== urlAtStart && shouldClearFaviconOnNavigate(urlAtStart, tab.url))
   ) return false;
   const next = resolvedFavicon(tab.favicon, candidate, sanitized);
   if (!sanitized) tab.faviconSource = previousSource;

--- a/src/main/tabicons-model.js
+++ b/src/main/tabicons-model.js
@@ -22,6 +22,7 @@ const MAX_SOURCE_DIMENSION = 1024;
 const MAX_SOURCE_PIXELS = 512 * 512;
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const PNG_DATA_PREFIX = 'data:image/png;base64,';
+const GENERIC_BINARY_MEDIA_TYPE = 'application/octet-stream';
 
 function canonical(value) {
   if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
@@ -82,6 +83,52 @@ function validSourcePngBytes(raw) {
   return bytes;
 }
 
+/** A bounded, structurally valid ICO container. Some otherwise ordinary
+ * sites (App Store Connect is the production case) serve `/favicon.ico` as
+ * `application/octet-stream`. We may sniff that narrow fallback only after
+ * proving it is actually an icon container; arbitrary generic downloads must
+ * never reach Chromium's image decoder merely because their URL ends in .ico. */
+function validSourceIcoBytes(raw) {
+  if (!Buffer.isBuffer(raw) && !(raw instanceof Uint8Array)) return null;
+  const bytes = Buffer.isBuffer(raw)
+    ? raw
+    : Buffer.from(raw.buffer, raw.byteOffset, raw.byteLength);
+  if (
+    bytes.length < 22 ||
+    bytes.length > MAX_SOURCE_BYTES ||
+    bytes.readUInt16LE(0) !== 0 ||
+    bytes.readUInt16LE(2) !== 1
+  ) return null;
+  const count = bytes.readUInt16LE(4);
+  if (count < 1 || count > 256) return null;
+  const directoryEnd = 6 + count * 16;
+  if (directoryEnd > bytes.length) return null;
+  for (let index = 0; index < count; index++) {
+    const entry = 6 + index * 16;
+    const width = bytes[entry] || 256;
+    const height = bytes[entry + 1] || 256;
+    const size = bytes.readUInt32LE(entry + 8);
+    const offset = bytes.readUInt32LE(entry + 12);
+    if (
+      width > MAX_SOURCE_DIMENSION ||
+      height > MAX_SOURCE_DIMENSION ||
+      width * height > MAX_SOURCE_PIXELS ||
+      size < 8 ||
+      offset < directoryEnd ||
+      offset > bytes.length - size
+    ) return null;
+    const frame = bytes.subarray(offset, offset + size);
+    const png = frame.length >= PNG_SIGNATURE.length &&
+      frame.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE);
+    // ICO frames are either PNGs or DIBs. These are the Windows bitmap header
+    // generations accepted by Chromium's ICO decoder.
+    const dib = frame.length >= 4 &&
+      [12, 40, 52, 56, 108, 124].includes(frame.readUInt32LE(0));
+    if (!png && !dib) return null;
+  }
+  return bytes;
+}
+
 function sourcePngFromDataUrl(source) {
   if (typeof source !== 'string') return null;
   const comma = source.indexOf(',');
@@ -116,6 +163,43 @@ function normalizeImageMediaType(contentType) {
 }
 
 const isImageMediaType = (contentType) => normalizeImageMediaType(contentType) !== null;
+
+function normalizedMediaType(contentType) {
+  return typeof contentType === 'string'
+    ? contentType.split(';', 1)[0].trim().toLowerCase()
+    : '';
+}
+
+function isIcoUrl(source) {
+  try {
+    return /\.ico$/i.test(new URL(source).pathname);
+  } catch {
+    return false;
+  }
+}
+
+/** Whether a response is worth reading under the existing byte ceiling.
+ * Generic binary is allowed only for a conventional `.ico` URL; callers must
+ * still pass the completed bytes through faviconResponseMediaType below. */
+function canReadFaviconResponse(contentType, source) {
+  const type = normalizedMediaType(contentType);
+  return isImageMediaType(type) ||
+    (type === GENERIC_BINARY_MEDIA_TYPE && isIcoUrl(source));
+}
+
+/** Resolve the inert media type used for decoding after a bounded read.
+ * Honest image/* labels retain their existing path. A generic `.ico` response
+ * is promoted only when its bytes pass validSourceIcoBytes. */
+function faviconResponseMediaType(contentType, source, bytes) {
+  const type = normalizedMediaType(contentType);
+  if (isImageMediaType(type)) return type;
+  if (
+    type === GENERIC_BINARY_MEDIA_TYPE &&
+    isIcoUrl(source) &&
+    validSourceIcoBytes(bytes)
+  ) return 'image/x-icon';
+  return null;
+}
 
 /** The image MIME type of a `data:` URL, or null when it isn't an image. */
 function dataUrlMediaType(source) {
@@ -378,8 +462,11 @@ module.exports = {
   canonical,
   validIconData,
   validSourcePngBytes,
+  validSourceIcoBytes,
   sourcePngFromDataUrl,
   isImageMediaType,
+  canReadFaviconResponse,
+  faviconResponseMediaType,
   dataUrlMediaType,
   imageSourceToDataUrl,
   boundedImageDataUrl,

--- a/src/main/tabicons.js
+++ b/src/main/tabicons.js
@@ -176,12 +176,21 @@ async function rasterizeSource(source, browsingSession, signal) {
         signal: requestSignal,
       });
       if (!response.ok || requestSignal.aborted) return null;
-      const contentType = response.headers?.get?.('content-type')?.split(';', 1)[0]?.trim()?.toLowerCase();
-      const isPng = contentType === 'image/png';
-      // Reject non-image responses before reading the body at all.
-      if (!isPng && !model.isImageMediaType(contentType)) return null;
+      const declaredContentType = response.headers?.get?.('content-type');
+      // App Store Connect's conventional favicon is a real bounded ICO served
+      // as application/octet-stream. The shared model admits that narrow case
+      // for both local display and this synced sidecar path, then validates the
+      // completed ICO container before Chromium sees any bytes.
+      if (!model.canReadFaviconResponse(declaredContentType, source)) return null;
       const bytes = await readBounded(response);
       if (requestSignal.aborted || !bytes) return null;
+      const contentType = model.faviconResponseMediaType(
+        declaredContentType,
+        source,
+        bytes,
+      );
+      if (!contentType) return null;
+      const isPng = contentType === 'image/png';
       if (isPng) {
         // PNG: cheap header/dimension guard, then decode natively — unchanged.
         const png = model.validSourcePngBytes(bytes);

--- a/src/main/window-activation.js
+++ b/src/main/window-activation.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** Bring the target browser window in front for an explicit OS handoff.
+ *
+ * BrowserWindow.focus() makes a window key only after its application is
+ * active. On macOS, another app opening an HTTP(S) URL can leave Blanc behind
+ * that app unless the application itself is activated with `steal: true`.
+ * Keep that stronger behavior confined to default-browser/second-instance
+ * handoffs; ordinary background tab work must never pull Blanc forward. */
+function bringExternalWindowToFront(application, window, { platform = process.platform } = {}) {
+  if (!window || window.isDestroyed?.()) return false;
+  if (window.isMinimized?.()) window.restore();
+  window.show?.();
+  window.moveTop?.();
+  if (platform === 'darwin') application?.focus?.({ steal: true });
+  window.focus?.();
+  return true;
+}
+
+module.exports = { bringExternalWindowToFront };

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2050,7 +2050,7 @@ body[data-glance-purpose="change"] .glance-picker {
 }
 .closed-clear {
   color: var(--text-dim);
-  font-family: var(--font-mono);
+  font-family: var(--font-ui);
   font-size: 10px;
   letter-spacing: 0.04em;
   text-transform: lowercase;

--- a/test/desktop/README.md
+++ b/test/desktop/README.md
@@ -52,8 +52,8 @@ npm run test:acceptance:desktop      # execute the runnable scenarios against th
 xvfb-run -a npm run test:acceptance:desktop   # ...on a headless Linux/CI box
 
 npm run test:packaged:regressions    # deterministic signed-build release regressions
-npm run test:packaged:favicons-live  # both pre-tag live favicon matrices (50 unique public sites)
-BLANC_FAVICON_MATRIX=primary npm run test:packaged:favicons-live    # original 25
+npm run test:packaged:favicons-live  # both pre-tag live favicon matrices (51 unique public sites)
+BLANC_FAVICON_MATRIX=primary npm run test:packaged:favicons-live    # original 25 + App Store Connect
 BLANC_FAVICON_MATRIX=additional npm run test:packaged:favicons-live # separate 25
 ```
 
@@ -62,11 +62,11 @@ display (macOS); prefix `xvfb-run -a` on headless Linux.
 
 The two favicon live matrices are intentionally not PR/CI checks because third-party
 availability is outside the repository's control. The fail-closed release
-script runs both non-overlapping 25-site sets against the signed packaged
+script runs two non-overlapping sets (26 primary, 25 additional) against the signed packaged
 candidate before creating the immutable source tag, alongside the deterministic
-packaged regression smoke. Each matrix runs as five cold batches of five sites:
-enough concurrency to cover background-tab behavior without turning favicon
-compatibility into an unrelated 25-homepage resource-saturation test.
+packaged regression smoke. Sites run in cold batches of at most five: enough
+concurrency to cover background-tab behavior without turning favicon
+compatibility into an unrelated homepage resource-saturation test.
 
 Google OAuth browser-compatibility coverage is intentionally separate from the
 cross-platform product scenarios here. See [`test/oauth/`](../oauth/README.md)

--- a/test/desktop/packaged-live-favicons-smoke.mjs
+++ b/test/desktop/packaged-live-favicons-smoke.mjs
@@ -46,6 +46,10 @@ const primarySites = [
   { name: 'ESPN', url: 'https://www.espn.com/', host: 'espn.com' },
   { name: 'DuckDuckGo', url: 'https://duckduckgo.com/', host: 'duckduckgo.com' },
   { name: 'Stripe', url: 'https://stripe.com/', host: 'stripe.com' },
+  // Only a large touch icon is declared; the usable /favicon.ico is valid ICO
+  // bytes served as application/octet-stream. This guards the shared local +
+  // synced fallback that browsers such as Brave already support.
+  { name: 'App Store Connect', url: 'https://appstoreconnect.apple.com/', host: 'appstoreconnect.apple.com' },
 ];
 const additionalSites = [
   { name: 'Facebook', url: 'https://www.facebook.com/', host: 'facebook.com' },
@@ -76,10 +80,10 @@ const additionalSites = [
 ];
 const matrices = { primary: primarySites, additional: additionalSites };
 const allSites = [...primarySites, ...additionalSites];
-assert.equal(primarySites.length, 25);
+assert.equal(primarySites.length, 26);
 assert.equal(additionalSites.length, 25);
-assert.equal(new Set(allSites.map(({ name }) => name.toLowerCase())).size, 50, 'favicon matrix names must be unique');
-assert.equal(new Set(allSites.map(({ host }) => host)).size, 50, 'favicon matrix hosts must be unique');
+assert.equal(new Set(allSites.map(({ name }) => name.toLowerCase())).size, 51, 'favicon matrix names must be unique');
+assert.equal(new Set(allSites.map(({ host }) => host)).size, 51, 'favicon matrix hosts must be unique');
 
 const matrixName = String(process.env.BLANC_FAVICON_MATRIX ?? '').trim().toLowerCase();
 if (matrixName && !matrices[matrixName]) {

--- a/test/desktop/release-regressions-smoke.mjs
+++ b/test/desktop/release-regressions-smoke.mjs
@@ -16,6 +16,33 @@ if (!executablePath || !fs.existsSync(executablePath)) {
   );
 }
 
+// A real 32-bit DIB-framed ICO, matching App Store Connect's production
+// container shape rather than taking the newer PNG-in-ICO decoder branch.
+const GENERIC_ICO_DIB = Buffer.alloc(40 + (32 * 32 * 4) + (32 * 4));
+GENERIC_ICO_DIB.writeUInt32LE(40, 0);
+GENERIC_ICO_DIB.writeInt32LE(32, 4);
+GENERIC_ICO_DIB.writeInt32LE(64, 8); // XOR bitmap + AND mask
+GENERIC_ICO_DIB.writeUInt16LE(1, 12);
+GENERIC_ICO_DIB.writeUInt16LE(32, 14);
+GENERIC_ICO_DIB.writeUInt32LE(32 * 32 * 4, 20);
+for (let pixel = 0; pixel < 32 * 32; pixel++) {
+  const offset = 40 + pixel * 4;
+  GENERIC_ICO_DIB[offset] = 0x20;
+  GENERIC_ICO_DIB[offset + 1] = 0x78;
+  GENERIC_ICO_DIB[offset + 2] = 0xd8;
+  GENERIC_ICO_DIB[offset + 3] = 0xff;
+}
+const GENERIC_ICO = Buffer.alloc(22 + GENERIC_ICO_DIB.length);
+GENERIC_ICO.writeUInt16LE(1, 2);
+GENERIC_ICO.writeUInt16LE(1, 4);
+GENERIC_ICO[6] = 32;
+GENERIC_ICO[7] = 32;
+GENERIC_ICO.writeUInt16LE(1, 10);
+GENERIC_ICO.writeUInt16LE(32, 12);
+GENERIC_ICO.writeUInt32LE(GENERIC_ICO_DIB.length, 14);
+GENERIC_ICO.writeUInt32LE(22, 18);
+GENERIC_ICO_DIB.copy(GENERIC_ICO, 22);
+
 const poll = async (read, predicate, message, timeoutMs = 30_000) => {
   const deadline = Date.now() + timeoutMs;
   let value;
@@ -29,6 +56,33 @@ const poll = async (read, predicate, message, timeoutMs = 30_000) => {
 
 const server = http.createServer((request, response) => {
   response.setHeader('Content-Type', 'text/html; charset=utf-8');
+  if (request.url === '/favicon.ico') {
+    // App Store Connect serves this exact combination: valid ICO bytes under
+    // a generic binary label. Blanc must sniff only after the bounded
+    // container validates, then rasterize it for local and synced surfaces.
+    response.setHeader('Content-Type', 'application/octet-stream');
+    setTimeout(() => response.end(GENERIC_ICO), 300);
+    return;
+  }
+  if (request.url === '/oversized-touch.png') {
+    response.setHeader('Content-Type', 'image/png');
+    response.end(Buffer.alloc(256 * 1024 + 1));
+    return;
+  }
+  if (request.url === '/generic-ico') {
+    response.end(`<!doctype html>
+      <title>Generic ICO probe</title>
+      <link rel="apple-touch-icon" href="/oversized-touch.png">
+      <script>location.replace('/generic-ico/login')</script>
+      <main>generic ICO probe</main>`);
+    return;
+  }
+  if (request.url === '/generic-ico/login') {
+    response.end(`<!doctype html>
+      <title>Generic ICO redirect target</title>
+      <main>generic ICO redirect target</main>`);
+    return;
+  }
   if (request.url === '/favicon') {
     response.end(`<!doctype html>
       <title>Favicon probe</title>
@@ -134,6 +188,24 @@ try {
     const faviconBytes = Buffer.from(faviconTab.favicon.split(',')[1], 'base64');
     assert.equal(faviconBytes.subarray(1, 4).toString('ascii'), 'PNG');
     assert.ok(faviconBytes.length > 100, 'sanitized favicon should contain real image bytes');
+  });
+
+  await withPackagedApp({
+    label: 'release-regressions-generic-ico',
+    launchArgs: [`${origin}/generic-ico`],
+  }, async (app) => {
+    const faviconTab = await poll(
+      () => readTabState(app).then((state) =>
+        state?.tabs?.find((tab) => tab.url === `${origin}/generic-ico/login`) ?? null),
+      (tab) => tab?.favicon?.startsWith('data:image/png;base64,'),
+      'packaged candidate did not rasterize the bounded generic-MIME ICO fallback',
+      45_000,
+    );
+    const faviconBytes = Buffer.from(faviconTab.favicon.split(',')[1], 'base64');
+    assert.equal(faviconBytes.subarray(1, 4).toString('ascii'), 'PNG');
+    assert.equal(faviconBytes.readUInt32BE(16), 32);
+    assert.equal(faviconBytes.readUInt32BE(20), 32);
+    assert.ok(faviconBytes.length > 100, 'generic-MIME ICO should contain real pixels');
   });
 
   await withPackagedApp({

--- a/test/unit/closed-tabs-ui.test.js
+++ b/test/unit/closed-tabs-ui.test.js
@@ -18,6 +18,7 @@ test('closed-tab recovery tiers remain internal implementation detail', () => {
 
 test('closed-tab rows can forget one entry or clear the undo list', () => {
   const overlay = read('src/renderer/overlay.js');
+  const styles = read('src/renderer/styles.css');
   const preload = read('src/main/preload.js');
   const main = read('src/main/main.js');
   assert.match(overlay, /browserAPI\.forgetClosedEntry\(entry\.id\)/);
@@ -27,6 +28,11 @@ test('closed-tab rows can forget one entry or clear the undo list', () => {
   assert.match(main, /chromeHandle\('tabs:forget-closed-entry'/);
   assert.match(main, /chromeHandle\('tabs:clear-closed'/);
   assert.match(main, /if \(entry\.view\) downgradeHeldEntry\(entry\)/);
+  assert.match(
+    styles,
+    /\.closed-clear\s*\{[^}]*font-family:\s*var\(--font-ui\)/,
+    'the recently-closed clear action uses Inter with the rest of the section UI',
+  );
 });
 
 test('every closed entry gets a bounded undo lifetime', () => {

--- a/test/unit/favicon-policy.test.js
+++ b/test/unit/favicon-policy.test.js
@@ -32,6 +32,20 @@ test('keeps favicon across same-origin query/hash changes', () => {
   assert.equal(shouldClearFaviconOnNavigate('https://x.com/a', 'https://x.com/a#section'), false);
 });
 
+test('the async sanitizer guard uses the same-origin policy instead of exact URL identity', () => {
+  const main = require('node:fs').readFileSync(
+    require('node:path').join(__dirname, '../../src/main/main.js'),
+    'utf8',
+  );
+  const setTabFavicon = main.match(/async function setTabFavicon\(tab, source\) \{[\s\S]*?\n\}/)?.[0];
+  assert.ok(setTabFavicon, 'setTabFavicon must remain liftable for this regression guard');
+  assert.match(
+    setTabFavicon,
+    /tab\.url !== urlAtStart && shouldClearFaviconOnNavigate\(urlAtStart, tab\.url\)/,
+    'a valid icon fetched across a same-origin redirect must still apply',
+  );
+});
+
 test('clears favicon on a cross-origin navigation', () => {
   assert.equal(shouldClearFaviconOnNavigate('https://github.com/', 'https://www.apple.com/'), true);
 });

--- a/test/unit/favicon-sanitizer-cache.test.js
+++ b/test/unit/favicon-sanitizer-cache.test.js
@@ -10,6 +10,25 @@ const pngBytes = Buffer.from(LEGACY_PNG_DATA.split(',')[1], 'base64');
 pngBytes.writeUInt32BE(32, 16);
 pngBytes.writeUInt32BE(32, 20);
 const PNG_DATA = `data:image/png;base64,${pngBytes.toString('base64')}`;
+const ICO_BYTES = (() => {
+  const dib = Buffer.alloc(40);
+  dib.writeUInt32LE(40, 0);
+  dib.writeInt32LE(16, 4);
+  dib.writeInt32LE(32, 8);
+  dib.writeUInt16LE(1, 12);
+  dib.writeUInt16LE(32, 14);
+  const bytes = Buffer.alloc(22 + dib.length);
+  bytes.writeUInt16LE(1, 2);
+  bytes.writeUInt16LE(1, 4);
+  bytes[6] = 16;
+  bytes[7] = 16;
+  bytes.writeUInt16LE(1, 10);
+  bytes.writeUInt16LE(32, 12);
+  bytes.writeUInt32LE(dib.length, 14);
+  bytes.writeUInt32LE(22, 18);
+  dib.copy(bytes, 22);
+  return bytes;
+})();
 
 const image = {
   isEmpty: () => false,
@@ -24,6 +43,20 @@ require.cache[electronId] = {
   exports: { nativeImage: { createFromBuffer: () => image } },
 };
 
+const rasterized = [];
+const rasterId = require.resolve('../../src/main/icon-raster');
+require.cache[rasterId] = {
+  id: rasterId,
+  filename: rasterId,
+  loaded: true,
+  exports: {
+    rasterize: async (dataUrl) => {
+      rasterized.push(dataUrl);
+      return PNG_DATA;
+    },
+  },
+};
+
 let attempts = 0;
 const networkId = require.resolve('../../src/main/favicon-network');
 require.cache[networkId] = {
@@ -35,7 +68,11 @@ require.cache[networkId] = {
       if (source.includes('mislabeled')) {
         return { contentType: 'image/x-icon', bytes: pngBytes };
       }
-      if (source.includes('browser-fallback') || source.includes('cross-origin')) return null;
+      if (
+        source.includes('browser-fallback') ||
+        source.includes('generic-ico') ||
+        source.includes('cross-origin')
+      ) return null;
       attempts += 1;
       return attempts === 1 ? null : { contentType: 'image/png', bytes: pngBytes };
     },
@@ -111,6 +148,24 @@ test('same-origin browser fallback fetches the exact candidate without cookies o
     assert.equal(options.referrerPolicy, 'no-referrer');
     assert.equal(options.redirect, 'error');
   }
+});
+
+test('same-origin generic-MIME ICO fallback rasterizes into local PNG pixels', async () => {
+  const source = 'https://generic-ico.example/favicon.ico';
+  const browsingSession = {
+    fetch: async (url) => response({
+      status: 200,
+      url,
+      contentType: 'application/octet-stream',
+      bytes: ICO_BYTES,
+    }),
+  };
+  assert.equal(await sanitizeFavicon(
+    source,
+    undefined,
+    { browsingSession, pageUrl: 'https://generic-ico.example/dashboard' },
+  ), PNG_DATA);
+  assert.ok(rasterized.at(-1).startsWith('data:image/x-icon;base64,'));
 });
 
 test('browser fallback refuses a cross-origin candidate before requesting it', async () => {

--- a/test/unit/tabicons-model.test.js
+++ b/test/unit/tabicons-model.test.js
@@ -17,6 +17,25 @@ const PNG_2X = pngAtSize(PNG_A, m.ICON_SIZE);
 const pngBBytes = Buffer.from(PNG_A.split(',')[1], 'base64');
 pngBBytes[pngBBytes.length - 1] ^= 1;
 const PNG_B = `data:image/png;base64,${pngBBytes.toString('base64')}`;
+const ICO_BYTES = (() => {
+  const dib = Buffer.alloc(40);
+  dib.writeUInt32LE(40, 0); // BITMAPINFOHEADER
+  dib.writeInt32LE(16, 4);
+  dib.writeInt32LE(32, 8); // XOR + mask height
+  dib.writeUInt16LE(1, 12);
+  dib.writeUInt16LE(32, 14);
+  const bytes = Buffer.alloc(22 + dib.length);
+  bytes.writeUInt16LE(1, 2); // icon resource
+  bytes.writeUInt16LE(1, 4); // one image
+  bytes[6] = 16;
+  bytes[7] = 16;
+  bytes.writeUInt16LE(1, 10);
+  bytes.writeUInt16LE(32, 12);
+  bytes.writeUInt32LE(dib.length, 14);
+  bytes.writeUInt32LE(22, 18);
+  dib.copy(bytes, 22);
+  return bytes;
+})();
 const icon = (over = {}) => ({ url: 'https://a.example/', data: PNG_A, ...over });
 const entry = (over = {}) => ({ updatedAt: NOW - HOUR, icons: [icon()], ...over });
 
@@ -52,6 +71,26 @@ test('source PNG guard rejects alternate formats and dimension bombs before deco
     m.sourcePngFromDataUrl(`data:image/png;base64,${hugeWidth.toString('base64')}`),
     null
   );
+});
+
+test('a bounded generic .ico response is sniffed only after its container validates', () => {
+  const source = 'https://appstoreconnect.apple.com/favicon.ico';
+  assert.equal(m.validSourceIcoBytes(ICO_BYTES), ICO_BYTES);
+  assert.equal(m.canReadFaviconResponse('application/octet-stream', source), true);
+  assert.equal(
+    m.faviconResponseMediaType('application/octet-stream', source, ICO_BYTES),
+    'image/x-icon',
+  );
+
+  const corrupt = Buffer.from(ICO_BYTES);
+  corrupt.writeUInt32LE(corrupt.length + 1, 18);
+  assert.equal(m.validSourceIcoBytes(corrupt), null);
+  assert.equal(m.faviconResponseMediaType('application/octet-stream', source, corrupt), null);
+  assert.equal(
+    m.canReadFaviconResponse('application/octet-stream', 'https://example.com/icon.png'),
+    false,
+  );
+  assert.equal(m.canReadFaviconResponse('text/html', source), false);
 });
 
 test('image media type detection accepts real favicon MIME types and rejects others', () => {

--- a/test/unit/tabicons.test.js
+++ b/test/unit/tabicons.test.js
@@ -10,6 +10,25 @@ pngBytes.writeUInt32BE(32, 16);
 pngBytes.writeUInt32BE(32, 20);
 const PNG_DATA = `data:image/png;base64,${pngBytes.toString('base64')}`;
 const PNG_BYTES = Buffer.from(PNG_DATA.split(',')[1], 'base64');
+const ICO_BYTES = (() => {
+  const dib = Buffer.alloc(40);
+  dib.writeUInt32LE(40, 0);
+  dib.writeInt32LE(16, 4);
+  dib.writeInt32LE(32, 8);
+  dib.writeUInt16LE(1, 12);
+  dib.writeUInt16LE(32, 14);
+  const bytes = Buffer.alloc(22 + dib.length);
+  bytes.writeUInt16LE(1, 2);
+  bytes.writeUInt16LE(1, 4);
+  bytes[6] = 16;
+  bytes[7] = 16;
+  bytes.writeUInt16LE(1, 10);
+  bytes.writeUInt16LE(32, 12);
+  bytes.writeUInt32LE(dib.length, 14);
+  bytes.writeUInt32LE(22, 18);
+  dib.copy(bytes, 22);
+  return bytes;
+})();
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-tabicons-'));
 const requests = [];
 let decodeCount = 0;
@@ -199,6 +218,39 @@ test('non-PNG favicons rasterize through the renderer seam and store the result'
     const icons = tabicons.exportForSync(ctx).devices['device-a'].icons;
     assert.ok(icons.some((i) => i.url === httpSvg.url && i.data === PNG_DATA));
     assert.ok(icons.some((i) => i.url === inlineSvg.url && i.data === PNG_DATA));
+  } finally {
+    tabicons.setRasterizer(null);
+  }
+});
+
+test('a generic-MIME ICO fallback rasterizes into the synced tab sidecar', async () => {
+  const seen = [];
+  tabicons.setRasterizer(async (dataUrl) => {
+    seen.push(dataUrl);
+    return PNG_DATA;
+  });
+  try {
+    const tab = {
+      url: 'https://appstoreconnect.apple.com/',
+      favicon: 'https://appstoreconnect.apple.com/favicon.ico',
+      private: false,
+      view: {
+        webContents: {
+          session: {
+            fetch: async () => response('application/octet-stream', ICO_BYTES),
+          },
+        },
+      },
+    };
+    tabicons.setSnapshotProvider(() => ({ tabList: [tab] }));
+
+    assert.equal(await tabicons.captureTab(tab, ctx), true);
+    assert.equal(seen.length, 1);
+    assert.ok(seen[0].startsWith('data:image/x-icon;base64,'));
+    assert.deepEqual(
+      tabicons.exportForSync(ctx).devices['device-a'].icons.find(({ url }) => url === tab.url),
+      { url: tab.url, data: PNG_DATA },
+    );
   } finally {
     tabicons.setRasterizer(null);
   }

--- a/test/unit/window-activation.test.js
+++ b/test/unit/window-activation.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { bringExternalWindowToFront } = require('../../src/main/window-activation');
+
+function fixture({ minimized = false, destroyed = false } = {}) {
+  const calls = [];
+  const application = {
+    focus(options) { calls.push(['app.focus', options]); },
+  };
+  const window = {
+    isDestroyed: () => destroyed,
+    isMinimized: () => minimized,
+    restore: () => calls.push(['restore']),
+    show: () => calls.push(['show']),
+    moveTop: () => calls.push(['moveTop']),
+    focus: () => calls.push(['window.focus']),
+  };
+  return { application, window, calls };
+}
+
+test('macOS external URL handoff restores, raises, activates, and focuses Blanc', () => {
+  const { application, window, calls } = fixture({ minimized: true });
+  assert.equal(
+    bringExternalWindowToFront(application, window, { platform: 'darwin' }),
+    true,
+  );
+  assert.deepEqual(calls, [
+    ['restore'],
+    ['show'],
+    ['moveTop'],
+    ['app.focus', { steal: true }],
+    ['window.focus'],
+  ]);
+});
+
+test('other platforms raise the handoff window without macOS steal activation', () => {
+  const { application, window, calls } = fixture();
+  assert.equal(
+    bringExternalWindowToFront(application, window, { platform: 'win32' }),
+    true,
+  );
+  assert.deepEqual(calls, [['show'], ['moveTop'], ['window.focus']]);
+});
+
+test('a destroyed handoff window is a safe no-op', () => {
+  const { application, window, calls } = fixture({ destroyed: true });
+  assert.equal(
+    bringExternalWindowToFront(application, window, { platform: 'darwin' }),
+    false,
+  );
+  assert.deepEqual(calls, []);
+});


### PR DESCRIPTION
Fix App Store Connect favicon decoding and same-origin redirect recovery across local and synced surfaces. Also use Inter for the recently closed clear action and bring Blanc forward for external URL handoffs.\n\nVerified with 1009 unit tests, packaged regression smoke, live App Store Connect canary, native macOS foreground handoff, signature verification, and Electron fuse verification.