### PR TITLE
Fix upfront Patron gate for workspaces

### DIFF
--- a/docs/press/release-notes/v1.8.1.md
+++ b/docs/press/release-notes/v1.8.1.md
@@ -1,0 +1,5 @@
+# Blanc 1.8.1
+
+## Fixed
+
+- Named Workspaces now stops non-Patrons at an upfront Patron prompt and links directly to Patron Settings instead of opening a workspace name editor that only fails after submission. The main process still re-checks every create/save write, while existing workspaces remain available to lapsed Patrons.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@ghostery/adblocker-electron": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",

--- a/site/src/pages/press.astro
+++ b/site/src/pages/press.astro
@@ -6,7 +6,7 @@ import MemoryChart from '../components/MemoryChart.astro';
 import slashCommandCopy from '../../../copy/slash-commands.json';
 import releaseData from '../data/releases.json';
 
-const VERSION = '1.8.0';
+const VERSION = '1.8.1';
 const TAG = `v${VERSION}`;
 /* Wherever this page states a version and a date together, the date is that
    version's own ship date — read from the generated changelog data rather than

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -151,6 +151,10 @@
   let createWorkspaceValue = '';
   let pendingSaveAsWorkspace = false;
   let saveAsWorkspaceValue = '';
+  // Non-Patrons can discover the surface, but creation entry stops here —
+  // before a name editor implies that the paid write is available. This row
+  // links to Patron Settings; main still re-checks the entitlement on commit.
+  let workspacePatronGateVisible = false;
   // Scratch guard (Task 9 follow-up): set when an open/create attempt comes
   // back {error:'unsaved-scratch'} — this window is unbound and holds real
   // tabs, so main refused to switch it without confirming first. Carries
@@ -624,6 +628,7 @@
   function applyWorkspacesPayload(payload) {
     wsPatronActive = !!payload?.patronActive;
     wsWorkspaces = Array.isArray(payload?.items) ? payload.items : [];
+    if (wsPatronActive) workspacePatronGateVisible = false;
     syncFooterWorkspace();
     if (workspaceSwitcherOpen) paintWorkspaceSwitcher();
   }
@@ -660,11 +665,13 @@
     createWorkspaceValue = '';
     pendingSaveAsWorkspace = false;
     saveAsWorkspaceValue = '';
+    workspacePatronGateVisible = false;
     claimEditorFocus = false;
   }
 
   function workspacePopoverEditing() {
-    return pendingCreateWorkspace
+    return workspacePatronGateVisible
+      || pendingCreateWorkspace
       || pendingSaveAsWorkspace
       || pendingRenameWorkspaceId != null
       || pendingDeleteWorkspaceId != null;
@@ -748,6 +755,27 @@
     wsSwitcherSaveAs.hidden = !visible;
   }
 
+  function renderWorkspacePatronGateRow() {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'ws-switcher-row workspace-row';
+    row.setAttribute('role', 'menuitem');
+    row.setAttribute('aria-label', 'Open Patron Settings for Named Workspaces');
+    const name = document.createElement('span');
+    name.className = 'ws-switcher-name';
+    name.textContent = 'Creating workspaces needs Blanc Patron';
+    const action = document.createElement('span');
+    action.className = 'ws-switcher-n';
+    action.textContent = 'settings →';
+    row.append(name, action);
+    row.addEventListener('click', () => {
+      closeWorkspaceSwitcher();
+      window.browserAPI.closeOverlay();
+      window.browserAPI.openPage('settings', 'patron');
+    });
+    return row;
+  }
+
   /** Shared name field for create / save-as / rename inside the popover. */
   function renderSwitcherNameInput({
     value, placeholder, ariaLabel, onInput, onCommit, onCancel, selectAll, caret, className,
@@ -772,8 +800,15 @@
   }
 
   function renderWorkspaceSwitcherList() {
-    const naming = pendingCreateWorkspace || pendingSaveAsWorkspace;
-    setSwitcherCommandVisibility(!naming);
+    const exclusiveState = workspacePatronGateVisible
+      || pendingCreateWorkspace
+      || pendingSaveAsWorkspace;
+    setSwitcherCommandVisibility(!exclusiveState);
+
+    if (workspacePatronGateVisible) {
+      workspaceSwitcherList.replaceChildren(renderWorkspacePatronGateRow());
+      return;
+    }
 
     if (pendingCreateWorkspace) {
       const wrap = document.createElement('div');
@@ -981,10 +1016,22 @@
     });
   }
 
