### PR TITLE
Harden Product Hunt launch gates

### DIFF
--- a/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
+++ b/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
@@ -11,7 +11,7 @@
 
 **Goal:** Fire the five discovery channels Blanc has never used — in one concentrated week, with measurement restored and the payment path proven first — so the September cohort is large enough for retention to become a real question.
 
-**Architecture:** Three phases. Phase 0 clears real lead times (AlternativeTo's paid priority review; Google Ads verification) and de-risks the spike (site copy corrected, production Patron purchase proven, current release + 48h soak with upgrade evidence). Phase 1 builds the reusable assets during the feature freeze. Phase 2 fires channels cheap→expensive across four days so neither one-shot card is spent on untested copy.
+**Architecture:** Three phases. Phase 0 clears real lead times (AlternativeTo's paid priority review; Product Hunt personal-account access; Google Ads verification) and de-risks the spike (site copy corrected, production Patron purchase proven, current release + 48h soak with upgrade evidence). Phase 1 builds the reusable assets during the feature freeze. Phase 2 fires evergreen listings, then argumentative communities, then Product Hunt across four days so neither one-shot card is spent on untested copy.
 
 **Tech Stack:** Astro 7 (`site/`), Cloudflare Pages, GA4 (property 544287080), Polar.sh (Patron checkout), `blanc-ping` Worker stats, `gh` CLI.
 
@@ -89,7 +89,7 @@ community on the owner's behalf. Those steps are marked and must stop for the hu
   `main` is not downloadable behavior unless a
   new immutable release completes the same platform checks and restarts the
   ≥48-hour soak.
-- **Channel order is cheap→expensive and is not negotiable:** listings → Show HN → Reddit → Product Hunt.
+- **Channel order is not negotiable:** evergreen listings → Show HN → Reddit → Product Hunt.
 - **No retention experiments this cycle.** n=27 cannot support one. The checkpoint is Oct 1.
 - **Adding a site page REQUIRES adding its path to `MANIFEST` in `site/src/pages/sitemap.xml.js`** — the sitemap endpoint asserts the manifest matches discovered pages exactly and **fails the build** otherwise.
 - **Site deploys use `npm run site:deploy`** (includes the mandatory `--branch=main`). After deploying, confirm Wrangler reports `Environment: Production`, `Branch: main`, and the expected source SHA.
@@ -1690,21 +1690,39 @@ echo '{"date":"YYYY-MM-DD","channel":"reddit","subreddits":["..."],"removed":[],
 
 **Why last:** The copy has now been tested against two days of live argument. A PH badge is permanent — spend it on a message proven to work.
 
+- [ ] **Step 0: Confirm the owner's personal account can post — do this before Thursday**
+
+Product Hunt requires a personal account; company accounts cannot post. Its
+current [posting-access guide](https://help.producthunt.com/en/articles/481909-how-can-i-get-access-to-post)
+says a newly created personal account normally waits one week before posting,
+while subscribing to the newsletter can grant immediate access. The owner must
+open the live submission flow and confirm it reaches the product form. An agent
+must not create the account, subscribe, or claim access from account age alone.
+
 - [ ] **Step 1: Revise the listing using both days' objections**
 
-- [ ] **Step 2: Launch at 00:01 Pacific**
-
-PH ranks on a daily cycle; a late-morning launch forfeits most of the day.
-
-- [ ] **Step 3: Lead with the demo video and verified stills**
+- [ ] **Step 2: Upload the demo video and verified stills early enough to preview**
 
 Product Hunt's gallery accepts video through a full YouTube URL, not a raw MP4.
-Upload Task 8's final export as public or unlisted (never private), paste the
-full URL into the draft, and verify the preview before scheduling. Upload the
-prepared 240×240 thumbnail and both 1270×760 packaged-v1.10.0 stills from
+Upload Task 8's final export as public or unlisted (never private). Its current
+[YouTube troubleshooting guide](https://help.producthunt.com/en/articles/11869741-youtube-link-troubleshooting)
+warns that a newly uploaded video may need about **12 hours** before Product
+Hunt can integrate it, so do not leave the upload for launch night. Paste the
+full URL into the draft and verify the rendered preview. Upload the prepared
+240×240 thumbnail and both 1270×760 packaged-v1.10.0 stills from
 `docs/superpowers/plans/assets/product-hunt/`; those two images satisfy the
 gallery's two-image floor. A Named Workspaces still is optional and must be
 omitted unless it is a release-backed capture labeled as a Patron feature.
+
+- [ ] **Step 3: Schedule Thursday's launch**
+
+Use **Schedule Launch**, not a manual launch-night action. Product Hunt's
+current [scheduling guide](https://help.producthunt.com/en/articles/2724119-how-to-schedule-a-post)
+allows selecting a date within 30 days, and its
+[posting guide](https://help.producthunt.com/en/articles/479557-how-to-post-a-product)
+says scheduled posts go live at **12:01 a.m. Pacific** on the selected day.
+Before scheduling, verify the Thursday date, the full YouTube preview, both
+stills, the thumbnail, the pricing tag, and the final objection-informed copy.
 
 - [ ] **Step 4: Engage all day**
 

--- a/docs/superpowers/plans/assets/launch-copy.md
+++ b/docs/superpowers/plans/assets/launch-copy.md
@@ -300,11 +300,20 @@ cross-post identical text. Revise these drafts after the Show HN objection log.
 
 ## Product Hunt
 
+**Account gate:** use the owner's personal account and confirm it can reach the
+submission form before Thursday. Product Hunt's current
+[posting-access guide](https://help.producthunt.com/en/articles/481909-how-can-i-get-access-to-post)
+says company accounts cannot post and newly created personal accounts normally
+wait one week; newsletter subscription can grant immediate access.
+
 Product Hunt's current form allows a 260-character description, recommends a
 240×240 square thumbnail, requires at least two gallery images for the gallery
 to appear, recommends 1270×760 gallery images, and supports gallery video only
 through a full YouTube URL. Upload the final demo to YouTube as public or
-unlisted—not private—and verify the full URL before scheduling. Re-check the
+unlisted—not private—at least 12 hours before the final preview when possible;
+Product Hunt warns that new YouTube uploads may need about 12 hours before they
+can be integrated. Verify the full URL in the preview, then use **Schedule
+Launch** for Thursday; scheduled posts go live at 12:01 a.m. Pacific. Re-check the
 [official posting guide](https://help.producthunt.com/en/articles/479557-how-to-post-a-product)
 when creating the draft.
 
@@ -526,7 +535,9 @@ drop a full defense where one sentence would do.
   v1.9.1 pair.
 - [ ] The Product Hunt thumbnail is 240×240 and both prepared gallery stills
   are 1270×760; the stills render without private data or post-v1.10.0 UI.
-- [ ] Product Hunt's full YouTube URL is not private and appears in the preview.
+- [ ] The owner's personal Product Hunt account can reach the submission form.
+- [ ] Product Hunt's full YouTube URL is not private, has had processing time,
+  and appears in the preview with both stills before **Schedule Launch**.
 - [ ] Each Reddit community's live rules permit the planned post format.
 - [ ] The HN account is eligible under the current Show HN restriction.
 - [ ] Anthony writes the HN title, first comment, and replies himself without

--- a/docs/superpowers/specs/2026-08-20-growth-counter-offensive-design.md
+++ b/docs/superpowers/specs/2026-08-20-growth-counter-offensive-design.md
@@ -130,22 +130,25 @@ worth running at all.
 
 Ordered by external clock, not by convenience.
 
-1. **Create the AlternativeTo account immediately.** Its submission FAQ requires
-   seven days of account age before the account may suggest an app. This is the
-   only item with a hard external lead time, and missing it removes a channel
-   from launch week entirely.
-2. **Restore measurement.** GA4 has been unreadable for several days — the
+1. **Submit AlternativeTo immediately.** Its current FAQ requires email
+   verification, not account age. The real lead time is editorial review: paid
+   priority review is normally 1–2 business days and can take longer when busy.
+2. **Verify Product Hunt posting access immediately.** Product Hunt requires a
+   personal account. Its current first-party guidance says a new account
+   normally waits one week before it can post, while subscribing to the
+   newsletter can grant immediate access. Do not discover this gate on Thursday.
+3. **Restore measurement.** GA4 has been unreadable for several days — the
    Claude in Chrome extension reports zero connected browsers — so site→download
    conversion is currently invisible. Reconnect it, and *independently* tag every
    channel URL with `?ref=` so per-channel attribution survives even if GA4 stays
    flaky. Launching the biggest traffic event in Blanc's history without
    measurement wastes it twice: no read on which channel worked, and no baseline
    for the next attempt.
-3. **Complete Google Ads advertiser verification.** Due **2026-09-02**; delivery
+4. **Complete Google Ads advertiser verification.** Due **2026-09-02**; delivery
    stops if it lapses. It must be finished before launch week, not during it.
-4. **Run one real production Patron purchase** on a packaged build. Clears the
+5. **Run one real production Patron purchase** on a packaged build. Clears the
    Named Workspaces gate and proves the checkout before traffic arrives.
-5. **Release v1.8.0** with Named Workspaces, then **soak at least 48 hours**
+6. **Release v1.8.0** with Named Workspaces, then **soak at least 48 hours**
    before launch day, so the launch rides a build that has survived a weekend
    rather than one that is hours old.
 

--- a/test/unit/public-truth.test.js
+++ b/test/unit/public-truth.test.js
@@ -221,6 +221,12 @@ test('official launch artifacts track the release declared by the README', () =>
   assert.match(copy, /BetaList's current[\s\S]{0,200}all submissions[\s\S]{0,80}paid/i);
   assert.match(plan, /BetaList's[\s\S]{0,200}all\s+submissions are paid/i);
   assert.doesNotMatch(plan, /submitting Monday costs nothing/i);
+  assert.match(copy, /Product Hunt[\s\S]{0,600}personal account[\s\S]{0,400}one week/i);
+  assert.match(copy, /YouTube[\s\S]{0,400}12 hours/i);
+  const productHuntUpload = plan.indexOf('Step 2: Upload the demo video');
+  const productHuntSchedule = plan.indexOf("Step 3: Schedule Thursday's launch");
+  assert.ok(productHuntUpload >= 0, 'Product Hunt upload step must exist');
+  assert.ok(productHuntSchedule > productHuntUpload, 'Product Hunt media preview must precede scheduling');
   assert.ok(plan.includes(`Blanc v${version} is the current public baseline`));
   assert.ok(plan.includes(`Launch rides v${version} after a ≥48h soak`));
   assert.ok(plan.includes(`homepage show ${version} — not a Cloudflare preview URL`));


### PR DESCRIPTION
## Summary
- require verified personal-account posting access before Thursday
- account for the one-week new-account wait and newsletter shortcut
- move YouTube upload and preview before scheduling and preserve a 12-hour processing window
- make Schedule Launch and the 12:01 a.m. Pacific behavior explicit
- retire stale external-channel timing language in the source spec

## Current first-party evidence
- https://help.producthunt.com/en/articles/481909-how-can-i-get-access-to-post
- https://help.producthunt.com/en/articles/11869741-youtube-link-troubleshooting
- https://help.producthunt.com/en/articles/2724119-how-to-schedule-a-post
- https://help.producthunt.com/en/articles/479557-how-to-post-a-product

## Verification
- git diff --check
- node --test test/unit/public-truth.test.js (15/15)