### PR TITLE
docs(release): record Windows v1.10.0 updater handoff

### DIFF
--- a/docs/release-incidents/2026-08-29-v1.10.0.md
+++ b/docs/release-incidents/2026-08-29-v1.10.0.md
@@ -73,12 +73,21 @@ v1.10.0, invoke the real **Restart Now** action, confirm installation/relaunch
 and the installed `v1.10.0` marker, then re-run strict code-signature and
 Gatekeeper checks against the updated bundle.
 
-### Windows updater handoff — PENDING
+### Windows updater handoff — PASS 2026-08-29
 
-Start inside the public v1.9.1 packaged app, let it discover and download
-v1.10.0, invoke the real **Restart Now** action, and confirm installation,
-relaunch, and the installed `v1.10.0` marker. A direct installer launch is not
-equivalent evidence.
+- The owner started inside the public v1.9.1 packaged app on Windows 11. Blanc
+  discovered and downloaded the public v1.10.0 update, presented the real
+  **Restart Now** action, installed the update, and relaunched with the exact
+  `v1.10.0` marker rendered in the footer. This was an updater handoff, not a
+  direct installer launch.
+- The first attempt exposed a recoverable updater defect after the complete
+  installer download: the PowerShell Authenticode helper reached its 120-second
+  timeout, the temporary installer remained locked (`EBUSY`), and subsequent
+  manual checks could re-arm the download watchdog during verification and
+  produce the misleading **Update download stalled** dialog. The authenticated
+  download itself had reached 100%; a clean retry subsequently completed the
+  restart handoff above. Track the signature-helper cleanup and watchdog phase
+  race separately from this release-artifact result.
 
 ### Linux public AppImage launch/render — PASS 2026-08-29
 
@@ -93,6 +102,7 @@ equivalent evidence.
   the rendered new-tab DOM reported the exact marker `v1.10.0`.
 - The same run's ordinary Ubuntu and Windows DNS launch smokes also passed.
 
-The v1.10.0 publication gate and Linux public-artifact follow-up are complete.
-Launch-week clearance remains pending until the 48-hour soak and the macOS and
-Windows updater handoffs are recorded.
+The v1.10.0 publication gate, Linux public-artifact follow-up, and Windows
+updater handoff are complete. Launch-week clearance remains pending until the
+48-hour soak and the complete macOS updater/signature/Gatekeeper evidence are
+recorded.


### PR DESCRIPTION
Records the owner-verified public v1.9.1 to v1.10.0 Windows Restart Now handoff and the recovered signature-helper/watchdog defect observed on the first attempt.\n\nVerification: documentation-only; git diff --check passed.