### PR TITLE
Record prelaunch Reddit objection evidence

### DIFF
--- a/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
+++ b/docs/superpowers/plans/2026-08-20-growth-counter-offensive.md
@@ -1668,6 +1668,17 @@ specifically, and the retrospective must not claim otherwise.
 
 **Depends on:** Task 12, including its objection list.
 
+- [ ] **Step 0: Account for the pre-existing third-party r/browsers thread**
+
+A third-party user—not the owner—posted
+[“Has anyone heard of Blanc Browser?”](https://www.reddit.com/r/browsers/comments/1vj0og9/has_anyone_heard_of_blanc_browser/)
+on 2026-08-08 after seeing an Instagram ad. This is public pre-launch objection
+evidence, not a founder launch and not attributable launch traffic. Carry its
+AI/vibe-coding, repository-trust, and Arc-replacement questions into the rewrite.
+On posting day, assess whether another Blanc thread would be welcome so soon
+after the existing discussion; skip r/browsers if the live rules or context are
+ambiguous. Do not revive the old thread or treat it as the Wednesday post.
+
 - [ ] **Step 1: Revise the Reddit copy (Task 10) using Tuesday's objections**
 
 Pre-empt in the post body whatever HN hit hardest. If telemetry dominated Tuesday, address it in the post rather than waiting to be asked.
@@ -1698,7 +1709,7 @@ reads as spam and gets removed.
 - [ ] **Step 4: Record results**
 
 ```bash
-echo '{"date":"YYYY-MM-DD","channel":"reddit","posted":["..."],"skipped":[{"subreddit":"...","reason":"rule or eligibility gate"}],"removed":[],"objections":["..."]}' \
+echo '{"date":"YYYY-MM-DD","channel":"reddit","preExistingMentions":["r/browsers:1vj0og9 (third party; not launch-attributable)"],"posted":["..."],"skipped":[{"subreddit":"...","reason":"rule, eligibility, or recent-duplicate gate"}],"removed":[],"objections":["..."]}' \
   >> "$LAUNCH_LOG"
 ```
 

--- a/docs/superpowers/plans/assets/launch-copy.md
+++ b/docs/superpowers/plans/assets/launch-copy.md
@@ -187,6 +187,19 @@ Current eligibility matrix (re-check immediately before posting):
 | r/windows | Skip unless already approved | Software promotion requires prior moderator permission plus the green-check user flair, and the [live rules](https://www.reddit.com/r/windows/about/rules) currently say new applicants are not being accepted. Do not apply, modmail, or post unless the owner's account already holds that permission and flair. |
 | r/linux | Conditional | The personal account must already satisfy the [live rules](https://www.reddit.com/r/linux/about/rules): no more than 10% of its posts may be the owner's own content, Blanc must be directly relevant to Linux/open source, the owner must make a genuine reply to a related story before posting, use the direct official source, and stay to engage. If the existing participation ratio fails, skip rather than creating activity to qualify. |
 
+**Known pre-launch mention:** a third-party user opened an
+[r/browsers discussion about Blanc](https://www.reddit.com/r/browsers/comments/1vj0og9/has_anyone_heard_of_blanc_browser/)
+on 2026-08-08 after seeing an Instagram ad. It is not the owner's founder post,
+does not complete the Reddit launch task, and its traffic or engagement must not
+be attributed to the launch. Its comments are still useful objection evidence:
+some readers questioned whether the project was AI/vibe-coded, whether the
+repository history was enough to trust, and whether Blanc should be framed as
+an Arc replacement. Address those themes with concrete release evidence and
+candid product boundaries. On posting day, also decide whether a new founder
+post so soon after that discussion would be welcome under the live r/browsers
+rules; skip if the answer is ambiguous. Do not revive or commandeer the old
+thread as a substitute launch.
+
 ### Browser community draft — candidate after same-day rule check
 
 **Title**

--- a/test/unit/public-truth.test.js
+++ b/test/unit/public-truth.test.js
@@ -228,6 +228,8 @@ test('official launch artifacts track the release declared by the README', () =>
   assert.match(copy, /r\/linux[\s\S]{0,500}10%[\s\S]{0,400}related story/i);
   assert.match(plan, /r\/windows:[\s\S]{0,300}skip unless[\s\S]{0,300}green-check flair/i);
   assert.match(plan, /r\/linux:[\s\S]{0,500}no-more-than-10%[\s\S]{0,300}related story/i);
+  assert.match(copy, /third-party user[\s\S]{0,300}1vj0og9[\s\S]{0,500}does not complete the Reddit launch task/i);
+  assert.match(plan, /1vj0og9[\s\S]{0,500}not a founder launch[\s\S]{0,500}skip r\/browsers/i);
   assert.doesNotMatch(copy, /https:\/\/blancbrowser\.com\/\?ref=reddit/);
   assert.doesNotMatch(plan, /https:\/\/blancbrowser\.com\/\?ref=reddit/);
   const productHuntUpload = plan.indexOf('Step 2: Upload the demo video');


### PR DESCRIPTION
## Summary
- record the existing third-party r/browsers discussion without misclassifying it as the founder launch
- carry its AI/vibe-coding, repository-trust, and Arc-positioning objections into the Reddit rewrite
- require a same-day duplicate-context decision before another r/browsers post
- keep its traffic and engagement out of launch attribution
- add regression assertions for that classification

## Verification
- node --test test/unit/public-truth.test.js
- git diff --check