### PR TITLE
Opaque Settings select pickers (no Liquid Glass ghosting)

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -2137,11 +2137,17 @@ function createUtilitySheet() {
   runtime.utilitySheetView = view;
   installChromeShortcuts(wc);
   // Esc dismisses no matter what inside the page holds focus (mirrors the
-  // island overlay's handler).
+  // island overlay's handler). When a Settings picker (or similar) has armed
+  // escape interest, forward Esc into the sheet first so the picker can close
+  // without dismissing the whole sheet — same layering as workspaceSwitcherOpen.
   wc.on('before-input-event', bindWindowRuntime(runtime, (event, input) => {
     if (runtime.utilitySheetView !== view) return;
     if (runtime.utilitySheetUrl && input.type === 'keyDown' && input.key === 'Escape') {
       event.preventDefault();
+      if (runtime.utilitySheetEscapeArmed && !wc.isDestroyed()) {
+        wc.send('pages:surface:escape');
+        return;
+      }
       hideUtilitySheet();
     }
   }));
@@ -2177,6 +2183,7 @@ function createUtilitySheet() {
     if (runtime.utilitySheetView !== view) return event.preventDefault();
     if (isUtilityUrl(targetUrl)) {
       runtime.utilitySheetUrl = targetUrl; // keep the toggle honest across in-sheet nav
+      runtime.utilitySheetEscapeArmed = false; // document is about to be replaced
       return;
     }
     event.preventDefault();
@@ -2218,6 +2225,7 @@ function showUtilityPage(url) {
   }
   if (!sheet) return;
   runtime.utilitySheetUrl = url;
+  runtime.utilitySheetEscapeArmed = false;
   scheduleUtilitySheetNavigation(runtime, sheet, url);
   // Mirror tabs: a detached view's document still reports visibilityState
   // 'visible' and never background-throttles — toggle real visibility.
@@ -2234,6 +2242,7 @@ function hideUtilitySheet({ refocusContent = true } = {}) {
   const runtime = rt();
   if (!runtime.utilitySheetUrl) return;
   runtime.utilitySheetUrl = null;
+  runtime.utilitySheetEscapeArmed = false;
   cancelUtilitySheetNavigation(runtime.utilitySheetView);
   const sheet = liveUtilitySheet(runtime);
   if (hasLiveWindow() && sheet) {
@@ -6683,6 +6692,9 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
         return !!sheet && wc === sheet.wc;
       },
       close: () => hideUtilitySheet(),
+      setEscapeArmed: (armed) => {
+        rt().utilitySheetEscapeArmed = !!armed;
+      },
     },
     pageSurfaces: {
       owns: (host, wc) => {

--- a/src/main/pages.js
+++ b/src/main/pages.js
@@ -100,6 +100,11 @@ function setupPages(hooks = {}) {
   };
 
   handle('pages:surface:close', [...UTILITY_PAGES], () => hooks.utilitySheet.close());
+  // Settings opaque pickers arm Escape so main forwards it into the sheet
+  // instead of dismissing the sheet (see createUtilitySheet before-input-event).
+  handle('pages:surface:escape-arm', [...UTILITY_PAGES], (armed) => {
+    hooks.utilitySheet.setEscapeArmed?.(!!armed);
+  });
 
   handle('pages:bookmarks:list', ['bookmarks', 'newtab'], () => bookmarks.listBookmarks());
   handle('pages:bookmarks:remove', 'bookmarks', (id) => {

--- a/src/main/tab-preload.js
+++ b/src/main/tab-preload.js
@@ -6,7 +6,16 @@ const { contextBridge, ipcRenderer } = require('electron');
 if (window.location.protocol === 'blanc:') {
   const host = window.location.host;
   const invoke = (channel, ...args) => ipcRenderer.invoke(channel, ...args);
-  const surface = { close: () => invoke('pages:surface:close') };
+  const surface = {
+    close: () => invoke('pages:surface:close'),
+    /** Tell main Escape should close an in-page consumer first (Settings pickers). */
+    armEscape: (armed) => invoke('pages:surface:escape-arm', !!armed),
+    onEscape: (callback) => {
+      const listener = () => callback();
+      ipcRenderer.on('pages:surface:escape', listener);
+      return () => ipcRenderer.removeListener('pages:surface:escape', listener);
+    },
+  };
   let api = null;
 
   if (host === 'newtab') {

--- a/src/main/window-runtime-registry.js
+++ b/src/main/window-runtime-registry.js
@@ -84,6 +84,10 @@ function createRuntime({ id = null, profileId = DEFAULT_PROFILE_ID } = {}) {
     shieldTrigger: null,
     utilitySheetView: null,
     utilitySheetUrl: null,
+    /** Settings (and similar) in-page pickers arm this so Escape closes the
+     * picker before dismissing the utility sheet — same layering as
+     * workspaceSwitcherOpen on the overlay. */
+    utilitySheetEscapeArmed: false,
     /** The floating bottom-center permission-prompt view; attached only
      * while permissionPrompts is non-empty. */
     permissionView: null,
@@ -162,6 +166,7 @@ function detachWindow(runtime) {
   runtime.glanceTabId = null;
   runtime.utilitySheetView = null;
   runtime.utilitySheetUrl = null;
+  runtime.utilitySheetEscapeArmed = false;
   runtime.permissionView = null;
   runtime.permissionViewAttached = false;
 }

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -306,9 +306,11 @@ a.patron-checkout:hover { filter: brightness(1.05); }
   min-width: 160px;
 }
 .setting .label .hint { color: var(--text-dim); font-size: 12px; }
-.setting > select {
+.setting > select,
+.setting > .settings-select {
   /* Native selects use their longest option as an intrinsic minimum. Let the
-     control shrink inside the row instead of widening the whole sheet. */
+     control shrink inside the row instead of widening the whole sheet.
+     Enhanced Settings pickers (.settings-select) share the same flex budget. */
   flex: 0 1 auto;
   min-width: 0;
   max-width: min(360px, 100%);
@@ -484,6 +486,122 @@ a.patron-checkout:hover { filter: brightness(1.05); }
 }
 .settings-content #patronKey {
   font-family: var(--font-mono);
+}
+
+/* Opaque in-page Settings pickers. Native <select> popups pick up macOS Liquid
+   Glass and ghost the closed face through the menu; these menus stay solid
+   --surface-raised like the settings card and closed field. The real <select>
+   remains the value source (change listeners / programmatic .value writes). */
+.settings-select {
+  position: relative;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+}
+.settings-select-trigger {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  color: var(--text);
+  background-color: var(--surface-raised);
+  background-image: var(--select-caret);
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 10px 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 28px 6px 10px;
+  cursor: pointer;
+  text-align: left;
+}
+.settings-select-trigger:hover { border-color: var(--text-dim); }
+.settings-select.is-open .settings-select-trigger {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.settings-select-label {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.settings-select-native {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  border: 0 !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+  appearance: none !important;
+  background: none !important;
+}
+.settings-select-menu {
+  position: fixed;
+  z-index: 40;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  box-sizing: border-box;
+  max-width: min(420px, calc(100vw - 16px));
+  max-height: min(320px, calc(100vh - 16px));
+  overflow-x: hidden;
+  overflow-y: auto;
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.14);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+@media (prefers-color-scheme: dark) {
+  .settings-select-menu { box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45); }
+}
+:root[data-theme="dark"] .settings-select-menu,
+:root[data-theme="private"] .settings-select-menu {
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+}
+.settings-select-option {
+  position: relative;
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  line-height: 1.35;
+  color: var(--text);
+  padding: 7px 12px 7px 28px;
+  border-radius: calc(var(--radius) - 2px);
+  cursor: pointer;
+  outline: none;
+  white-space: normal;
+}
+.settings-select-option.is-selected::before {
+  content: "✓";
+  position: absolute;
+  left: 9px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 11px;
+  color: var(--text);
+}
+.settings-select-option:hover,
+.settings-select-option:focus {
+  background: var(--accent-dim);
+}
+.settings-select-option.is-active,
+.settings-select-option:focus {
+  background: var(--accent);
+  color: var(--surface-raised);
+}
+.settings-select-option.is-active.is-selected::before,
+.settings-select-option:focus.is-selected::before {
+  color: var(--surface-raised);
 }
 
 .settings-group + .settings-group { margin-top: 40px; }

--- a/src/renderer/pages/settings.js
+++ b/src/renderer/pages/settings.js
@@ -777,4 +777,257 @@
       });
     }
   })();
+
+  // Replace native <select> popups (Liquid Glass / ghosted closed face on
+  // macOS) with opaque in-page menus. Keep the real <select> as the value
+  // source so existing change listeners and programmatic .value writes work.
+  enhanceSettingsSelects(document.querySelectorAll('.settings-content select'));
 })();
+
+/** Opaque Settings picker over each remaining .settings-content <select>. */
+function enhanceSettingsSelects(selects) {
+  let openPicker = null;
+  const surface = window.bowserPages?.surface;
+
+  const setEscapeArmed = (armed) => {
+    try { surface?.armEscape?.(armed); } catch { /* bridge absent in static preview */ }
+  };
+
+  const closeOpen = () => {
+    if (openPicker) openPicker.close();
+  };
+
+  document.addEventListener('pointerdown', (e) => {
+    if (openPicker && !openPicker.root.contains(e.target) && !openPicker.menu.contains(e.target)) {
+      closeOpen();
+    }
+  });
+  // Page keydown is a fallback; main's sheet before-input-event normally owns
+  // Escape and forwards pages:surface:escape when escape is armed.
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && openPicker) {
+      e.preventDefault();
+      const trigger = openPicker.trigger;
+      closeOpen();
+      trigger.focus();
+    }
+  });
+  surface?.onEscape?.(() => {
+    if (!openPicker) return;
+    const trigger = openPicker.trigger;
+    closeOpen();
+    trigger.focus();
+  });
+  document.querySelector('body.sheet .page')?.addEventListener('scroll', closeOpen, { passive: true });
+  window.addEventListener('resize', closeOpen);
+
+  for (const select of selects) {
+    if (!(select instanceof HTMLSelectElement)) continue;
+    if (select.dataset.settingsSelectEnhanced === '1') continue;
+    select.dataset.settingsSelectEnhanced = '1';
+    enhanceSettingsSelect(select);
+  }
+
+  function enhanceSettingsSelect(select) {
+    const wrap = document.createElement('div');
+    wrap.className = 'settings-select';
+    select.parentNode.insertBefore(wrap, select);
+
+    const trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.className = 'settings-select-trigger';
+    trigger.setAttribute('aria-haspopup', 'listbox');
+    trigger.setAttribute('aria-expanded', 'false');
+    if (select.id) trigger.id = `${select.id}Trigger`;
+
+    const titleEl = select.closest('.setting')?.querySelector('.label > span:first-child');
+    if (titleEl) {
+      if (!titleEl.id) titleEl.id = select.id ? `${select.id}Label` : `${trigger.id || 'settingsSelect'}Label`;
+      trigger.setAttribute('aria-labelledby', titleEl.id);
+    } else if (select.getAttribute('aria-label')) {
+      trigger.setAttribute('aria-label', select.getAttribute('aria-label'));
+    }
+
+    const face = document.createElement('span');
+    face.className = 'settings-select-label';
+    trigger.append(face);
+
+    const menu = document.createElement('ul');
+    menu.className = 'settings-select-menu';
+    menu.setAttribute('role', 'listbox');
+    menu.id = select.id ? `${select.id}Listbox` : `${trigger.id || 'settingsSelect'}Listbox`;
+    menu.hidden = true;
+    trigger.setAttribute('aria-controls', menu.id);
+    if (titleEl?.id) menu.setAttribute('aria-labelledby', titleEl.id);
+
+    select.classList.add('settings-select-native');
+    select.setAttribute('tabindex', '-1');
+    select.setAttribute('aria-hidden', 'true');
+
+    wrap.append(trigger, select);
+    // Menu is portaled to <body> so sheet overflow can't clip it, and so it
+    // isn't a descendant of the trigger for hit-testing while open.
+    document.body.append(menu);
+
+    const syncFace = () => {
+      const opt = select.selectedOptions[0];
+      face.textContent = opt ? opt.textContent : '';
+    };
+
+    const rebuildMenu = () => {
+      menu.replaceChildren();
+      for (const opt of select.options) {
+        const li = document.createElement('li');
+        li.className = 'settings-select-option';
+        li.setAttribute('role', 'option');
+        li.dataset.value = opt.value;
+        li.textContent = opt.textContent;
+        li.tabIndex = -1;
+        if (opt.selected) {
+          li.classList.add('is-selected');
+          li.setAttribute('aria-selected', 'true');
+        } else {
+          li.setAttribute('aria-selected', 'false');
+        }
+        menu.append(li);
+      }
+    };
+
+    const positionMenu = () => {
+      const r = trigger.getBoundingClientRect();
+      const pad = 8;
+      menu.style.minWidth = `${Math.ceil(r.width)}px`;
+      // Force layout so offsetHeight is current before flipping.
+      const mh = menu.offsetHeight || 0;
+      const mw = menu.offsetWidth || r.width;
+      const spaceBelow = window.innerHeight - r.bottom - pad;
+      const openUp = mh > spaceBelow && r.top - pad > spaceBelow;
+      let left = r.left;
+      if (left + mw > window.innerWidth - pad) left = Math.max(pad, window.innerWidth - mw - pad);
+      if (left < pad) left = pad;
+      menu.style.left = `${Math.round(left)}px`;
+      menu.style.top = openUp
+        ? `${Math.round(Math.max(pad, r.top - mh - 4))}px`
+        : `${Math.round(r.bottom + 4)}px`;
+    };
+
+    const api = {
+      root: wrap,
+      menu,
+      trigger,
+      close() {
+        menu.hidden = true;
+        trigger.setAttribute('aria-expanded', 'false');
+        wrap.classList.remove('is-open');
+        for (const li of menu.querySelectorAll('.settings-select-option.is-active')) {
+          li.classList.remove('is-active');
+        }
+        if (openPicker === api) openPicker = null;
+        setEscapeArmed(false);
+      },
+      open() {
+        closeOpen();
+        rebuildMenu();
+        menu.hidden = false;
+        trigger.setAttribute('aria-expanded', 'true');
+        wrap.classList.add('is-open');
+        positionMenu();
+        openPicker = api;
+        setEscapeArmed(true);
+        const selected = menu.querySelector('[aria-selected="true"]') || menu.querySelector('.settings-select-option');
+        if (selected) {
+          selected.tabIndex = 0;
+          selected.classList.add('is-active');
+          selected.focus();
+        }
+      },
+    };
+
+    const choose = (li) => {
+      if (!li) return;
+      const value = li.dataset.value;
+      if (select.value !== value) {
+        select.value = value;
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      syncFace();
+      api.close();
+      trigger.focus();
+    };
+
+    trigger.addEventListener('click', () => {
+      if (menu.hidden) api.open();
+      else api.close();
+    });
+
+    trigger.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        if (menu.hidden) api.open();
+      }
+    });
+
+    menu.addEventListener('click', (e) => {
+      choose(e.target.closest('.settings-select-option'));
+    });
+
+    menu.addEventListener('pointerdown', (e) => {
+      // Keep the document pointerdown closer from treating menu clicks as outside.
+      e.stopPropagation();
+    });
+
+    menu.addEventListener('keydown', (e) => {
+      const opts = [...menu.querySelectorAll('.settings-select-option')];
+      const i = opts.indexOf(document.activeElement);
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = opts[Math.min(opts.length - 1, Math.max(0, i) + 1)] || opts[0];
+        opts.forEach((o) => { o.tabIndex = -1; o.classList.remove('is-active'); });
+        next.tabIndex = 0;
+        next.classList.add('is-active');
+        next.focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const next = opts[Math.max(0, (i < 0 ? 0 : i) - 1)] || opts[0];
+        opts.forEach((o) => { o.tabIndex = -1; o.classList.remove('is-active'); });
+        next.tabIndex = 0;
+        next.classList.add('is-active');
+        next.focus();
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        choose(document.activeElement?.closest?.('.settings-select-option') || opts[i]);
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        api.close();
+        trigger.focus();
+      } else if (e.key === 'Tab') {
+        api.close();
+      }
+    });
+
+    // Programmatic select.value = … (e.g. secureDns showAccepted) must refresh
+    // the closed face without a change event.
+    const desc = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value');
+    if (desc?.get && desc?.set) {
+      Object.defineProperty(select, 'value', {
+        configurable: true,
+        enumerable: true,
+        get() { return desc.get.call(this); },
+        set(v) {
+          desc.set.call(this, v);
+          syncFace();
+        },
+      });
+    }
+
+    select.addEventListener('change', syncFace);
+    new MutationObserver(syncFace).observe(select, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['selected', 'value'],
+    });
+
+    syncFace();
+  }
+}

