### PR TITLE
Gate Reddit launch posts by community rules

### DIFF
--- a/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
+++ b/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
@@ -225,7 +225,7 @@ One value per channel, used verbatim everywhere. No variants — a typo splits t
 
 ```
 Show HN        https://github.com/bnfy/blanc          (see Task 12 — NOT the marketing root)
-Reddit         https://blancbrowser.com/?ref=reddit
+Reddit         https://blancbrowser.com
 Product Hunt   https://blancbrowser.com/?ref=ph
 AlternativeTo  https://blancbrowser.com                (clean — tags risk the listing)
 BetaList       https://blancbrowser.com/?ref=betalist
@@ -251,7 +251,7 @@ cat > docs/superpowers/plans/assets/launch-urls.md <<'URLS'
 | Channel | URL | Attribution |
 |---|---|---|
 | Show HN | https://github.com/bnfy/blanc | GitHub referrer traffic |
-| Reddit | https://blancbrowser.com/?ref=reddit | GA4 landing page |
+| Reddit | https://blancbrowser.com | HTTP referrer; clean URL conservatively satisfies no-referral-link rules |
 | Product Hunt | https://blancbrowser.com/?ref=ph | GA4 landing page |
 | AlternativeTo | https://blancbrowser.com | HTTP referrer (tags discouraged) |
 | BetaList | https://blancbrowser.com/?ref=betalist | GA4 landing page |
@@ -1351,9 +1351,14 @@ extension, Blanc is genuinely not for you and I'd rather say so up front.
 
 - [x] **Step 2a: Write channel-specific Reddit drafts**
 
-One post, retargeted per community. **Never cross-post identical text.**
+One post, retargeted per eligible community. **Never cross-post identical
+text.** The drafts are candidates, not a posting list: r/windows is on hold
+unless the owner's account already has promotion permission and the green-check
+flair; r/macapps and r/linux each have account-history gates documented in the
+copy pack. Do not manufacture eligibility.
 
-**Title** (r/browsers, r/macapps, r/windows, r/linux variants):
+**Base title** (rewrite to the live community's format; r/macapps requires the
+`[OS]` prefix if eligible):
 
 ```
 I built Blanc, a desktop browser that replaces the tab strip with one floating pill
@@ -1385,7 +1390,7 @@ adds three macOS Dock colorways and named workspaces on every
 platform, and creating a named workspace is the one action that needs an active
 subscription.
 
-https://blancbrowser.com/?ref=reddit
+https://blancbrowser.com
 
 Happy to answer anything, including the sceptical version.
 ```
@@ -1667,16 +1672,33 @@ specifically, and the retrospective must not claim otherwise.
 
 Pre-empt in the post body whatever HN hit hardest. If telemetry dominated Tuesday, address it in the post rather than waiting to be asked.
 
-- [ ] **Step 2: Post to browser communities first, then platform communities**
+- [ ] **Step 2: Resolve eligibility, then post only where the live rules permit**
 
-Check each community's self-promotion rules before posting. Founder-authored, with screenshots and a candid limitations section. **Do not paste identical text across subreddits** — it reads as spam and gets removed.
+Use Task 10's current eligibility matrix and re-open every linked rule page on
+posting day. Founder-authored, with screenshots, founder disclosure, and a
+candid limitations section. Use the clean `https://blancbrowser.com` URL, not a
+`?ref=reddit` variant. **Do not paste identical text across subreddits** — it
+reads as spam and gets removed.
+
+- **r/browsers:** candidate after the same-day rule check.
+- **r/macapps:** main feed only if the personal account already has 10 local
+  karma, “Read the Rules” approval, is outside the 30-day cooldown, and meets
+  the current trust/transparency path. Use `[OS]`, the live pricing flair, and
+  Problem/Comparison/Pricing format. Otherwise use the current App Pile
+  megathread only if permitted, or skip.
+- **r/windows:** skip unless the personal account already has moderator
+  permission and the green-check flair. The current rules say new applicants
+  are not being accepted; do not request or manufacture an exception.
+- **r/linux:** post only if the account already meets the no-more-than-10%
+  own-content ratio. Make the required genuine reply to a related story, use a
+  direct source, and stay to engage. If the existing ratio fails, skip.
 
 - [ ] **Step 3: Engage in comments the same day**
 
 - [ ] **Step 4: Record results**
 
 ```bash
-echo '{"date":"YYYY-MM-DD","channel":"reddit","subreddits":["..."],"removed":[],"objections":["..."]}' \
+echo '{"date":"YYYY-MM-DD","channel":"reddit","posted":["..."],"skipped":[{"subreddit":"...","reason":"rule or eligibility gate"}],"removed":[],"objections":["..."]}' \
   >> "$LAUNCH_LOG"
 ```
 

