### PR TITLE
Add a Report an issue link and GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug report
+description: Something in Blanc is broken or behaves wrongly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this.
+
+        **Please don't report security vulnerabilities here** — this tracker is
+        public. Email support@blancbrowser.com instead.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What you expected, and what Blanc did instead.
+      placeholder: I clicked the shield chip and the popover opened behind the page.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: |
+        The smallest sequence that shows the problem. If it only happens on a
+        particular site, name the site — most rendering and blocking bugs are
+        specific to one page.
+      placeholder: |
+        1. Open https://example.com
+        2. Press Cmd+L and type…
+        3. The Island…
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Blanc version
+      description: "Find it under **Blanc → About Blanc** (macOS) or **Help → About Blanc** (Windows and Linux)."
+      placeholder: "1.4.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      placeholder: "macOS 26.1, Windows 11 23H2, Ubuntu 24.04…"
+    validations:
+      required: false
+
+  - type: input
+    id: site
+    attributes:
+      label: Site involved
+      description: If the problem happens on a specific page, its URL. Leave blank if it isn't site-specific.
+      placeholder: "https://www.example.com/article"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: blocking
+    attributes:
+      label: Does it still happen with ad blocking off?
+      description: |
+        Turn it off in Settings → Privacy & Security, or run `/allow-ads` to
+        allow ads on just this site. This one answer separates a blocking bug
+        from a browser bug, and usually saves a round trip.
+      options:
+        - "Haven't tried"
+        - "Yes — still happens with blocking off"
+        - "No — goes away with blocking off"
+        - "Not applicable"
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Screenshots, a screen recording, or console output all help. You can paste images straight in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,7 @@ body:
     attributes:
       label: Blanc version
       description: "Find it under **Blanc → About Blanc** (macOS) or **Help → About Blanc** (Windows and Linux)."
-      placeholder: "1.4.0"
+      placeholder: "1.8.1"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,4 +7,4 @@ contact_links:
     about: Report privately by email. This tracker is public — please don't file security issues here.
   - name: Support question
     url: mailto:support@blancbrowser.com
-    about: Trouble with an install, a licence key, or your account.
+    about: Trouble with an install, a license key, or your account.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Blank issues stay enabled: a report with no template is worth far more than
+# a report someone abandoned because no category fit.
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: mailto:support@blancbrowser.com
+    about: Report privately by email. This tracker is public — please don't file security issues here.
+  - name: Support question
+    url: mailto:support@blancbrowser.com
+    about: Trouble with an install, a licence key, or your account.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Idea or request
+description: Suggest something Blanc should do differently
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Blanc is deliberately small. It ships no AI assistant and no extension
+        runtime, and it favours one coherent product over a configurable one —
+        so some good ideas get declined on fit rather than merit. Saying what
+        you were trying to do helps more than naming a feature, because there
+        may already be a way, or a smaller change that solves it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The situation you're in when you want this, not the feature itself.
+      placeholder: I keep losing track of which tab is playing audio when I have a group open.
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What would you like Blanc to do?
+    validations:
+      required: false
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: How do you handle it today?
+      description: Including "I switch to another browser for this" — that's useful to know.
+    validations:
+      required: false

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -200,6 +200,24 @@ a.patron-checkout {
 }
 a.patron-checkout:hover { filter: brightness(1.05); }
 
+/* An <a> that reads as a NEUTRAL button (matches Activate / Turn on sync, not
+   the accent patron CTA above). Stays an anchor for the same reason: the
+   utility sheet's will-navigate handler turns an http(s) target into a real
+   tab, and window.open is denied there. */
+.link-button {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--text-dim);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 5px 12px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+}
+.link-button:hover { color: var(--text); border-color: var(--text-dim); }
+
 .hint.field-error { color: var(--danger); }
 
 .spacer { flex: 1 1 auto; }

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -471,6 +471,21 @@ a.patron-checkout:hover { filter: brightness(1.05); }
 
 .settings-content { flex: 1 1 auto; min-width: 0; }
 
