### PR TITLE
docs: record Blanc 1.9.1 soak clock

### DIFF
--- a/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
+++ b/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
@@ -894,14 +894,16 @@ npx wrangler pages deployment list --project-name=blancbrowser
 
 Confirm the expected source SHA shows `Environment: Production` and
 `Branch: main`. Then load the **canonical domain** and confirm both the
-changelog and the homepage show 1.8.0 — not a Cloudflare preview URL.
+changelog and the homepage show 1.9.1 — not a Cloudflare preview URL.
 
-- [ ] **Step 10: Record the current v1.9.1 soak clock**
+- [x] **Step 10: Record the current v1.9.1 soak clock**
 
 ```bash
 echo '{"date":"2026-08-26","version":"1.9.1","publishedAt":"2026-08-26T04:29:03Z","soakEndsAt":"2026-08-28T04:29:03Z"}' \
   >> "$LAUNCH_LOG"
 ```
+
+Recorded once in the private launch log on August 27.
 
 - [ ] **Step 11: Soak exit criteria — real upgrade evidence, not elapsed time**
 

--- a/test/unit/public-truth.test.js
+++ b/test/unit/public-truth.test.js
@@ -170,6 +170,7 @@ test('official launch artifacts track the release declared by the README', () =>
   assert.ok(copy.includes(`v${version} tag is the exact source snapshot`));
   assert.ok(plan.includes(`Blanc v${version} is the current public baseline`));
   assert.ok(plan.includes(`Launch rides v${version} after a ≥48h soak`));
+  assert.ok(plan.includes(`homepage show ${version} — not a Cloudflare preview URL`));
 });
 
 test('platform specs match the shipped first-run telemetry contract', () => {


### PR DESCRIPTION
## Summary
- record the authenticated v1.9.1 publication and soak timestamps in the private launch log
- mark the soak-clock checklist step complete
- fix the stale production-version check and guard it in public-truth tests

## Verification
- node --test test/unit/public-truth.test.js (13/13)
- git diff --check