### PR TITLE
Correct AlternativeTo MIT launch copy

### DIFF
--- a/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
+++ b/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
@@ -125,7 +125,9 @@ community on the owner's behalf. Those steps are marked and must stop for the hu
 alternatives, approval email, and canonical listing URL are recorded. AlternativeTo's current
 FAQ requires email verification—not account age—and says paid priority
 submissions are usually reviewed within 1–2 business days, or up to a week in
-busy periods.
+busy periods. The approved description predates Blanc's August 30 adoption of
+the MIT License; Task 11 Step 2 corrects that public source-status sentence
+after the pre-launch baseline and verifies the result signed out.
 
 **Why in Phase 0, not launch week:** The plan originally claimed a seven-day
 account-age requirement. **That is false** — it came from a stale line in
@@ -1545,13 +1547,16 @@ echo '{"date":"YYYY-MM-DD","measuredAt":"HH:MM ET","event":"launch-week-baseline
 
 **Every number in Task 15 is measured against this row.**
 
-- [x] **Step 2: Confirm the AlternativeTo listing is publicly reachable**
+- [ ] **Step 2: Confirm the AlternativeTo listing and correct its pre-MIT copy**
 
-Passed August 27 in a signed-out browser at
+The availability half passed August 27 in a signed-out browser at
 `https://alternativeto.net/software/blanc/`: the page rendered the Blanc
-listing, six alternatives, and the `Sign In` control. AlternativeTo presents a
-Cloudflare challenge to automated clients, so a `403` from `curl` is not
-evidence that the approved listing is unavailable.
+listing, six alternatives, and the `Sign In` control. **After Step 1 captures
+the pre-launch baseline**, the owner edits the description to the current MIT
+wording in Task 10, saves it, and rechecks the public signed-out listing until
+the MIT source-status sentence is visible. Do not edit the listing before the
+baseline. AlternativeTo presents a Cloudflare challenge to automated clients,
+so a `403` from `curl` is not evidence that the approved listing is unavailable.
 
 - [ ] **Step 3: Submit to BetaList**
 

--- a/docs/superpowers/plans/assets/launch-copy.md
+++ b/docs/superpowers/plans/assets/launch-copy.md
@@ -410,10 +410,11 @@ free, while Named Workspace creation is paid.
 > quiet background tabs that release memory, private tabs, end-to-end encrypted
 > sync, and Touch ID passkeys on macOS.
 >
-> Blanc is free. The source is publicly available on GitHub but is not released
-> under an open-source licence. Optional Patron ($30/year or $4/month) adds three
-> macOS Dock colorways and the ability to create Named Workspaces on every
-> platform. Existing workspaces remain renameable and removable after a lapse.
+> Blanc is free and open source under the MIT License. The bundled filter lists
+> retain their CC BY-SA terms, and the Blanc name and logo remain reserved
+> trademarks. Optional Patron ($30/year or $4/month) adds three macOS Dock
+> colorways and the ability to create Named Workspaces on every platform.
+> Existing workspaces remain renameable and removable after a lapse.
 
 Do not put URLs, email addresses, or phone numbers in the description.
 

--- a/test/unit/public-truth.test.js
+++ b/test/unit/public-truth.test.js
@@ -216,6 +216,8 @@ test('official launch artifacts track the release declared by the README', () =>
   assert.ok(copy.startsWith(`# Blanc v${version} launch copy pack`));
   assert.ok(copy.includes(`| Current public release | v${version} |`));
   assert.ok(copy.includes(`v${version} tag is the exact source snapshot`));
+  assert.match(copy, /Blanc is free and open source under the MIT License/);
+  assert.doesNotMatch(copy, /not released under an open-source licen[cs]e/i);
   assert.ok(plan.includes(`Blanc v${version} is the current public baseline`));
   assert.ok(plan.includes(`Launch rides v${version} after a ≥48h soak`));
   assert.ok(plan.includes(`homepage show ${version} — not a Cloudflare preview URL`));


### PR DESCRIPTION
## Summary
- replace the stale pre-MIT AlternativeTo description with the current MIT boundary
- sequence the live listing edit after the pre-launch download baseline
- prevent the retired licensing sentence from returning

## Verification
- `git diff --check`
- `node --test test/unit/public-truth.test.js` (15/15)
- `npm run test:unit` (1,173 pass; two loopback tests sandbox-denied)
- `node --test test/unit/onepassword-live-gate-server.test.js` outside sandbox (3/3)