--- a/src/renderer/pages/sheet.js
+++ b/src/renderer/pages/sheet.js
@@ -1,7 +1,9 @@
 // Shared glue for utility pages presented in the sheet (body.sheet):
 // dialog semantics, the ✕, scrim-click dismissal, and initial focus on the
 // page heading so keyboard/screen-reader users land on what just opened.
-// Esc is handled main-side (before-input-event); this file never needs it.
+// Esc is handled main-side (before-input-event). In-page consumers (Settings
+// pickers) arm pages:surface:escape-arm so the first Esc closes them before
+// the sheet dismisses — this file never needs its own Esc handler.
 (() => {
   const page = document.querySelector('.page');
   if (!page || !window.bowserPages?.surface) return;

--- a/test/unit/window-runtime-registry.test.js
+++ b/test/unit/window-runtime-registry.test.js
@@ -23,6 +23,7 @@ test('createRuntime initializes the per-window inventory to main.js defaults', (
   assert.equal(r.shieldTrigger, null);
   assert.equal(r.utilitySheetView, null);
   assert.equal(r.utilitySheetUrl, null);
+  assert.equal(r.utilitySheetEscapeArmed, false);
   assert.ok(r.tabsWantingAddressBarFocus instanceof Set);
   assert.equal(r.chromeHeight, 64);
   assert.equal(r.tabsBroadcastTimer, null);


### PR DESCRIPTION
## Summary
- Replace Settings `<select>` popups with opaque in-page menus matching the settings card surface
- Keep the native `<select>` as the value source (existing change listeners / programmatic writes)
- Arm Escape via main so the first Esc closes the picker and the second dismisses the sheet
- Wire accessible names (`aria-labelledby` / `aria-controls`) for the triggers and listboxes

## Test plan
- [ ] Open Settings → every dropdown (Appearance, Quiet tabs, Encrypted DNS, IP address in video calls, etc.) shows an opaque menu with no glass ghosting
- [ ] Esc with a menu open closes only the menu; Esc again closes Settings
- [ ] Changing Encrypted DNS / WebRTC still persists; custom DNS reject path still shows the error face
- [ ] Outside click and sheet scroll dismiss the open menu

Made with [Cursor](https://cursor.com)