### PR TITLE
Fix Mahjong 1.11 release review findings

### DIFF
--- a/spec/acceptance/newtab-layouts.feature
+++ b/spec/acceptance/newtab-layouts.feature
@@ -23,6 +23,8 @@ Feature: Start page layouts
     When I open a new tab
     Then the start page renders the "mahjong" layout
     And the embedded mahjong game is ready
+    And rapid Undo cancels pending Mahjong feedback
+    And the Mahjong completion dialog remains usable at the minimum desktop size
 
   @F35-4 @desktop
   Scenario: An embedded Mahjong timer pauses when another start layout is shown

--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -520,30 +520,51 @@ function install(refs) {
           const wrap = document.getElementById('mjBoardWrap');
           const time = document.getElementById('mjWinTime');
           const best = document.getElementById('mjWinBest');
-          if (!card || !wrap || !time || !best) return null;
+          const lastAction = document.getElementById('mjWinBoards');
+          if (!card || !wrap || !time || !best || !lastAction) return null;
           const wasHidden = card.hidden;
           const previousTime = time.textContent;
           const previousBest = best.textContent;
+          const previousScrollTop = card.scrollTop;
           try {
             // Use the longest realistic Tray labels so containment reflects
             // the completed UI rather than its shorter dormant markup.
             time.textContent = '14,400 points · 9999:59';
             best.textContent = 'best 14,400 · 9999:59';
             card.hidden = false;
+            card.scrollTop = 0;
             void card.offsetWidth;
             await new Promise((resolve) => setTimeout(resolve, 320));
             const cardRect = card.getBoundingClientRect();
             const wrapRect = wrap.getBoundingClientRect();
+            const initialActionRect = lastAction.getBoundingClientRect();
+            const actionInitiallyVisible =
+              initialActionRect.top >= cardRect.top - 1 &&
+              initialActionRect.bottom <= cardRect.bottom + 1;
+            if (!actionInitiallyVisible) {
+              card.scrollTop = card.scrollHeight;
+              await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+            }
+            const actionRect = lastAction.getBoundingClientRect();
             return {
               card: { left: cardRect.left, top: cardRect.top, right: cardRect.right, bottom: cardRect.bottom },
               wrap: { left: wrapRect.left, top: wrapRect.top, right: wrapRect.right, bottom: wrapRect.bottom },
-              centerDeltaX: Math.abs((cardRect.left + cardRect.right - wrapRect.left - wrapRect.right) / 2),
-              centerDeltaY: Math.abs((cardRect.top + cardRect.bottom - wrapRect.top - wrapRect.bottom) / 2),
+              viewport: { left: 0, top: 0, right: innerWidth, bottom: innerHeight },
+              centerDeltaX: Math.abs((cardRect.left + cardRect.right - innerWidth) / 2),
+              centerDeltaY: Math.abs((cardRect.top + cardRect.bottom - innerHeight) / 2),
               clientHeight: card.clientHeight,
               scrollHeight: card.scrollHeight,
+              scrollTop: card.scrollTop,
+              overflowY: getComputedStyle(card).overflowY,
+              actionInitiallyVisible,
+              actionVisibleAfterScroll:
+                actionRect.top >= cardRect.top - 1 && actionRect.bottom <= cardRect.bottom + 1,
+              viewportWidth: innerWidth,
+              viewportHeight: innerHeight,
             };
           } finally {
             card.hidden = wasHidden;
+            card.scrollTop = previousScrollTop;
             time.textContent = previousTime;
             best.textContent = previousBest;
           }
@@ -567,6 +588,47 @@ function install(refs) {
         })()`);
       } catch {
         return false;
+      }
+    },
+    async rapidUndoMahjongMatch() {
+      const tab = tabs.get(getActiveTabId());
+      if (!tab || !urlOf(tab).startsWith('blanc://newtab')) return null;
+      const frame = tab.view.webContents.mainFrame.framesInSubtree
+        .find((candidate) => candidate.url.startsWith('blanc://mahjong/'));
+      if (!frame) return null;
+      try {
+        return await frame.executeJavaScript(`(async () => {
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+          const free = [...document.querySelectorAll('.mj-tile:not([data-blocked]):not([hidden])')];
+          let pair = null;
+          for (let first = 0; first < free.length && !pair; first += 1) {
+            const firstName = free[first].getAttribute('aria-label')?.split(',')[0];
+            for (let second = first + 1; second < free.length; second += 1) {
+              const secondName = free[second].getAttribute('aria-label')?.split(',')[0];
+              if (firstName && firstName === secondName) {
+                pair = [free[first], free[second]];
+                break;
+              }
+            }
+          }
+          if (!pair) return { matched: false };
+          pair[0].click();
+          pair[1].click();
+          await sleep(50);
+          document.getElementById('mjUndo')?.click();
+          await sleep(900);
+          return {
+            matched: true,
+            score: document.getElementById('mjScore')?.textContent ?? null,
+            live: document.getElementById('mjLive')?.textContent ?? null,
+            transientCount: document.querySelectorAll(
+              '.mj-tile-flight, .mj-score-flight, .mj-tray-burst'
+            ).length,
+            comboFxClass: document.getElementById('mjComboFx')?.className ?? null,
+          };
+        })()`);
+      } catch {
+        return null;
       }
     },
     clickNewtabLayoutSwitcher(name) {

--- a/src/renderer/pages/mahjong.css
+++ b/src/renderer/pages/mahjong.css
@@ -701,7 +701,6 @@
   box-shadow: 0 4px 0 rgba(70, 42, 4, 0.9), 0 14px 32px rgba(0, 8, 6, 0.62), 0 0 38px rgba(244, 193, 65, 0.4), inset 0 1px rgba(255, 255, 255, 0.2), inset 0 -10px 18px rgba(50, 27, 2, 0.22);
 }
 .mj-combo-fx[data-tier="masterful"] .mj-combo-callout { scale: 1.08; }
-}
 .mj-auto-chip {
   padding: 7px 11px;
   border: 1px solid rgba(233, 204, 132, 0.54); border-radius: 999px; color: var(--mj-brass-bright);
@@ -1430,7 +1429,8 @@
   transform: translate(-50%, -50%);
   width: min(520px, calc(100% - 28px));
   max-height: calc(100% - 28px);
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: clamp(30px, 4.2vw, 42px);
   text-align: center;
   box-shadow:

--- a/src/renderer/pages/mahjong.js
+++ b/src/renderer/pages/mahjong.js
@@ -534,6 +534,22 @@ function setTileAnimationBusy(busy) {
   syncModalBackground();
 }
 
+function invalidateTileAnimations() {
+  tileAnimationGeneration += 1;
+  scoreAnimationGeneration += 1;
+  comboAnimationPauseCount = 0;
+  clearTransientMotion();
+  if (comboFxTimer !== null) window.clearTimeout(comboFxTimer);
+  comboFxTimer = null;
+  const fx = document.getElementById('mjComboFx');
+  if (fx) fx.className = 'mj-combo-fx';
+  for (const slot of document.querySelectorAll('.mj-tray-slot')) {
+    slot.classList.remove('auto-clearing', 'is-rippling', 'is-receiving', 'is-matching');
+  }
+  for (const score of scoreElements()) score.classList.remove('score-pulse');
+  setTileAnimationBusy(false);
+}
+
 function beginComboAnimationPause() {
   checkpointComboClock();
   comboAnimationPauseCount += 1;
@@ -971,6 +987,7 @@ document.addEventListener('keydown', (event) => {
 
 document.getElementById('mjUndo').addEventListener('click', () => {
   if (!game || !E.undo(game)) return;
+  invalidateTileAnimations();
   sound.play('undo');
   resumeTimerAfterUndo();
   saveAfterMutation();
@@ -1019,6 +1036,7 @@ function shuffleGame() {
   if (!game || E.isWon(game)) return false;
   const wasRescue = game.status === 'rescue';
   if (!E.shuffleRemaining(game, E.createRng(randomSeed()))) return false;
+  invalidateTileAnimations();
   sound.play('shuffle');
   saveAfterMutation();
   renderBoard();
@@ -1269,15 +1287,7 @@ function saveAfterMutation() {
 }
 
 function configureGame(nextGame) {
-  tileAnimationGeneration += 1;
-  scoreAnimationGeneration += 1;
-  comboAnimationPauseCount = 0;
-  clearTransientMotion();
-  if (comboFxTimer !== null) window.clearTimeout(comboFxTimer);
-  comboFxTimer = null;
-  const fx = document.getElementById('mjComboFx');
-  if (fx) fx.className = 'mj-combo-fx';
-  setTileAnimationBusy(false);
+  invalidateTileAnimations();
   game = nextGame;
   game.gameId = gameId;
   game.assists ||= { undo: 0, hint: 0, shuffle: 0 };
@@ -1441,7 +1451,10 @@ function setFreeHighlight(enabled) {
   document.body.dataset.freeHighlight = enabled ? 'strong' : 'standard';
   const shell = document.querySelector('.mj');
   if (shell) shell.dataset.freeHighlight = enabled ? 'strong' : 'standard';
-  if (freeHighlight) freeHighlight.checked = enabled;
+  if (freeHighlight) {
+    freeHighlight.checked = enabled;
+    freeHighlight.defaultChecked = enabled;
+  }
   try { localStorage.setItem(FREE_HIGHLIGHT_KEY, enabled ? 'on' : 'off'); } catch { /* per-session */ }
 }
 let strongFree = false;

--- a/test/desktop/steps/newtab-layouts.steps.js
+++ b/test/desktop/steps/newtab-layouts.steps.js
@@ -4,6 +4,8 @@ const assert = require('node:assert/strict');
 const { Given, When, Then } = require('@cucumber/cucumber');
 const { waitForValue } = require('../support/poll');
 
+const MAHJONG_TILE_COUNTS = Object.freeze({ turtle: 144, arch: 96, peaks: 72 });
+
 async function openNewTab(world) {
   await world.call('newTab');
   await world.waitForState((state) => {
@@ -52,11 +54,11 @@ Then('the embedded mahjong game is ready', async function () {
     () => this.call('readMahjongEmbedDom'),
     (dom) =>
       dom?.url?.startsWith('blanc://mahjong/') &&
-      dom.tileCount === 144 &&
+      dom.tileCount === MAHJONG_TILE_COUNTS[dom.layout] &&
       dom.freeTileCount >= 2 &&
       dom.tileHeight >= 59 &&
-      dom.boardFrameHeight >= 535,
-    'the embedded mahjong frame to render a playable, full-size 144-tile deal'
+      dom.boardFrameHeight >= 400,
+    'the embedded mahjong frame to render its active Daily layout at playable size'
   );
   const game = await this.call('readMahjongEmbedDom');
   assert.ok(game.boardCenterDeltaX <= 1, `board x center drifted ${game.boardCenterDeltaX}px`);
@@ -73,15 +75,63 @@ Then('the embedded mahjong game is ready', async function () {
   const completion = await this.call('readMahjongCompletionGeometry');
   assert.ok(completion, 'completion geometry should be measurable');
   assert.ok(completion.centerDeltaX <= 1, `completion x center drifted ${completion.centerDeltaX}px`);
-  assert.ok(completion.centerDeltaY <= 1, `completion y center drifted ${completion.centerDeltaY}px`);
-  assert.ok(completion.card.left >= completion.wrap.left - 1);
-  assert.ok(completion.card.top >= completion.wrap.top - 1);
-  assert.ok(completion.card.right <= completion.wrap.right + 1);
-  assert.ok(completion.card.bottom <= completion.wrap.bottom + 1);
+  assert.ok(
+    completion.centerDeltaY <= 1,
+    `completion y center drifted ${completion.centerDeltaY}px: ${JSON.stringify(completion)}`
+  );
+  assert.ok(completion.card.left >= completion.viewport.left - 1);
+  assert.ok(completion.card.top >= completion.viewport.top - 1);
+  assert.ok(completion.card.right <= completion.viewport.right + 1);
+  assert.ok(completion.card.bottom <= completion.viewport.bottom + 1);
   assert.ok(
     completion.scrollHeight <= completion.clientHeight + 1,
     `completion card unexpectedly scrolls (${completion.scrollHeight}px > ${completion.clientHeight}px)`
   );
+});
+
+Then('rapid Undo cancels pending Mahjong feedback', async function () {
+  const result = await this.call('rapidUndoMahjongMatch');
+  assert.ok(result?.matched, 'a free matching pair should be available');
+  assert.equal(result.score, '0');
+  assert.equal(result.live, 'Last move undone.');
+  assert.equal(result.transientCount, 0, 'stale motion elements should be removed');
+  assert.equal(result.comboFxClass, 'mj-combo-fx');
+});
+
+Then('the Mahjong completion dialog remains usable at the minimum desktop size', async function () {
+  const original = await this.call('windowContentBounds');
+  assert.ok(original, 'window content bounds should be available');
+  try {
+    await this.call('setWindowContentSize', 640, 480);
+    await waitForValue(
+      () => this.call('windowContentBounds'),
+      (bounds) => bounds?.width === 640 && bounds?.height === 480,
+      'minimum desktop content bounds'
+    );
+    const completion = await waitForValue(
+      () => this.call('readMahjongCompletionGeometry'),
+      (value) => value?.viewportWidth === 640 && value.actionVisibleAfterScroll,
+      'scrollable compact Mahjong completion dialog'
+    );
+    assert.equal(completion.overflowY, 'auto');
+    assert.ok(
+      completion.scrollHeight > completion.clientHeight,
+      'the compact regression should exercise the card scroll path'
+    );
+    assert.ok(completion.scrollTop > 0, 'the final action should be reachable by scrolling');
+    assert.equal(completion.actionVisibleAfterScroll, true);
+    assert.ok(completion.card.left >= completion.viewport.left - 1);
+    assert.ok(completion.card.top >= completion.viewport.top - 1);
+    assert.ok(completion.card.right <= completion.viewport.right + 1);
+    assert.ok(completion.card.bottom <= completion.viewport.bottom + 1);
+  } finally {
+    await this.call('setWindowContentSize', original.width, original.height);
+    await waitForValue(
+      () => this.call('windowContentBounds'),
+      (bounds) => bounds?.width === original.width && bounds?.height === original.height,
+      'restored desktop content bounds'
+    );
+  }
 });
 
 When('I make a move in embedded Mahjong', async function () {

--- a/test/unit/mahjong-page.test.js
+++ b/test/unit/mahjong-page.test.js
@@ -10,6 +10,10 @@ const styles = ['pages.css', 'mahjong.css'].map((name) => fs.readFileSync(
   path.join(__dirname, `../../src/renderer/pages/${name}`),
   'utf8'
 )).join('\n');
+const mahjongStyles = fs.readFileSync(
+  path.join(__dirname, '../../src/renderer/pages/mahjong.css'),
+  'utf8'
+);
 const html = fs.readFileSync(
   path.join(__dirname, '../../src/renderer/pages/mahjong.html'),
   'utf8'
@@ -47,6 +51,20 @@ function mediaBlocks(query) {
     searchFrom = cursor;
   }
 }
+
+test('the Mahjong stylesheet has balanced blocks', () => {
+  let depth = 0;
+  let line = 1;
+  for (const character of mahjongStyles) {
+    if (character === '\n') line += 1;
+    else if (character === '{') depth += 1;
+    else if (character === '}') {
+      depth -= 1;
+      assert.ok(depth >= 0, `unexpected closing brace on line ${line}`);
+    }
+  }
+  assert.equal(depth, 0, 'Mahjong CSS ends with an open block');
+});
 
 test('mahjong provides static hint feedback and suppresses shake for reduced motion', () => {
   const block = mediaBlocks('(prefers-reduced-motion: reduce)')
@@ -304,6 +322,7 @@ test('v2 exposes setup, Tray rescue, local restoration, and keyboard affordances
   assert.match(controller, /game\?\.mode === 'tray'[\s\S]*!document\.hidden[\s\S]*embedActive[\s\S]*!tileAnimationBusy[\s\S]*comboAnimationPauseCount === 0[\s\S]*!activeModal\(\)/);
   assert.match(controller, /document\.getElementById\('mjHint'\)\.addEventListener[\s\S]*game\.assists\.hint \+= 1[\s\S]*saveAfterMutation\(\)/);
   assert.doesNotMatch(controller, /getElementById\('mjHint'\)[\s\S]{0,600}resetCombo/);
+  assert.match(controller, /freeHighlight\.checked = enabled;\s*freeHighlight\.defaultChecked = enabled;/);
 });
 
 test('only automatic-clear motion locks input while ordinary tile feedback stays responsive', () => {
@@ -317,6 +336,10 @@ test('only automatic-clear motion locks input while ordinary tile feedback stays
   assert.match(controller, /result\.type === 'tray-pair' \? 760[\s\S]*result\.type === 'tray-park' \|\| result\.type === 'rescue' \? 340[\s\S]*: 240/);
   assert.match(controller, /comboAnimationPauseCount === 0/);
   assert.match(controller, /if \(tileAnimationBusy\) \{[\s\S]*event\.preventDefault\(\);[\s\S]*return;/);
+  assert.match(controller, /function invalidateTileAnimations\(\)[\s\S]*tileAnimationGeneration \+= 1;[\s\S]*scoreAnimationGeneration \+= 1;/);
+  assert.match(controller, /getElementById\('mjUndo'\)\.addEventListener[\s\S]*E\.undo\(game\)[\s\S]*invalidateTileAnimations\(\)/);
+  assert.match(controller, /E\.shuffleRemaining\(game,[\s\S]*invalidateTileAnimations\(\)/);
+  assert.match(controller, /function configureGame\(nextGame\) \{\s*invalidateTileAnimations\(\);/);
 });
 
 test('combo feedback restores animated tiles and removes immediately for reduced motion', () => {
@@ -352,6 +375,12 @@ test('combo feedback restores animated tiles and removes immediately for reduced
   assert.match(styles, /\.mj-combo-fx\s*\{[^}]*contain:\s*layout paint;[^}]*isolation:\s*isolate;/);
   assert.match(styles, /\.mj-combo-callout strong\s*\{[^}]*font:\s*820[^}]*-webkit-text-stroke:[^}]*text-shadow:/);
   assert.doesNotMatch(styles, /\.mj-(?:combo-particles|combo-glint|tray-burst)[^{]*\{[^}]*mix-blend-mode:/);
+});
+
+test('the completion card scrolls its content while its decorative layer stays clipped', () => {
+  assert.match(styles, /\.mj-win\s*\{[^}]*max-height:[^}]*overflow-x:\s*hidden;[^}]*overflow-y:\s*auto;/);
+  assert.doesNotMatch(styles, /\.mj-win\s*\{[^}]*overflow:\s*hidden;/);
+  assert.match(styles, /\.mj-win-visual\s*\{[^}]*overflow:\s*hidden;/);
 });
 
 test('desktop game header promotes session identity and status hierarchy', () => {

--- a/test/unit/tab-sleep-dirty-probe.test.js
+++ b/test/unit/tab-sleep-dirty-probe.test.js
@@ -41,3 +41,10 @@ test('an edited text control still protects the tab', () => {
   });
   assert.equal(result.dirty, true);
 });
+
+test('a persisted checkbox aligned with its default is not unsaved work', () => {
+  const result = runProbe({
+    inputs: [{ type: 'checkbox', checked: true, defaultChecked: true }],
+  });
+  assert.equal(result.dirty, false);
+});


### PR DESCRIPTION
Addresses every finding from the pre-1.11 Mahjong code review:

- make Daily acceptance layout-aware
- keep completion actions reachable at minimum window size
- invalidate stale motion and score feedback on Undo and Shuffle
- keep the persisted free-tile toggle compatible with Quiet Tabs
- repair malformed Mahjong CSS and add regression coverage

Verification:
- npm run test:unit: 1,320 passing
- desktop acceptance: 127 scenarios and 781 steps passing
- substrate checks passing
- Mahjong telemetry smoke passing