### PR TITLE
scripts: automate launch demo exports

### DIFF
--- a/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
+++ b/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
@@ -960,12 +960,26 @@ Total ~20s. No narration, no captions burned in — it gets reposted in contexts
 
 - [ ] **Step 3: Convert colour space**
 
-Capture is P3; convert to sRGB or the colours shift in every browser that renders it.
+Run the checked-in exporter. It inspects the source metadata, converts a
+non-BT.709 input rather than merely relabelling it, emits a 30 fps H.264 MP4,
+and fails if the final capture is not 18–24 seconds:
+
+```bash
+scripts/export-launch-demo.sh
+```
+
+The existing raw captures are already tagged BT.709. A new Screen Recording
+may instead be Display P3; the exporter handles either case but fails closed if
+the input metadata is missing.
 
 - [ ] **Step 4: Export both forms**
 
 - MP4 (Reddit and the source upload for Product Hunt's required YouTube URL)
 - GIF under 8MB (Hacker News comments, inline embeds)
+
+The exporter tries progressively smaller GIF presets and refuses to report
+success unless `island-demo.gif` is below 8 MiB. Do not hand-wave a larger
+file as “close enough.”
 
 - [ ] **Step 5: Store it**
 

--- a/scripts/export-launch-demo.sh
+++ b/scripts/export-launch-demo.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+INPUT=${1:-"$ROOT_DIR/export/product-demos/island-demo-raw.mov"}
+OUTPUT_DIR=${2:-"$ROOT_DIR/export/product-demos"}
+MP4="$OUTPUT_DIR/island-demo.mp4"
+GIF="$OUTPUT_DIR/island-demo.gif"
+MP4_TMP="$OUTPUT_DIR/.island-demo.mp4.tmp"
+GIF_TMP="$OUTPUT_DIR/.island-demo.gif.tmp"
+MAX_GIF_BYTES=$((8 * 1024 * 1024))
+
+for tool in ffmpeg ffprobe; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "STOP: $tool is required" >&2
+    exit 1
+  fi
+done
+
+if [ ! -f "$INPUT" ]; then
+  echo "STOP: recording not found: $INPUT" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+trap 'rm -f "$MP4_TMP" "$GIF_TMP"' EXIT
+
+probe_stream() {
+  ffprobe -v error -select_streams v:0 \
+    -show_entries "stream=$1" -of default=noprint_wrappers=1:nokey=1 "$INPUT"
+}
+
+duration=$(probe_stream duration)
+color_space=$(probe_stream color_space)
+color_transfer=$(probe_stream color_transfer)
+color_primaries=$(probe_stream color_primaries)
+
+if ! awk -v seconds="$duration" 'BEGIN { exit !(seconds >= 18 && seconds <= 24) }'; then
+  echo "STOP: the final recording must be 18–24 seconds; found ${duration}s" >&2
+  exit 1
+fi
+
+for value in "$color_space" "$color_transfer" "$color_primaries"; do
+  if [ -z "$value" ] || [ "$value" = "unknown" ] || [ "$value" = "unspecified" ]; then
+    echo "STOP: the recording has incomplete color metadata; do not guess the input color space" >&2
+    exit 1
+  fi
+done
+
+color_filter=""
+if [ "$color_space" != "bt709" ] || [ "$color_transfer" != "bt709" ] || [ "$color_primaries" != "bt709" ]; then
+  color_filter="colorspace=all=bt709:format=yuv420p,"
+fi
+
+echo "Exporting MP4 from ${duration}s source (${color_space}/${color_transfer}/${color_primaries})"
+ffmpeg -hide_banner -loglevel error -y -i "$INPUT" \
+  -vf "${color_filter}fps=30,scale='min(1920,iw)':-2:flags=lanczos,format=yuv420p" \
+  -an -c:v libx264 -preset medium -crf 18 -movflags +faststart \
+  -color_primaries bt709 -color_trc bt709 -colorspace bt709 \
+  -f mp4 "$MP4_TMP"
+mv -f "$MP4_TMP" "$MP4"
+
+gif_ok=false
+for preset in "960 10 128" "800 10 96" "720 8 80" "640 8 64"; do
+  IFS=' ' read -r width fps colors <<< "$preset"
+  echo "Trying GIF at ${width}px, ${fps} fps, ${colors} colors"
+  ffmpeg -hide_banner -loglevel error -y -i "$INPUT" \
+    -filter_complex "[0:v]${color_filter}fps=${fps},scale=${width}:-2:flags=lanczos,split[v0][v1];[v0]palettegen=max_colors=${colors}:stats_mode=diff[p];[v1][p]paletteuse=dither=bayer:bayer_scale=3" \
+    -an -f gif "$GIF_TMP"
+  gif_bytes=$(wc -c < "$GIF_TMP" | tr -d ' ')
+  if [ "$gif_bytes" -lt "$MAX_GIF_BYTES" ]; then
+    mv -f "$GIF_TMP" "$GIF"
+    gif_ok=true
+    break
+  fi
+  rm -f "$GIF_TMP"
+done
+
+if [ "$gif_ok" != true ]; then
+  echo "STOP: no tested GIF preset produced a file under 8 MiB" >&2
+  exit 1
+fi
+
+mp4_summary=$(ffprobe -v error -select_streams v:0 \
+  -show_entries stream=width,height,pix_fmt,color_space,color_transfer,color_primaries \
+  -show_entries format=duration,size -of default=noprint_wrappers=1 "$MP4")
+gif_bytes=$(wc -c < "$GIF" | tr -d ' ')
+
+echo "$mp4_summary"
+echo "gif_size_bytes=$gif_bytes"
+echo "PASS: $MP4"
+echo "PASS: $GIF"


### PR DESCRIPTION
## Summary
- add a fail-closed exporter for the launch demo MP4 and GIF
- convert tagged non-BT.709 recordings instead of merely relabelling them
- enforce the 18–24 second beat and the 8 MiB GIF ceiling
- document the one-command Task 8 workflow

## Verification
- shellcheck scripts/export-launch-demo.sh
- bash -n scripts/export-launch-demo.sh
- real 19.99-second BT.709 source exported successfully
- synthetic Display-P3/sRGB source converted to BT.709 successfully
- existing 11.2-second clip rejected as intended
- git diff --check