### PR TITLE
fix(updater): release Windows verifier locks

### DIFF
--- a/src/main/updater-download.js
+++ b/src/main/updater-download.js
@@ -129,16 +129,21 @@ function createDownloadStallWatchdog({
 function shouldArmDownloadStallWatchdog(result, {
   alreadyDownloading = false,
   alreadyDownloaded = false,
+  verificationInProgress = false,
 } = {}) {
   // alreadyDownloaded covers a cached installer from a previous session:
   // electron-updater emits update-downloaded during checkForUpdates() *before*
   // that promise resolves, so arming here would watch a transfer that is already
   // done and false-trigger a stall after DOWNLOAD_STALL_MS of silence.
+  // verificationInProgress covers repeated manual checks after the bytes finish:
+  // those checks can return a cancellation token even though PowerShell is now
+  // validating the installer and no more download-progress events can arrive.
   return Boolean(
     result?.isUpdateAvailable
     && result.cancellationToken
     && !alreadyDownloading
-    && !alreadyDownloaded,
+    && !alreadyDownloaded
+    && !verificationInProgress
   );
 }
 

--- a/src/main/updater-signature.js
+++ b/src/main/updater-signature.js
@@ -37,24 +37,32 @@ function extractCommonName(dn) {
 }
 
 // Runs PowerShell's Get-AuthenticodeSignature and returns {error, stdout}. Never
-// rejects — the caller decides what a failure means. Mirrors electron-updater's
-// invocation (PSModulePath reset + chcp for non-ASCII cert subjects) but with a
-// long timeout. The file path is single-quote-escaped to prevent command
-// injection (Get-AuthenticodeSignature 'a';calc;'b' would otherwise run calc).
+// rejects — the caller decides what a failure means. Invoke powershell.exe
+// directly so Node's timeout terminates the process that owns the installer
+// handle. Running it behind cmd.exe (`shell: true`) only kills the shell on some
+// Windows versions, leaving PowerShell alive and the temporary installer locked.
+// Reset PSModulePath through the child environment and set PowerShell's output
+// encoding in-process instead of relying on `chcp`. The file path is
+// single-quote-escaped to prevent command injection
+// (Get-AuthenticodeSignature 'a';calc;'b' would otherwise run calc).
 function runAuthenticodeSignature(filePath, { execFileImpl = execFile, timeoutMs = SIGNATURE_TIMEOUT_MS } = {}) {
   return new Promise((resolve) => {
     const escaped = String(filePath).replace(/'/g, "''");
     execFileImpl(
-      'set "PSModulePath=" & chcp 65001 >NUL & powershell.exe',
+      'powershell.exe',
       [
         '-NoProfile',
         '-NonInteractive',
         '-InputFormat',
         'None',
         '-Command',
-        `"Get-AuthenticodeSignature -LiteralPath '${escaped}' | ConvertTo-Json -Compress"`,
+        `[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false); Get-AuthenticodeSignature -LiteralPath '${escaped}' | ConvertTo-Json -Compress`,
       ],
-      { shell: true, timeout: timeoutMs, windowsHide: true },
+      {
+        timeout: timeoutMs,
+        windowsHide: true,
+        env: { ...process.env, PSModulePath: '' },
+      },
       (error, stdout) => resolve({ error, stdout }),
     );
   });

--- a/src/main/updater.js
+++ b/src/main/updater.js
@@ -70,6 +70,10 @@ let manualDownloadPending = false;
 let activeDownloadCancellation = null;
 let downloadProgressLogger = null;
 let downloadStallWatchdog = null;
+// True from the first Authenticode verifier call until update-downloaded/error.
+// A repeated check during this phase can still return a cancellation token, but
+// there are no download-progress events left to feed the stall watchdog.
+let downloadVerificationInProgress = false;
 
 function updaterLogger() {
   return autoUpdater.logger || console;
@@ -77,6 +81,7 @@ function updaterLogger() {
 
 function clearDownloadTracking() {
   activeDownloadCancellation = null;
+  downloadVerificationInProgress = false;
   downloadStallWatchdog?.disarm();
   downloadProgressLogger?.reset();
 }
@@ -112,6 +117,7 @@ const updateChecks = createUpdateCheckCoordinator({
     if (shouldArmDownloadStallWatchdog(result, {
       alreadyDownloading: Boolean(activeDownloadCancellation),
       alreadyDownloaded: updateDownloaded,
+      verificationInProgress: downloadVerificationInProgress,
     })) {
       activeDownloadCancellation = result.cancellationToken;
       downloadProgressLogger?.reset();
@@ -155,6 +161,7 @@ function setupAutoUpdater() {
   installWindowsSignatureVerifier({
     logger: autoUpdater.logger,
     onVerifyStart: () => {
+      downloadVerificationInProgress = true;
       downloadStallWatchdog?.disarm();
       activeDownloadCancellation = null;
     },

--- a/test/unit/updater-download.test.js
+++ b/test/unit/updater-download.test.js
@@ -165,6 +165,12 @@ test('stall watchdog arms only for a fresh in-flight download', () => {
     alreadyDownloaded: true,
   }), false, 'a cached previous-session download already raised update-downloaded');
 
+  assert.equal(shouldArmDownloadStallWatchdog(available, {
+    alreadyDownloading: false,
+    alreadyDownloaded: false,
+    verificationInProgress: true,
+  }), false, 'a repeated check cannot reinterpret signature verification as a fresh download');
+
   assert.equal(shouldArmDownloadStallWatchdog(
     { isUpdateAvailable: false, cancellationToken: token },
     { alreadyDownloading: false, alreadyDownloaded: false },

--- a/test/unit/updater-signature.test.js
+++ b/test/unit/updater-signature.test.js
@@ -66,15 +66,20 @@ test('unparseable verifier output fails OPEN', async () => {
   assert.equal(await verify(['Bananify Creative'], 'C:/x.exe'), null);
 });
 
-test('runAuthenticodeSignature passes the generous timeout to execFile', async () => {
+test('runAuthenticodeSignature owns PowerShell directly so timeout releases the installer', async () => {
   const { runAuthenticodeSignature, SIGNATURE_TIMEOUT_MS } = require('../../src/main/updater-signature');
-  let capturedTimeout;
-  await runAuthenticodeSignature('C:/installer.exe', {
-    execFileImpl: (_cmd, _args, options, cb) => {
-      capturedTimeout = options.timeout;
+  let invocation;
+  await runAuthenticodeSignature("C:/O'Brien/installer.exe", {
+    execFileImpl: (cmd, args, options, cb) => {
+      invocation = { cmd, args, options };
       cb(null, '{"Status":0}');
     },
   });
-  assert.equal(capturedTimeout, SIGNATURE_TIMEOUT_MS);
+  assert.equal(invocation.cmd, 'powershell.exe');
+  assert.equal(invocation.options.timeout, SIGNATURE_TIMEOUT_MS);
+  assert.equal(invocation.options.shell, undefined, 'no cmd.exe parent can survive while PowerShell holds the installer');
+  assert.equal(invocation.options.env.PSModulePath, '');
+  assert.match(invocation.args.at(-1), /OutputEncoding/);
+  assert.match(invocation.args.at(-1), /O''Brien/, 'single quotes in the literal path stay escaped');
   assert.ok(SIGNATURE_TIMEOUT_MS > 20 * 1000, 'well above electron-updater\'s 20s cliff');
 });


### PR DESCRIPTION
## Summary\n- invoke PowerShell directly so a signature-check timeout terminates the process holding the temporary installer\n- preserve UTF-8 signature output without a cmd.exe/chcp wrapper\n- prevent repeated update checks from rearming the download watchdog during Authenticode verification\n\n## Verification\n- full unit suite passed\n- focused updater suites passed\n- revised Authenticode command ran successfully on the affected Windows 11 Parallels VM in about 8 seconds\n- returned Status 0 for Bananify Creative with a timestamp certificate\n- git diff --check passed