### PR TITLE
Prepare Blanc 1.8.0 release

### DIFF
--- a/docs/press/release-notes/v1.8.0.md
+++ b/docs/press/release-notes/v1.8.0.md
@@ -1,0 +1,19 @@
+# Blanc 1.8.0
+
+## Added
+
+- Named Workspaces let Blanc Patrons save a window's tabs and groups, switch between those sets in place, and rename or delete them from the command panel. Workspaces autosave as you browse and return after a relaunch; the `/workspace` command provides the same controls from the keyboard.
+
+- Patron Settings now includes a direct checkout path for becoming a Patron, with monthly and annual options. Existing Patrons can still enter their Polar license key when activating another device or reinstalling Blanc.
+
+## Changed
+
+- When another app asks Blanc to open a website, Blanc now brings the destination window to the front instead of loading the page behind whatever you were using.
+
+## Fixed
+
+- Website icons are substantially more reliable across the interface. Blanc now recovers icons through redirects and generic ICO responses such as App Store Connect's, heals previously iconless Favorites, paints Favorite results in the Quick Switcher, and carries decoded PNG icons through Profile Sync to the start page and Quick Switcher on another device.
+
+- Named Workspaces now protect private tabs and unsaved windows during a switch, keep editor focus stable while tab state updates, and avoid the save-first dead end when only private tabs are at risk.
+
+- The Recently Closed section's Clear action now uses Blanc's interface typeface consistently.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -6,7 +6,7 @@ import MemoryChart from '../components/MemoryChart.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 import releaseData from '../data/releases.json';
 
-const VERSION = '1.7.0';
+const VERSION = '1.8.0';
 const TAG = `v${VERSION}`;
 /* Wherever this page states a version and a date together, the date is that
    version's own ship date — read from the generated changelog data rather than

--- a/spec/acceptance/tabs-and-groups.feature
+++ b/spec/acceptance/tabs-and-groups.feature
@@ -50,6 +50,7 @@ Feature: Tabs and tab groups
   Scenario: Recently closed is a bounded undo list the user can clear
     Given recently closed contains "older.example" and "newer.example"
     When I open the command palette
+    And I unfold recently closed
     Then recently closed exposes no recovery-tier jargon
     When I forget the newest recently closed tab
     Then recently closed contains only "older.example"

--- a/test/desktop/steps/runnable.steps.js
+++ b/test/desktop/steps/runnable.steps.js
@@ -118,8 +118,19 @@ Given('recently closed contains {string} and {string}', async function (older, n
   );
 });
 
-Then('recently closed exposes no recovery-tier jargon', async function () {
+When('I unfold recently closed', async function () {
   await openOverlaySurface(this, 'openPalette', 'palette');
+  const page = await overlayPage();
+  const header = page.locator('.island-ghead').filter({ hasText: 'recently closed' });
+  await header.waitFor({ state: 'visible' });
+  if (!await header.locator('.caret').evaluate((caret) => caret.classList.contains('open'))) {
+    await header.click();
+  }
+  const rows = page.locator('.closed-row');
+  await rows.first().waitFor({ state: 'visible' });
+});
+
+Then('recently closed exposes no recovery-tier jargon', async function () {
   const page = await overlayPage();
   const rows = page.locator('.closed-row');
   await rows.first().waitFor({ state: 'visible' });

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.7.0');
+  assert.equal(packageVersion, '1.8.0');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),


### PR DESCRIPTION
## Summary
- bump Blanc from 1.7.0 to 1.8.0; Electron remains current at 43.4.1
- add release notes led by Named Workspaces, Patron checkout, and favicon reliability
- advance the press download pin to 1.8.0
- update the Recently Closed acceptance flow to explicitly unfold the section after its intended folded-by-default change

## Verification
- npm run release:verify:press
- 1,012/1,012 unit tests
- 116/116 desktop acceptance scenarios; 703/703 steps
- cold launch, Google OAuth, DNS, production dependency audit, and 17-page site build all passed
- targeted @F2-7: 1 scenario, 9 steps passed