+/* Settings fields use Inter, not the shared monospace input face. Settings is
+   prose-like configuration, and the mono treatment read as unnecessarily
+   technical here (it stays elsewhere — search boxes, group labels — by design).
+   The one exception is the Patron license key: a monospace face keeps an
+   opaque key legible character-by-character while typing or checking it. */
+.settings-content input[type="text"],
+.settings-content input[type="url"],
+.settings-content input[type="password"],
+.settings-content select {
+  font-family: var(--font-ui);
+}
+.settings-content #patronKey {
+  font-family: var(--font-mono);
+}
+
 .settings-group + .settings-group { margin-top: 40px; }
 /* Anchor targets (e.g. the shield popover's "blocking settings →" deep-link,
    blanc://settings/#group-privacy) must clear the sheet's 69px sticky band —

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -159,7 +159,7 @@
             <div class="setting">
               <div class="label">
                 <span>Block ads &amp; trackers</span>
-                <span class="hint">EasyList + EasyPrivacy at the network layer, plus element hiding</span>
+                <span class="hint">Stops ads and the hidden trackers that follow you from site to site. On by default.</span>
               </div>
               <label class="toggle">
                 <input id="adblockEnabled" type="checkbox" />
@@ -169,34 +169,34 @@
 
             <div class="setting">
               <div class="label">
-                <span>WebRTC</span>
-                <span class="hint">Limits which network addresses WebRTC may reveal. Standard hides non-default-route and multi-homed addresses.</span>
+                <span>IP address in video calls</span>
+                <span class="hint">Video and voice calls in your browser can reveal your real IP address, even on a VPN. Standard is right for almost everyone.</span>
               </div>
               <select id="webrtcPolicy">
-                <option value="standard">Standard — hide non-default addresses</option>
-                <option value="strict">Disable direct UDP — for proxy users; may break or degrade some video calls</option>
+                <option value="standard">Standard (recommended)</option>
+                <option value="strict">Strict — stronger, but can break some video calls</option>
               </select>
             </div>
 
             <div class="setting">
               <div class="label">
                 <span>Encrypted DNS</span>
-                <span class="hint">Encrypts DNS lookups between Blanc and the chosen resolver. It does not hide the sites you visit from your network, and it makes the resolver a party you trust. Automatic does not guarantee encryption. Strict providers may block captive-portal login pages — switch to Automatic to get through.</span>
+                <span class="hint">Encrypts the behind-the-scenes lookups that turn a web address into a connection, so others on your Wi-Fi can't easily see which sites you open. It doesn't hide your browsing from your internet provider. Automatic is safe to leave on — if a Wi-Fi login page ever won't load, switch back to it.</span>
               </div>
               <select id="secureDns">
-                <option value="auto">Automatic — upgrade when available (may fall back to unencrypted)</option>
-                <option value="off">Off — use the system resolver (best with a VPN's own DNS)</option>
-                <option value="cloudflare">Cloudflare — unfiltered</option>
-                <option value="quad9">Quad9 — blocks known-malware domains, validates DNSSEC</option>
-                <option value="mullvad">Mullvad — unfiltered</option>
+                <option value="auto">Automatic (recommended)</option>
+                <option value="off">Off — use your system setting (best with a VPN)</option>
+                <option value="cloudflare">Cloudflare</option>
+                <option value="quad9">Quad9 — also blocks known malware sites</option>
+                <option value="mullvad">Mullvad</option>
                 <option value="custom">Custom provider…</option>
               </select>
             </div>
 
             <div class="setting" id="secureDnsCustomRow" hidden>
               <div class="label">
-                <span>Custom DoH template</span>
-                <span class="hint">An https:// DoH URL (RFC 8484), e.g. https://dns.nextdns.io/&lt;profile&gt;.</span>
+                <span>Custom provider address</span>
+                <span class="hint">The secure DNS address your provider gave you (an https:// link), e.g. https://dns.nextdns.io/&lt;profile&gt;.</span>
                 <span class="hint field-error" id="secureDnsError" hidden>That is not a valid DoH URL — the previous provider is still in use.</span>
               </div>
               <input id="secureDnsTemplate" type="url" placeholder="https://your-provider.example/dns-query" />

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -24,6 +24,7 @@
         <a href="#group-privacy" data-group="privacy">Privacy &amp; Security</a>
         <a href="#group-sync" data-group="sync">Sync</a>
         <a href="#group-patron" data-group="patron">Patron</a>
+        <a href="#group-help" data-group="help">Help</a>
       </nav>
 
       <div class="settings-content">
@@ -302,6 +303,20 @@
               <button id="patronActivate">Activate</button>
             </div>
             <p class="section-hint" id="patronStatus" role="status"></p>
+          </div>
+        </section>
+
+        <section class="settings-group" id="group-help">
+          <h2 class="group-title">Help</h2>
+          <div class="settings-card">
+            <p class="section-hint">
+              Something broken, or working in a way it shouldn&rsquo;t? Reports go to Blanc&rsquo;s
+              public issue tracker on GitHub. Saying which version you&rsquo;re on, which operating
+              system, and what page you were looking at makes a report much faster to act on.
+            </p>
+            <div class="toolbar-row">
+              <a class="link-button" href="https://github.com/bnfy/blanc/issues/new" rel="noreferrer">Report an issue</a>
+            </div>
           </div>
         </section>
       </div>

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -315,7 +315,7 @@
               system, and what page you were looking at makes a report much faster to act on.
             </p>
             <div class="toolbar-row">
-              <a class="link-button" href="https://github.com/bnfy/blanc/issues/new" rel="noreferrer">Report an issue</a>
+              <a class="link-button" href="https://github.com/bnfy/blanc/issues/new/choose" rel="noreferrer">Report an issue</a>
             </div>
           </div>
         </section>

--- a/src/renderer/pages/settings.html
+++ b/src/renderer/pages/settings.html
@@ -174,14 +174,14 @@
               </div>
               <select id="webrtcPolicy">
                 <option value="standard">Standard (recommended)</option>
-                <option value="strict">Strict — stronger, but can break some video calls</option>
+                <option value="strict">Strict — stronger for proxy users, but can break some video calls</option>
               </select>
             </div>
 
             <div class="setting">
               <div class="label">
                 <span>Encrypted DNS</span>
-                <span class="hint">Encrypts the behind-the-scenes lookups that turn a web address into a connection, so others on your Wi-Fi can't easily see which sites you open. It doesn't hide your browsing from your internet provider. Automatic is safe to leave on — if a Wi-Fi login page ever won't load, switch back to it.</span>
+                <span class="hint">Encrypts the behind-the-scenes lookups that turn a web address into a connection, so someone sniffing those lookups can't read the names. It does not hide the sites you visit from your network, and it makes the DNS provider someone you trust. Automatic uses encryption when it can and may fall back to ordinary DNS — safe to leave on. If a Wi-Fi login page won't load, switch to Automatic or Off temporarily.</span>
               </div>
               <select id="secureDns">
                 <option value="auto">Automatic (recommended)</option>
@@ -197,7 +197,7 @@
               <div class="label">
                 <span>Custom provider address</span>
                 <span class="hint">The secure DNS address your provider gave you (an https:// link), e.g. https://dns.nextdns.io/&lt;profile&gt;.</span>
-                <span class="hint field-error" id="secureDnsError" hidden>That is not a valid DoH URL — the previous provider is still in use.</span>
+                <span class="hint field-error" id="secureDnsError" hidden>That address isn't valid — the previous provider is still in use.</span>
               </div>
               <input id="secureDnsTemplate" type="url" placeholder="https://your-provider.example/dns-query" />
             </div>


### PR DESCRIPTION
## Why

Blanc has ~670 downloads and 36 monthly actives but has never received a single GitHub issue — none open, none closed, and Discussions are off. Nothing in the app or on the site points anyone at the tracker; the only contact route is a `mailto:` tucked into the site footer, press page, and privacy policy. Zero reports is more plausibly a missing path than an absence of bugs: someone who hits a problem has to go hunting for an address, and silent uninstalls look exactly like this.

## What

- **Settings → Help**, with a "Report an issue" link to the tracker. The hint asks for version, OS, and the page involved so a report arrives actionable.
- **Issue templates** (`.github/ISSUE_TEMPLATE/`): a bug form (version, OS, site, and a "does it still happen with blocking off?" field that separates a blocking bug from a browser bug), an idea form framed around what the user was trying to do (Blanc declines some requests on fit, so intent matters more than the feature), and a `config.yml` that keeps blank issues enabled and routes security/support to email. The Settings link targets `/issues/new/choose` so it lands on the chooser rather than bypassing the templates.

## Design notes

- **No main-process change.** The utility sheet's `will-navigate` handler already turns an http(s) target into a real tab, so this stays an `<a>` rather than a button + IPC.
- The new `.link-button` class is the **neutral** button style (matches Activate / Turn on sync), deliberately distinct from the accent `a.patron-checkout` CTA — "Report an issue" is secondary, not a primary action. Both share the same "must stay an anchor because the sheet denies window.open" reasoning.

## Verification

Verified in the running app on a scratch profile: the Help entry renders in the sidebar, the link matches the neighbouring controls (1px border, 12px type, 5/12 padding), and clicking it opens a real tab on the tracker while the sheet dismisses. After rebasing onto current `main` (resolving the `Supporter`→`Patron` rename and a `pages.css` adjacency), `substrate:check` passes and the unit suite is 1019/1019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)