--- a/docs/superpowers/plans/assets/launch-copy.md
+++ b/docs/superpowers/plans/assets/launch-copy.md
@@ -36,7 +36,7 @@ Canonical URLs—copy exactly:
 | Channel | URL |
 |---|---|
 | Show HN | https://github.com/bnfy/blanc |
-| Reddit | https://blancbrowser.com/?ref=reddit |
+| Reddit | https://blancbrowser.com |
 | Product Hunt | https://blancbrowser.com/?ref=ph |
 | AlternativeTo | https://blancbrowser.com |
 | BetaList | https://blancbrowser.com/?ref=betalist |
@@ -169,12 +169,25 @@ These are facts to answer from, not sentences to paste.
 
 ## Reddit
 
-Candidate communities are not a posting list. Re-check each community's current
-self-promotion, flair, account-history, and link rules on posting day. Post only
-where the rules allow it, from the owner's personal account, and do not
-cross-post identical text. Revise these drafts after the Show HN objection log.
+Candidate communities are not a posting list. The owner must re-open each
+community's live rules on posting day, use a personal account, disclose that he
+built Blanc, and never manufacture karma, comments, account history, or
+moderator access to clear a gate. Use the clean `https://blancbrowser.com` URL:
+several candidate communities prohibit affiliate, referral, invite, shortened,
+or redirecting links, and Reddit's HTTP referrer is enough for aggregate source
+measurement. Do not cross-post identical text. Revise any eligible draft after
+the Show HN objection log.
 
