### PR TITLE
Gate BetaList on current paid plans

### DIFF
--- a/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
+++ b/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
@@ -1560,13 +1560,18 @@ so a `403` from `curl` is not evidence that the approved listing is unavailable.
 
 - [ ] **Step 3: Submit to BetaList**
 
-Use `https://blancbrowser.com/?ref=betalist` and the Task 10 copy. Standard
-review can take ~2 months; submitting Monday costs nothing and may land later.
+Use `https://blancbrowser.com/?ref=betalist` and the Task 10 copy. BetaList's
+current first-party [support page](https://betalist.com/support) says **all
+submissions are paid** and there is no free option; its live authenticated form
+shows the current plans, prices, and review/featuring timelines. After Steps 1
+and 2, the owner reviews those live choices and explicitly decides whether to
+purchase one. An agent must not choose or buy a plan. If the owner declines,
+record `not-submitted-paid-only` and do not count BetaList as a fired channel.
 
 - [ ] **Step 4: Record both statuses**
 
 ```bash
-echo '{"date":"YYYY-MM-DD","alternativeTo":"live|pending","betaList":"submitted"}' \
+echo '{"date":"YYYY-MM-DD","alternativeTo":"live|pending","betaList":"submitted|not-submitted-paid-only"}' \
   >> "$LAUNCH_LOG"
 ```
 

--- a/docs/superpowers/plans/assets/launch-copy.md
+++ b/docs/superpowers/plans/assets/launch-copy.md
@@ -429,6 +429,13 @@ Do not put URLs, email addresses, or phone numbers in the description.
 
 ## BetaList
 
+**Submission gate:** pending owner payment decision. BetaList's current
+[first-party support page](https://betalist.com/support) says all submissions
+are paid and there is no free option. Review the live plans, prices, and
+timelines in the authenticated form after the pre-launch baseline; do not infer
+or freeze a price from an earlier plan. If the owner declines, record the
+channel as not submitted rather than calling it fired.
+
 **Name**
 
 > Blanc

--- a/docs/superpowers/specs/2026-08-20-growth-counter-offensive-design.md
+++ b/docs/superpowers/specs/2026-08-20-growth-counter-offensive-design.md
@@ -160,14 +160,20 @@ Ordered by external clock, not by convenience.
   stated limits is the currency HN trades in, and it is the direct answer to the
   Electron objection.
 
-### Phase 2 — Launch week, sequenced cheap → expensive
+### Phase 2 — Launch week, sequenced evergreen → argumentative → showcase
 
 | Day | Channel | Rationale |
 |---|---|---|
-| Mon | AlternativeTo + BetaList listings | Zero-risk, permanent long-tail SEO. Lands even if every other channel flops. |
+| Mon | AlternativeTo + BetaList listings | Permanent long-tail groundwork. AlternativeTo is already approved; BetaList now requires a paid owner-selected plan. |
 | Tue AM ET | **Show HN** | Highest ceiling and highest hostility. Fired first because its criticism is free market research. |
 | Wed | Reddit founder posts | Rewritten using the objections HN actually raised, in communities whose rules permit self-promotion. |
 | Thu 00:01 PT | **Product Hunt** | Copy now battle-tested by two days of live argument. |
+
+**External-policy correction, 2026-08-30:** BetaList's current first-party
+[support page](https://betalist.com/support) says every submission is paid and
+there is no free option. Current plans, prices, and timelines appear at the end
+of its authenticated submission form. The original zero-risk/free assumption
+is retired; Task 11 treats BetaList as an explicit owner budget decision.
 
 The ordering is the central design decision. Show HN and Product Hunt are both
 effectively one-shot cards. Firing them on the same untested narrative risks

--- a/test/unit/public-truth.test.js
+++ b/test/unit/public-truth.test.js
@@ -218,6 +218,9 @@ test('official launch artifacts track the release declared by the README', () =>
   assert.ok(copy.includes(`v${version} tag is the exact source snapshot`));
   assert.match(copy, /Blanc is free and open source under the MIT License/);
   assert.doesNotMatch(copy, /not released under an open-source licen[cs]e/i);
+  assert.match(copy, /BetaList's current[\s\S]{0,200}all submissions[\s\S]{0,80}paid/i);
+  assert.match(plan, /BetaList's[\s\S]{0,200}all\s+submissions are paid/i);
+  assert.doesNotMatch(plan, /submitting Monday costs nothing/i);
   assert.ok(plan.includes(`Blanc v${version} is the current public baseline`));
   assert.ok(plan.includes(`Launch rides v${version} after a ≥48h soak`));
   assert.ok(plan.includes(`homepage show ${version} — not a Cloudflare preview URL`));


### PR DESCRIPTION
## Summary
- retire the stale assumption that BetaList submission is free
- require an explicit owner plan/payment decision after the launch baseline
- preserve an honest not-submitted status when the owner declines
- pin the corrected operational claim in the launch-truth test

## Current first-party evidence
- https://betalist.com/support
- https://betalist.com/terms/submissions
- https://betalist.com/criteria

## Verification
- `git diff --check`
- `node --test test/unit/public-truth.test.js` (15/15)