### PR TITLE
Refine inactive workspace Patron surface

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -6928,6 +6928,11 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
     applyAppIcon();
     applyVerticalTabsWidth(s.verticalTabsWidth);
     applyTabLayout(s.tabLayout);
+    // setPatron() uses this same fan-out after activation and each scheduled
+    // subscription validation. Re-project the derived entitlement so an open
+    // Workspaces popover hides or restores creation controls immediately;
+    // never expose the Patron record itself to chrome.
+    broadcastWorkspacesUpdated();
     // WebRTC reapply is unconditional — setWebRTCIPHandlingPolicy is a cheap,
     // idempotent per-tab call and settings writes are infrequent/user-initiated.
     applyWebrtcPolicyToAllTabs();

--- a/src/renderer/overlay.js
+++ b/src/renderer/overlay.js
@@ -151,10 +151,6 @@
   let createWorkspaceValue = '';
   let pendingSaveAsWorkspace = false;
   let saveAsWorkspaceValue = '';
-  // Non-Patrons can discover the surface, but creation entry stops here —
-  // before a name editor implies that the paid write is available. This row
-  // links to Patron Settings; main still re-checks the entitlement on commit.
-  let workspacePatronGateVisible = false;
   // Scratch guard (Task 9 follow-up): set when an open/create attempt comes
   // back {error:'unsaved-scratch'} — this window is unbound and holds real
   // tabs, so main refused to switch it without confirming first. Carries
@@ -628,7 +624,6 @@
   function applyWorkspacesPayload(payload) {
     wsPatronActive = !!payload?.patronActive;
     wsWorkspaces = Array.isArray(payload?.items) ? payload.items : [];
-    if (wsPatronActive) workspacePatronGateVisible = false;
     syncFooterWorkspace();
     if (workspaceSwitcherOpen) paintWorkspaceSwitcher();
   }
@@ -665,13 +660,11 @@
     createWorkspaceValue = '';
     pendingSaveAsWorkspace = false;
     saveAsWorkspaceValue = '';
-    workspacePatronGateVisible = false;
     claimEditorFocus = false;
   }
 
   function workspacePopoverEditing() {
-    return workspacePatronGateVisible
-      || pendingCreateWorkspace
+    return pendingCreateWorkspace
       || pendingSaveAsWorkspace
       || pendingRenameWorkspaceId != null
       || pendingDeleteWorkspaceId != null;
@@ -755,7 +748,7 @@
     wsSwitcherSaveAs.hidden = !visible;
   }
 
