### PR TITLE
docs(release): record macOS v1.10.0 updater handoff

### DIFF
--- a/docs/release-incidents/2026-08-29-v1.10.0.md
+++ b/docs/release-incidents/2026-08-29-v1.10.0.md
@@ -66,12 +66,18 @@ The exact deadline is `2026-08-31T18:58:24Z`. Elapsed time must be checked
 against the still-public, non-prerelease release after that instant. This clock
 does not substitute for any platform-specific runtime gate.
 
-### macOS arm64 updater handoff — PENDING
+### macOS arm64 updater handoff — PASS 2026-08-29
 
-Start inside the public v1.9.1 packaged app, let it discover and download
-v1.10.0, invoke the real **Restart Now** action, confirm installation/relaunch
-and the installed `v1.10.0` marker, then re-run strict code-signature and
-Gatekeeper checks against the updated bundle.
+- The owner started inside the public v1.9.1 packaged app, let Blanc discover
+  and download v1.10.0, invoked the real **Restart Now** action, and confirmed
+  installation and relaunch.
+- `/Applications/Blanc.app/Contents/Info.plist` reports the exact installed
+  version `1.10.0` after the handoff.
+- `codesign --verify --deep --strict --verbose=2 /Applications/Blanc.app`
+  passed: the updated bundle is valid on disk and satisfies its Designated
+  Requirement.
+- `spctl --assess --type execute --verbose=4 /Applications/Blanc.app` passed:
+  Gatekeeper reports `accepted` with source `Notarized Developer ID`.
 
 ### Windows updater handoff — PASS 2026-08-29
 
@@ -102,7 +108,6 @@ Gatekeeper checks against the updated bundle.
   the rendered new-tab DOM reported the exact marker `v1.10.0`.
 - The same run's ordinary Ubuntu and Windows DNS launch smokes also passed.
 
-The v1.10.0 publication gate, Linux public-artifact follow-up, and Windows
-updater handoff are complete. Launch-week clearance remains pending until the
-48-hour soak and the complete macOS updater/signature/Gatekeeper evidence are
-recorded.
+The v1.10.0 publication gate and all three platform follow-ups are complete.
+Launch-week clearance remains pending only until the 48-hour soak deadline is
+reached and recorded.


### PR DESCRIPTION
Records the owner-verified public v1.9.1 to v1.10.0 macOS Restart Now handoff, installed-version confirmation, strict deep code-signature verification, and Gatekeeper acceptance.\n\nVerification: documentation-only; git diff --check passed.