+  /** Renderer-side UX gate only. Main remains authoritative and repeats the
+   * entitlement check before every create/save write. Existing workspaces are
+   * deliberately not gated, so a lapsed Patron keeps access to their data. */
+  function guardWorkspaceCreationEntry() {
+    if (wsPatronActive) return false;
+    clearWorkspacePopoverEditors();
+    workspacePatronGateVisible = true;
+    openWorkspaceSwitcher();
+    return true;
+  }
+
   /** "Save this window as…" — name the capture inside the popover, then
    * commit via saveWorkspaceAs (same path /workspace <name> uses). Also the
    * scratch guard's "save first" step. */
   function beginSaveWorkspace() {
+    if (guardWorkspaceCreationEntry()) return;
     pendingCreateWorkspace = false;
     createWorkspaceValue = '';
     pendingRenameWorkspaceId = null;
@@ -1019,6 +1066,7 @@
 
   /** "new…" — create an empty workspace; name field stays in the popover. */
   function beginCreateWorkspace() {
+    if (guardWorkspaceCreationEntry()) return;
     pendingSaveAsWorkspace = false;
     saveAsWorkspaceValue = '';
     pendingRenameWorkspaceId = null;
@@ -1266,6 +1314,29 @@
 
   // --- Slash commands ---
 
+  function runWorkspaceCommand(input) {
+    const name = (input ?? '').replace(/^\/workspace\s*/, '').trim();
+    if (!name) {
+      // Reveal the footer switcher — the resting list no longer carries a
+      // workspaces section to scroll to.
+      openWorkspaceSwitcher();
+      return;
+    }
+    // Case-insensitive switch-if-exists stays lapse-safe. Only a new name is
+    // creation, so stop that path at the upfront renderer gate before an IPC
+    // round-trip; main repeats the entitlement check as the authority.
+    const existing = wsWorkspaces.find((w) => w.name.toLowerCase() === name.toLowerCase());
+    if (existing) { switchToWorkspace(existing); return; }
+    if (guardWorkspaceCreationEntry()) return;
+    runWorkspaceMutation(window.browserAPI.saveWorkspaceAs(name), {
+      context: { name },
+      // Scratch guard's "save first" lands here: a save that succeeds while
+      // a guard is awaiting one means THIS window is now bound. Retry still
+      // uses force:false so remaining private pages re-trip the guard.
+      onSuccess: () => { if (pendingScratchGuard?.awaitingSave) retryScratchGuard(false); },
+    });
+  }
+
   const COMMANDS = [
     // Also listed on blanc://shortcuts/ — update SLASH_COMMANDS in
     // pages/shortcuts.js when adding or changing a command here.
@@ -1306,28 +1377,7 @@
       window.browserAPI.cycleTheme(requested || null);
     } },
     { cmd: '/patron', hint: 'Support Blanc with a Patron subscription', run: () => window.browserAPI.openPage('settings', 'patron') },
-    { cmd: '/workspace', hint: 'Switch to a named workspace, or type a new name to save this window', keepOverlay: true, clearInput: true, run: (input) => {
-      const name = (input ?? '').replace(/^\/workspace\s*/, '').trim();
-      if (!name) {
-        // Reveal the footer switcher — the resting list no longer carries a
-        // workspaces section to scroll to.
-        openWorkspaceSwitcher();
-        return;
-      }
-      // Case-insensitive switch-if-exists; create (Patron-gated) if not —
-      // never create-only, and never /group-style find-or-create-a-group.
-      const existing = wsWorkspaces.find((w) => w.name.toLowerCase() === name.toLowerCase());
-      if (existing) { switchToWorkspace(existing); return; }
-      runWorkspaceMutation(window.browserAPI.saveWorkspaceAs(name), {
-        context: { name },
-        // Scratch guard's "save first" (beginScratchGuardSaveFirst) lands
-        // here: a save that succeeds while a guard is awaiting one means
-        // THIS window is now bound, so persistable tabs are covered. Retry
-        // still uses force:false — private pages remaining will re-trip,
-        // and retryScratchGuard's onUnsavedScratch re-shows the confirm.
-        onSuccess: () => { if (pendingScratchGuard?.awaitingSave) retryScratchGuard(false); },
-      });
-    } },
+    { cmd: '/workspace', hint: 'Switch to a named workspace, or type a new name to save this window', keepOverlay: true, clearInput: true, run: runWorkspaceCommand },
   ];
 
   function runCommand(command) {

--- a/test/unit/press-kit.test.js
+++ b/test/unit/press-kit.test.js
@@ -51,7 +51,7 @@ test('the public press page keeps its release links, indexability, and no-analyt
     fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
   ).version;
 
-  assert.equal(packageVersion, '1.8.0');
+  assert.equal(packageVersion, '1.8.1');
   assert.match(page, new RegExp(`const VERSION = '${packageVersion.replaceAll('.', '\\.')}'`));
   assert.equal(
     fs.existsSync(path.join(ROOT, `docs/press/release-notes/v${packageVersion}.md`)),

--- a/test/unit/workspaces-patron-entry.test.js
+++ b/test/unit/workspaces-patron-entry.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+// Regression: the main process always owned the Named Workspaces entitlement
+// check, but the overlay let non-Patrons enter a name before the write failed.
+// Entry now stops on an actionable Patron row while existing workspaces remain
+// lapse-safe. Main's duplicate check remains the security boundary.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.resolve(__dirname, '../..');
+const overlaySource = fs.readFileSync(path.join(ROOT, 'src/renderer/overlay.js'), 'utf8');
+
+const lift = (name) => {
+  const re = new RegExp(`function ${name}\\([^)]*\\) \\{[\\s\\S]*?\\n  \\}`);
+  const found = overlaySource.match(re)?.[0];
+  assert.ok(found, `${name} not found in overlay.js — update this test with it`);
+  return found;
+};
+
+test('non-Patron create and save-as entry stop before either name editor opens', () => {
+  for (const name of ['beginCreateWorkspace', 'beginSaveWorkspace']) {
+    const calls = [];
+    const sandbox = {
+      guardWorkspaceCreationEntry: () => { calls.push('gate'); return true; },
+      openWorkspaceSwitcher: () => calls.push('editor'),
+      pendingCreateWorkspace: false,
+      createWorkspaceValue: '',
+      pendingSaveAsWorkspace: false,
+      saveAsWorkspaceValue: '',
+      pendingRenameWorkspaceId: null,
+      workspaceEditValue: '',
+      pendingDeleteWorkspaceId: null,
+      claimEditorFocus: false,
+    };
+    vm.runInNewContext(`${lift(name)}; this.run = ${name};`, sandbox);
+    sandbox.run();
+    assert.deepEqual(calls, ['gate'], `${name} must stop at the upfront gate`);
+    assert.equal(sandbox.pendingCreateWorkspace, false);
+    assert.equal(sandbox.pendingSaveAsWorkspace, false);
+    assert.equal(sandbox.claimEditorFocus, false);
+  }
+});
+
+test('active Patrons still reach both workspace name editors', () => {
+  for (const name of ['beginCreateWorkspace', 'beginSaveWorkspace']) {
+    const calls = [];
+    const sandbox = {
+      guardWorkspaceCreationEntry: () => false,
+      openWorkspaceSwitcher: () => calls.push('editor'),
+      pendingCreateWorkspace: false,
+      createWorkspaceValue: '',
+      pendingSaveAsWorkspace: false,
+      saveAsWorkspaceValue: '',
+      pendingRenameWorkspaceId: null,
+      workspaceEditValue: '',
+      pendingDeleteWorkspaceId: null,
+      claimEditorFocus: false,
+    };
+    vm.runInNewContext(`${lift(name)}; this.run = ${name};`, sandbox);
+    sandbox.run();
+    assert.deepEqual(calls, ['editor']);
+    assert.equal(name === 'beginCreateWorkspace'
+      ? sandbox.pendingCreateWorkspace
+      : sandbox.pendingSaveAsWorkspace, true);
+    assert.equal(sandbox.claimEditorFocus, true);
+  }
+});
+
+test('/workspace keeps existing rows lapse-safe but gates a new name upfront', () => {
+  const existing = { id: 'ws_work', name: 'Work' };
+  const calls = [];
+  const sandbox = {
+    wsWorkspaces: [existing],
+    pendingScratchGuard: null,
+    openWorkspaceSwitcher: () => calls.push(['open-switcher']),
+    switchToWorkspace: (workspace) => calls.push(['switch', workspace.id]),
+    guardWorkspaceCreationEntry: () => { calls.push(['gate']); return true; },
+    runWorkspaceMutation: () => calls.push(['mutation']),
+    retryScratchGuard: () => {},
+    window: { browserAPI: { saveWorkspaceAs: (name) => calls.push(['save', name]) } },
+  };
+  vm.runInNewContext(`${lift('runWorkspaceCommand')}; this.run = runWorkspaceCommand;`, sandbox);
+
+  sandbox.run('/workspace work');
+  assert.deepEqual(calls, [['switch', 'ws_work']], 'lapsed users retain their existing data');
+
+  calls.length = 0;
+  sandbox.run('/workspace Personal project');
+  assert.deepEqual(calls, [['gate']], 'a new name stops before saveWorkspaceAs IPC');
+});
+
+test('/workspace sends a new name to main only after the renderer gate passes', () => {
+  const calls = [];
+  const sandbox = {
+    wsWorkspaces: [],
+    pendingScratchGuard: null,
+    openWorkspaceSwitcher: () => calls.push(['open-switcher']),
+    switchToWorkspace: () => {},
+    guardWorkspaceCreationEntry: () => false,
+    runWorkspaceMutation: (promise) => calls.push(['mutation', promise]),
+    retryScratchGuard: () => {},
+    window: { browserAPI: { saveWorkspaceAs: (name) => { calls.push(['save', name]); return 'pending'; } } },
+  };
+  vm.runInNewContext(`${lift('runWorkspaceCommand')}; this.run = runWorkspaceCommand;`, sandbox);
+  sandbox.run('/workspace Deep Work');
+  assert.deepEqual(calls, [['save', 'Deep Work'], ['mutation', 'pending']]);
+});
+
+test('the Patron gate row links directly to the Patron Settings section', () => {
+  const calls = [];
+  class El {
+    constructor(tag) { this.tagName = tag; this.children = []; this.listeners = {}; }
+    setAttribute(name, value) { this[name] = value; }
+    append(...children) { this.children.push(...children); }
+    addEventListener(name, fn) { this.listeners[name] = fn; }
+  }
+  const sandbox = {
+    document: { createElement: (tag) => new El(tag) },
+    closeWorkspaceSwitcher: () => calls.push(['close-switcher']),
+    window: { browserAPI: {
+      closeOverlay: () => calls.push(['close-overlay']),
+      openPage: (...args) => calls.push(['open-page', ...args]),
+    } },
+  };
+  vm.runInNewContext(
+    `${lift('renderWorkspacePatronGateRow')}; this.render = renderWorkspacePatronGateRow;`,
+    sandbox,
+  );
+  const row = sandbox.render();
+  assert.equal(row.children[0].textContent, 'Creating workspaces needs Blanc Patron');
+  assert.equal(row.children[1].textContent, 'settings →');
+  row.listeners.click();
+  assert.deepEqual(calls, [
+    ['close-switcher'],
+    ['close-overlay'],
+    ['open-page', 'settings', 'patron'],
+  ]);
+});
+
+test('the gate row replaces editor commands instead of appearing beside them', () => {
+  const render = lift('renderWorkspaceSwitcherList');
+  assert.match(render, /exclusiveState = workspacePatronGateVisible/);
+  assert.match(render, /setSwitcherCommandVisibility\(!exclusiveState\)/);
+  assert.ok(render.indexOf('if (workspacePatronGateVisible)')
+    < render.indexOf('if (pendingCreateWorkspace)'),
+  'the Patron row must win before either editor is rendered');
+});


### PR DESCRIPTION
## Urgent 1.8.1 hotfix
- stop non-Patrons before `new…` / `save as…` name editors open
- stop `/workspace <new name>` before the save IPC
- show an actionable row that opens Patron Settings and checkout
- preserve lapse-safe list/open/rename/remove behavior
- retain both authoritative main-process entitlement checks
- bump the immutable hotfix candidate to 1.8.1 with release notes

## Verification
- targeted workspace + press tests: 34/34
- acceptance dry-run: 116 scenarios / 703 steps resolved
- full release verification in progress