-  function renderWorkspacePatronGateRow() {
+  function renderWorkspacePatronGateRow(hasExisting = wsWorkspaces.length > 0) {
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'ws-switcher-row workspace-row';
@@ -763,10 +756,12 @@
     row.setAttribute('aria-label', 'Open Patron Settings for Named Workspaces');
     const name = document.createElement('span');
     name.className = 'ws-switcher-name';
-    name.textContent = 'Creating workspaces needs Blanc Patron';
+    name.textContent = hasExisting
+      ? 'Renew Patron to create another'
+      : 'Named Workspaces — Patron';
     const action = document.createElement('span');
     action.className = 'ws-switcher-n';
-    action.textContent = 'settings →';
+    action.textContent = hasExisting ? '→' : 'unlock →';
     row.append(name, action);
     row.addEventListener('click', () => {
       closeWorkspaceSwitcher();
@@ -800,15 +795,11 @@
   }
 
   function renderWorkspaceSwitcherList() {
-    const exclusiveState = workspacePatronGateVisible
-      || pendingCreateWorkspace
-      || pendingSaveAsWorkspace;
-    setSwitcherCommandVisibility(!exclusiveState);
-
-    if (workspacePatronGateVisible) {
-      workspaceSwitcherList.replaceChildren(renderWorkspacePatronGateRow());
-      return;
-    }
+    const naming = pendingCreateWorkspace || pendingSaveAsWorkspace;
+    // Inactive users keep the discoverable Workspaces surface, but creation
+    // controls never masquerade as enabled. Their single CTA is rendered in
+    // the list below; existing rows remain lapse-safe.
+    setSwitcherCommandVisibility(wsPatronActive && !naming);
 
     if (pendingCreateWorkspace) {
       const wrap = document.createElement('div');
@@ -846,12 +837,14 @@
 
     const nodes = [];
     if (wsWorkspaces.length === 0) {
-      const empty = document.createElement('div');
-      empty.className = 'ws-switcher-empty';
-      empty.textContent = wsPatronActive
-        ? 'No workspaces yet'
-        : 'Named sets of tabs — Patron';
-      nodes.push(empty);
+      if (wsPatronActive) {
+        const empty = document.createElement('div');
+        empty.className = 'ws-switcher-empty';
+        empty.textContent = 'No workspaces yet';
+        nodes.push(empty);
+      } else {
+        nodes.push(renderWorkspacePatronGateRow(false));
+      }
     } else {
       for (const workspace of wsWorkspaces) {
         if (pendingRenameWorkspaceId === workspace.id) {
@@ -862,6 +855,7 @@
           nodes.push(renderSwitcherWorkspaceRow(workspace));
         }
       }
+      if (!wsPatronActive) nodes.push(renderWorkspacePatronGateRow(true));
     }
     workspaceSwitcherList.replaceChildren(...nodes);
   }
@@ -1022,7 +1016,6 @@
   function guardWorkspaceCreationEntry() {
     if (wsPatronActive) return false;
     clearWorkspacePopoverEditors();
-    workspacePatronGateVisible = true;
     openWorkspaceSwitcher();
     return true;
   }

--- a/test/unit/workspaces-patron-entry.test.js
+++ b/test/unit/workspaces-patron-entry.test.js
@@ -13,6 +13,7 @@ const vm = require('node:vm');
 
 const ROOT = path.resolve(__dirname, '../..');
 const overlaySource = fs.readFileSync(path.join(ROOT, 'src/renderer/overlay.js'), 'utf8');
+const mainSource = fs.readFileSync(path.join(ROOT, 'src/main/main.js'), 'utf8');
 
 const lift = (name) => {
   const re = new RegExp(`function ${name}\\([^)]*\\) \\{[\\s\\S]*?\\n  \\}`);
@@ -110,7 +111,7 @@ test('/workspace sends a new name to main only after the renderer gate passes', 
   assert.deepEqual(calls, [['save', 'Deep Work'], ['mutation', 'pending']]);
 });
 
-test('the Patron gate row links directly to the Patron Settings section', () => {
+test('the Patron gate row distinguishes unlock from lapse and links to Patron Settings', () => {
   const calls = [];
   class El {
     constructor(tag) { this.tagName = tag; this.children = []; this.listeners = {}; }
@@ -119,6 +120,7 @@ test('the Patron gate row links directly to the Patron Settings section', () => 
     addEventListener(name, fn) { this.listeners[name] = fn; }
   }
   const sandbox = {
+    wsWorkspaces: [],
     document: { createElement: (tag) => new El(tag) },
     closeWorkspaceSwitcher: () => calls.push(['close-switcher']),
     window: { browserAPI: {
@@ -130,10 +132,13 @@ test('the Patron gate row links directly to the Patron Settings section', () => 
     `${lift('renderWorkspacePatronGateRow')}; this.render = renderWorkspacePatronGateRow;`,
     sandbox,
   );
-  const row = sandbox.render();
-  assert.equal(row.children[0].textContent, 'Creating workspaces needs Blanc Patron');
-  assert.equal(row.children[1].textContent, 'settings →');
-  row.listeners.click();
+  const unlock = sandbox.render(false);
+  assert.equal(unlock.children[0].textContent, 'Named Workspaces — Patron');
+  assert.equal(unlock.children[1].textContent, 'unlock →');
+  const renew = sandbox.render(true);
+  assert.equal(renew.children[0].textContent, 'Renew Patron to create another');
+  assert.equal(renew.children[1].textContent, '→');
+  unlock.listeners.click();
   assert.deepEqual(calls, [
     ['close-switcher'],
     ['close-overlay'],
@@ -141,11 +146,20 @@ test('the Patron gate row links directly to the Patron Settings section', () => 
   ]);
 });
 
-test('the gate row replaces editor commands instead of appearing beside them', () => {
+test('inactive users get one CTA instead of new and save-as controls', () => {
   const render = lift('renderWorkspaceSwitcherList');
-  assert.match(render, /exclusiveState = workspacePatronGateVisible/);
-  assert.match(render, /setSwitcherCommandVisibility\(!exclusiveState\)/);
-  assert.ok(render.indexOf('if (workspacePatronGateVisible)')
-    < render.indexOf('if (pendingCreateWorkspace)'),
-  'the Patron row must win before either editor is rendered');
+  assert.match(render, /setSwitcherCommandVisibility\(wsPatronActive && !naming\)/);
+  assert.match(render, /renderWorkspacePatronGateRow\(false\)/,
+    'never-Patrons need one unlock CTA');
+  assert.match(render, /if \(!wsPatronActive\) nodes\.push\(renderWorkspacePatronGateRow\(true\)\)/,
+    'lapsed Patrons keep rows plus one renew CTA');
+});
+
+test('Patron activation and validation repaint an already-open workspace popover', () => {
+  const settingsFanout = mainSource.match(
+    /settings\.onSettingsChanged\(\(s\) => \{[\s\S]*?\n  \}\);/,
+  )?.[0];
+  assert.ok(settingsFanout, 'settings fan-out not found in main.js');
+  assert.match(settingsFanout, /broadcastWorkspacesUpdated\(\)/,
+    'setPatron changes must push the newly derived entitlement to chrome');
 });


### PR DESCRIPTION
## Summary
- keep Named Workspaces discoverable while hiding `new…` and `save as…` for inactive Patrons
- show one Unlock CTA for never-Patrons and preserve existing workspace rows with one Renew CTA after lapse
- keep `/workspace` existing-name opens lapse-safe and gate new names before editor/IPC
- repaint the open popover when activation or scheduled Polar validation changes the derived entitlement

## Verification
- `npm run release:verify:press`
- unit: 1,019/1,019
- desktop acceptance: 116/116 scenarios, 703/703 steps
- cold launch, OAuth, DNS, production dependency audit, and site build passed