-### Browser community draft
+Current eligibility matrix (re-check immediately before posting):
+
+| Community | Launch status | Hard gate |
+|---|---|---|
+| r/browsers | Candidate | Re-open the [live rules](https://www.reddit.com/r/browsers/about/rules). Use the clean official URL; no affiliate/referral or invite link, and the post must be a substantive founder post rather than an FAQ/how-to link drop. |
+| r/macapps | Conditional | The personal account must already have at least 10 local karma, complete the community's “Read the Rules” approval, be outside the once-per-developer 30-day cooldown, and qualify for the main feed through the current trust or transparency path. A main-feed post must use the open-source `[OS]` title prefix, the correct live pricing flair, founder disclosure, and Problem/Comparison/Pricing format. If the account does not qualify for the main feed, use the current App Pile megathread only if its rules permit it; otherwise skip. See the [live rules](https://www.reddit.com/r/macapps/about/rules), [current trust-path and PCP policy](https://www.reddit.com/r/macapps/comments/1ryaeex/), and [post-approval instructions](https://www.reddit.com/r/macapps/comments/1smg62t/). |
+| r/windows | Skip unless already approved | Software promotion requires prior moderator permission plus the green-check user flair, and the [live rules](https://www.reddit.com/r/windows/about/rules) currently say new applicants are not being accepted. Do not apply, modmail, or post unless the owner's account already holds that permission and flair. |
+| r/linux | Conditional | The personal account must already satisfy the [live rules](https://www.reddit.com/r/linux/about/rules): no more than 10% of its posts may be the owner's own content, Blanc must be directly relevant to Linux/open source, the owner must make a genuine reply to a related story before posting, use the direct official source, and stay to engage. If the existing participation ratio fails, skip rather than creating activity to qualify. |
+
+### Browser community draft — candidate after same-day rule check
 
 **Title**
 
@@ -206,15 +219,15 @@ cross-post identical text. Revise these drafts after the Show HN objection log.
 > workspace requires Patron; renaming and removing one you already have keeps
 > working after a lapse.
 >
-> https://blancbrowser.com/?ref=reddit
+> https://blancbrowser.com
 >
 > Happy to answer the skeptical version of any of this.
 
-### macOS community draft
+### macOS community draft — conditional, rewrite into live PCP format
 
 **Title**
 
-> I made a minimal macOS browser around one floating command surface
+> [OS] I made a minimal macOS browser around one floating command surface
 
 **Body**
 
@@ -235,12 +248,12 @@ cross-post identical text. Revise these drafts after the Show HN objection log.
 > Named Workspaces. Existing workspaces remain renameable and removable if the
 > subscription lapses.
 >
-> https://blancbrowser.com/?ref=reddit
+> https://blancbrowser.com
 >
 > I would especially value feedback on whether the Island still exposes enough
 > state when several tabs are open.
 
-### Windows community draft
+### Windows community draft — hold; do not post without existing approval
 
 **Title**
 
@@ -265,12 +278,12 @@ cross-post identical text. Revise these drafts after the Show HN objection log.
 > Windows, while existing workspaces remain renameable and removable after a
 > lapse.
 >
-> https://blancbrowser.com/?ref=reddit
+> https://blancbrowser.com
 >
 > If you try it, I would like to know where the Island feels clearer—or less
 > clear—than a conventional toolbar.
 
-### Linux community draft
+### Linux community draft — conditional on existing participation eligibility
 
 **Title**
 
@@ -293,7 +306,7 @@ cross-post identical text. Revise these drafts after the Show HN objection log.
 > License. The browser is free; optional Patron ($4/month or $30/year) adds Named
 > Workspaces, with rename and removal preserved after a lapse.
 >
-> https://blancbrowser.com/?ref=reddit
+> https://blancbrowser.com
 >
 > I am interested in practical AppImage and desktop-integration feedback across
 > distributions.
@@ -538,7 +551,8 @@ drop a full defense where one sentence would do.
 - [ ] The owner's personal Product Hunt account can reach the submission form.
 - [ ] Product Hunt's full YouTube URL is not private, has had processing time,
   and appears in the preview with both stills before **Schedule Launch**.
-- [ ] Each Reddit community's live rules permit the planned post format.
+- [ ] Each Reddit community's live rules and the eligibility matrix permit the
+      planned post format; every ineligible candidate is explicitly skipped.
 - [ ] The HN account is eligible under the current Show HN restriction.
 - [ ] Anthony writes the HN title, first comment, and replies himself without
   agent drafting or editing.

--- a/docs/superpowers/plans/assets/launch-urls.md
+++ b/docs/superpowers/plans/assets/launch-urls.md
@@ -3,10 +3,12 @@
 | Channel | URL | Attribution |
 |---|---|---|
 | Show HN | https://github.com/bnfy/blanc | GitHub referrer traffic |
-| Reddit | https://blancbrowser.com/?ref=reddit | GA4 landing page |
+| Reddit | https://blancbrowser.com | HTTP referrer (conservative compliance with no-referral-link rules) |
 | Product Hunt | https://blancbrowser.com/?ref=ph | GA4 landing page |
 | AlternativeTo | https://blancbrowser.com | HTTP referrer (tags discouraged) |
 | BetaList | https://blancbrowser.com/?ref=betalist | GA4 landing page |
 
 A variant (`?ref=HN`, `?ref=hackernews`) splits the data and cannot be merged
-retroactively in GA4's landing-page report. Copy these exactly.
+retroactively in GA4's landing-page report. Copy these exactly. Reddit is the
+deliberate clean-URL exception: use the HTTP referrer and do not add a tracking
+query that can be mistaken for a prohibited referral link.

--- a/test/unit/public-truth.test.js
+++ b/test/unit/public-truth.test.js
@@ -223,6 +223,13 @@ test('official launch artifacts track the release declared by the README', () =>
   assert.doesNotMatch(plan, /submitting Monday costs nothing/i);
   assert.match(copy, /Product Hunt[\s\S]{0,600}personal account[\s\S]{0,400}one week/i);
   assert.match(copy, /YouTube[\s\S]{0,400}12 hours/i);
+  assert.match(copy, /r\/windows[\s\S]{0,300}Skip unless already approved/i);
+  assert.match(copy, /r\/macapps[\s\S]{0,800}10 local karma[\s\S]{0,500}Problem\/Comparison\/Pricing/i);
+  assert.match(copy, /r\/linux[\s\S]{0,500}10%[\s\S]{0,400}related story/i);
+  assert.match(plan, /r\/windows:[\s\S]{0,300}skip unless[\s\S]{0,300}green-check flair/i);
+  assert.match(plan, /r\/linux:[\s\S]{0,500}no-more-than-10%[\s\S]{0,300}related story/i);
+  assert.doesNotMatch(copy, /https:\/\/blancbrowser\.com\/\?ref=reddit/);
+  assert.doesNotMatch(plan, /https:\/\/blancbrowser\.com\/\?ref=reddit/);
   const productHuntUpload = plan.indexOf('Step 2: Upload the demo video');
   const productHuntSchedule = plan.indexOf("Step 3: Schedule Thursday's launch");
   assert.ok(productHuntUpload >= 0, 'Product Hunt upload step must exist');


### PR DESCRIPTION
## Summary
- turn the four Reddit drafts into an eligibility matrix backed by each community's current rules
- hold r/windows unless the owner already has the required moderator permission and flair
- gate r/macapps and r/linux on existing account eligibility without manufacturing history
- use Blanc's clean URL for Reddit and record posted and skipped communities separately
- add regression assertions for the launch gates

## Verification
- node --test test/unit/public-truth.test.js
- git diff --check