### PR TITLE
docs: disclose the launch release boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Plus favorites, history, downloads, settings, private tabs, per-site
 permission prompts, session restore, and signed + notarized auto-updating
 macOS builds.
 
+> **Release/source boundary:** downloads are currently v1.8.2. The default
+> branch includes a post-v1.8.2 Island-dot refinement; use the
+> [v1.8.2 tag](https://github.com/bnfy/blanc/tree/v1.8.2) for the source snapshot
+> associated with the current public binaries.
+
 ## Source and license
 
 Blanc is **source-available, not open source**. The application source is
@@ -76,14 +81,19 @@ electron-builder derives the .icns/.ico from it automatically.
 
 ## The island
 
-**Resting pill:** up to eight dots from the active tab's group (or the
-ungrouped set), with accent = active, pulsing = loading, and hollow = private.
-When that context has more tabs, a `+N` control opens the full list; other
-groups live in the expanded panel. The pill also shows the active site's
-favicon and domain and the count of ads/trackers blocked on the page. Click a
-dot to switch tabs without expanding. The strip behind the pill tints itself
-with the page's own top-edge color, so the chrome reads as a continuation of
-the site rather than a bar above it.
+**Resting pill on `main`:** up to eight direct dots combine standalone pinned
+tabs with the active named group, loose-tab section, or pinned shelf. A
+window-wide `+N` counts every omitted tab and opens the full list. Accent means
+active, pulsing means loading, and hollow means private. Quiet tabs keep their
+normal dot and click-to-wake behavior.
+
+The downloadable v1.8.2 build instead limits those eight dots to the active
+tab's group (or the ungrouped set); its `+N` counts overflow within that
+context, while other groups live in the expanded panel. Both versions also
+show the active site's favicon and domain and the count of ads/trackers blocked
+on the page. Click a dot to switch tabs without expanding. The strip behind
+the pill tints itself with the page's own top-edge color, so the chrome reads
+as a continuation of the site rather than a bar above it.
 
 **Expanded command bar** (click the pill): address input,
 back/forward/reload, favorite (heart), and a tab switcher. `Cmd/Ctrl+L`

--- a/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
+++ b/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
@@ -47,12 +47,23 @@ community on the owner's behalf. Those steps are marked and must stop for the hu
 - **Feature freeze is in effect for the whole of Phase 2.** No feature releases during launch week.
 - **Ship as-is.** No telemetry changes, no open-sourcing any component, Patron stays in the launch narrative. These were considered and declined during brainstorming.
 - **Launch rides v1.8.2 after a ≥48h soak.** Never launch on a build published the same day.
-- **Lock the launch to published v1.8.2 behavior.** The Show HN repository,
-  README, copy, screenshots, and demo must describe the packaged public build.
-  Do not merge or demonstrate the unreleased 1Password integration, tab-import
-  work, or revised window-wide Island-dot presentation before the channel
-  sequence finishes. If that feature work lands first, stop and re-audit every
-  public claim instead of presenting unreleased behavior as v1.8.2.
+- **Lock the launch to published v1.8.2 behavior. HARD STOP TRIGGERED
+  2026-08-24.** PR #208 (`6d76ddc`) merged the revised window-wide Island-dot
+  presentation to `main` after v1.8.2 shipped. The public binary remains
+  v1.8.2. The README now states that boundary and links the v1.8.2 source tag,
+  but no channel may publish until the owner resolves the launch target:
+
+  1. **Keep the planned v1.8.2 launch:** record packaged v1.8.2, retain the
+     candid README boundary, and never describe the `main`-only dot behavior as
+     downloadable. This preserves the passed release and soak gates.
+  2. **Promote the new dot behavior:** bump to a new immutable version, run the
+     complete release and platform handoff protocol, and restart the ≥48-hour
+     soak. This moves the launch date and requires re-freezing every product
+     fact and asset.
+
+  Reverting the owner's merged feature is not an assumed option. Unreleased
+  1Password and tab-import work must still remain off `main` through the launch
+  unless the same release re-gating decision is made for them.
 - **Channel order is cheap→expensive and is not negotiable:** listings → Show HN → Reddit → Product Hunt.
 - **No retention experiments this cycle.** n=27 cannot support one. The checkpoint is Oct 1.
 - **Adding a site page REQUIRES adding its path to `MANIFEST` in `site/src/pages/sitemap.xml.js`** — the sitemap endpoint asserts the manifest matches discovered pages exactly and **fails the build** otherwise.

--- a/docs/superpowers/plans/assets/launch-copy.md
+++ b/docs/superpowers/plans/assets/launch-copy.md
@@ -7,10 +7,12 @@ fact-check and prepare non-Hacker-News copy, but never post it.
 update a single channel when a product fact changes; update the frozen facts and
 every affected section together.
 
-**Release lock:** This pack describes packaged public v1.8.2. Do not use UI or
-claims from the unreleased 1Password, tab-import, or revised Island-dot work.
-If any of that work reaches `main` before launch, stop and re-audit the README,
-demo, frozen facts, and every channel draft before publishing.
+**Release lock — HARD STOP TRIGGERED 2026-08-24:** This pack describes packaged
+public v1.8.2, but PR #208 (`6d76ddc`) has since placed a revised Island-dot
+presentation on `main`. The README now discloses the source/release boundary.
+Do not publish this pack until the owner either keeps the v1.8.2 launch with
+that boundary or releases and soaks a new version, then re-freezes these facts.
+Do not use UI or claims from unreleased 1Password or tab-import work.
 
 ## Frozen facts
 
@@ -26,6 +28,7 @@ demo, frozen facts, and every channel draft before publishing.
 | Telemetry | One packaged-build launch ping: random install ID, random session ID, version, platform, architecture, coarse OS major. Fresh profiles save the presented choice before a ping can send |
 | Memory benchmark | One Mac, one session, three runs per browser, six ad-heavy news sites, median whole-process-tree `phys_footprint`: Blanc 1.3 GB; Brave 1.7 GB; Zen 3.2 GB; Chrome 5.6 GB; Vivaldi 5.9 GB. Blanc with blocking off: 4.2 GB |
 | Release authentication | macOS signed and notarized; Windows timestamped Authenticode; checksum manifest Sigstore-signed; Windows and Linux CI artifacts have GitHub provenance attestations |
+| Repository/build boundary | Packaged downloads are v1.8.2. `main` contains a post-v1.8.2 Island-dot refinement; the v1.8.2 tag is the source snapshot associated with the public binaries |
 
 Canonical URLs—copy exactly:
 
@@ -458,6 +461,8 @@ drop a full defense where one sentence would do.
 ## Morning-of fact check
 
 - [ ] `package.json` and the latest public release both still say v1.8.2.
+- [ ] The README still distinguishes the current public binaries from any
+  post-v1.8.2 code on `main`.
 - [ ] The macOS, Windows, and Linux downloads linked from the site resolve.
 - [ ] Pricing still reads $4/month and $30/year in Polar and on the site.
 - [ ] Named Workspace creation still requires Patron; rename/removal still work


### PR DESCRIPTION
## Summary
- disclose that downloads remain v1.8.2 while main contains PR #208's post-release Island-dot refinement
- describe both the main and v1.8.2 dot behavior accurately in the Show HN README
- record the triggered launch hard stop and the two valid resolution paths

## Verification
- v1.8.2 tag resolves to published source commit 3998b36
- node --test test/unit/public-truth.test.js test/unit/island-tab-presentation.test.js
- git diff --check