### PR TITLE
release: prepare Blanc 1.11.0

### DIFF
--- a/compliance/THIRD_PARTY_NOTICES.txt
+++ b/compliance/THIRD_PARTY_NOTICES.txt
@@ -41,7 +41,7 @@ RUNTIME NPM COMPONENTS
 
 EMBEDDED FRAMEWORK
 
-- Electron 44.0.0 — MIT — https://github.com/electron/electron
+- Electron 44.1.0 — MIT — https://github.com/electron/electron
   Electron embeds Chromium, Node.js, V8, and other upstream work. LICENSE.electron.txt and
   LICENSES.chromium.html are copied beside this notice in every packaged application.
 

--- a/compliance/root-lock-sbom.cdx.json
+++ b/compliance/root-lock-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:root:blanc@1.10.0",
+      "bom-ref": "application:root:blanc@1.11.0",
       "name": "blanc dependency lock",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "description": "Complete root npm supply-chain inventory, including development and optional packages."
     },
     "properties": [
@@ -7629,14 +7629,14 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/electron@44.0.0",
+      "bom-ref": "pkg:npm/electron@44.1.0",
       "name": "electron",
-      "version": "44.0.0",
+      "version": "44.1.0",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "1644ea3eb14f65896374f2396fb28e446b094dde8581440379f97932b5375f3f51f3ba408fd24bade2230ea71137c849224147228bb4a3c90acef7294fdaa245"
+          "content": "9262e0f1ac4e836d830b77d7c79342c01616f1fc74acadb3cc9dd37faec68cd0a4c5fa3111c77eca8d107c38e506d1c9b37c5e03c7d383ae1bea2573153544ae"
         }
       ],
       "licenses": [
@@ -7646,7 +7646,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/electron@44.0.0",
+      "purl": "pkg:npm/electron@44.1.0",
       "properties": [
         {
           "name": "blanc:development",
@@ -7668,7 +7668,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/electron/-/electron-44.0.0.tgz"
+          "url": "https://registry.npmjs.org/electron/-/electron-44.1.0.tgz"
         }
       ]
     },
@@ -18197,7 +18197,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:root:blanc@1.10.0",
+      "ref": "application:root:blanc@1.11.0",
       "dependsOn": [
         "pkg:npm/%401password/sdk@0.5.0",
         "pkg:npm/%40cucumber/cucumber@13.2.1",
@@ -18206,7 +18206,7 @@
         "pkg:npm/%40ghostery/adblocker@2.18.2",
         "pkg:npm/electron-builder@26.15.3",
         "pkg:npm/electron-updater@6.8.9",
-        "pkg:npm/electron@44.0.0",
+        "pkg:npm/electron@44.1.0",
         "pkg:npm/playwright@1.62.1",
         "pkg:npm/sharp@0.35.3"
       ]
@@ -19280,7 +19280,7 @@
       ]
     },
     {
-      "ref": "pkg:npm/electron@44.0.0",
+      "ref": "pkg:npm/electron@44.1.0",
       "dependsOn": [
         "pkg:npm/%40electron-internal/extract-zip@1.0.4",
         "pkg:npm/%40electron/get@5.0.0",

--- a/compliance/runtime-sbom.cdx.json
+++ b/compliance/runtime-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:runtime:blanc@1.10.0",
+      "bom-ref": "application:runtime:blanc@1.11.0",
       "name": "Blanc",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "description": "Shipped desktop runtime: npm closure, Electron framework, bundled fonts, and blocker data provenance."
     },
     "properties": [
@@ -1036,14 +1036,14 @@
     },
     {
       "type": "framework",
-      "bom-ref": "pkg:npm/electron@44.0.0",
+      "bom-ref": "pkg:npm/electron@44.1.0",
       "name": "electron",
-      "version": "44.0.0",
+      "version": "44.1.0",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "1644ea3eb14f65896374f2396fb28e446b094dde8581440379f97932b5375f3f51f3ba408fd24bade2230ea71137c849224147228bb4a3c90acef7294fdaa245"
+          "content": "9262e0f1ac4e836d830b77d7c79342c01616f1fc74acadb3cc9dd37faec68cd0a4c5fa3111c77eca8d107c38e506d1c9b37c5e03c7d383ae1bea2573153544ae"
         }
       ],
       "licenses": [
@@ -1053,7 +1053,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/electron@44.0.0",
+      "purl": "pkg:npm/electron@44.1.0",
       "properties": [
         {
           "name": "blanc:declaration",
@@ -1067,7 +1067,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/electron/-/electron-44.0.0.tgz"
+          "url": "https://registry.npmjs.org/electron/-/electron-44.1.0.tgz"
         }
       ]
     },
@@ -1704,7 +1704,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:runtime:blanc@1.10.0",
+      "ref": "application:runtime:blanc@1.11.0",
       "dependsOn": [
         "asset:blanc-adblock-seed",
         "asset:inter-font",
@@ -1712,7 +1712,7 @@
         "pkg:npm/%401password/sdk@0.5.0",
         "pkg:npm/%40ghostery/adblocker-electron@2.18.2",
         "pkg:npm/electron-updater@6.8.9",
-        "pkg:npm/electron@44.0.0"
+        "pkg:npm/electron@44.1.0"
       ]
     },
     {
@@ -1856,7 +1856,7 @@
       ]
     },
     {
-      "ref": "pkg:npm/electron@44.0.0",
+      "ref": "pkg:npm/electron@44.1.0",
       "dependsOn": []
     },
     {

--- a/docs/press/release-notes/v1.11.0.md
+++ b/docs/press/release-notes/v1.11.0.md
@@ -1,0 +1,21 @@
+# Blanc 1.11.0
+
+## Added
+
+- Mahjong is now available as a complete start-page layout. Fresh Mahjong tables begin with the deterministic Daily Peaks board in Burst mode, with scoring, timed combos, automatic clears, hints, shuffle, undo, records, sound controls, and a footer that can be hidden while playing.
+- Local crash diagnostics can now be exported from Settings, and an unclean shutdown offers explicit recovery choices without sending browsing data anywhere.
+- Certificate failures now use a dedicated Blanc surface with clearer site-trust information instead of falling through to a generic navigation error.
+
+## Changed
+
+- Mahjong has a more visual, responsive game experience: clearer rack tiles, dimensional score feedback, board-to-rack movement, stronger match and hint effects, polished dialogs and controls, reduced-motion fallbacks, and layouts that adapt cleanly to smaller windows.
+- Blanc's revised B mark now appears consistently across the desktop app, app-icon variants, internal pages, website, favicons, press assets, and social media artwork included in the repository.
+- The desktop blocker now ships with a verified precompiled seed for faster initialization while retaining the same bundled, hash-pinned filter inputs and fail-closed package checks.
+- Blanc is now distributed under the MIT License, with generated dependency notices, packaged compliance checks, and a CycloneDX software bill of materials for releases.
+- When optional usage measurement is enabled, packaged builds can record one bounded Mahjong-use event and the fixed start-page layouts rendered during an app session. These events contain no URLs, searches, page content, custom text, or game state and are never sent from private tabs.
+- Electron has been updated to 44.1.0.
+
+## Fixed
+
+- Mahjong completion actions remain reachable at Blanc's minimum window size, Daily acceptance respects the selected layout, and Undo or Shuffle can no longer leave stale motion or score feedback behind.
+- Windows update verification now releases installer handles reliably and avoids rearming the download watchdog while signature verification is in progress.

--- a/docs/release-incidents/2026-08-29-v1.10.0.md
+++ b/docs/release-incidents/2026-08-29-v1.10.0.md
@@ -60,11 +60,13 @@ explicit user actions.
 Publication does not itself prove an updater restart handoff or a public Linux
 launch. These gates remain distinct from the publication evidence above.
 
-### 48-hour soak clock — PENDING
+### 48-hour soak clock — PASS 2026-08-31
 
-The exact deadline is `2026-08-31T18:58:24Z`. Elapsed time must be checked
-against the still-public, non-prerelease release after that instant. This clock
-does not substitute for any platform-specific runtime gate.
+At `2026-08-31T19:04:22Z`, GitHub still reported v1.10.0 as public,
+non-draft, and non-prerelease with the unchanged publication time
+`2026-08-29T18:58:24Z`. The exact 48-hour deadline
+`2026-08-31T18:58:24Z` had elapsed. This clock result does not substitute for
+the platform-specific runtime gates recorded below.
 
 ### macOS arm64 updater handoff — PASS 2026-08-29
 

--- a/docs/release-incidents/2026-08-31-v1.11.0.md
+++ b/docs/release-incidents/2026-08-31-v1.11.0.md
@@ -1,0 +1,66 @@
+# v1.11.0 release verification — 2026-08-31
+
+Blanc v1.11.0 is prepared for publication through PR #259. The immutable
+release source commit, publication time, native workflow, authenticated
+manifest, and public-download evidence will be recorded here after the release
+completes.
+
+- Release PR: <https://github.com/bnfy/blanc/pull/259>
+- Private Windows/Linux validation: <https://github.com/bnfy/blanc/actions/runs/33428605456>
+- GitHub release: pending
+- Native release workflow: pending
+- Published at: pending
+
+## Scope
+
+This release adds the complete Mahjong start-page layout with Daily Peaks as
+the default fresh table and Burst gameplay, along with scoring, combos, hints,
+shuffle, undo, records, sound controls, responsive layouts, and an optional
+hidden footer. It also adds local crash diagnostics and recovery choices,
+dedicated certificate-failure UX, the revised Blanc mark across application and
+site assets, a verified precompiled blocker seed, MIT licensing and dependency
+compliance material, privacy-bounded optional product-use events, Electron
+44.1.0, and Windows updater-verification fixes.
+
+## Pre-publication evidence
+
+- The candidate passed all 1,321 unit tests, 127 live desktop acceptance
+  scenarios / 781 steps, cold launch, OAuth, DNS, production dependency audit,
+  generated-source, branding, token, settings, copy, adblock, compliance,
+  Windows-icon, and site-build gates.
+- PR #259's required checks passed and GitHub reported the PR mergeable.
+- The exact runtime candidate at `ad94b30` passed the private Windows and Linux
+  workflow. Both platforms passed artifact, packaged blocker, packaged
+  compliance, and hardened-fuse verification; Windows additionally passed the
+  exact publisher/timestamp Authenticode gate. The subsequent incident-record
+  commit changes documentation only, which is outside electron-builder's
+  packaged `build.files` allowlist.
+- The signed Windows validation installer
+  `Blanc-Setup-1.11.0.exe` had SHA-256
+  `52148baedeec6987fc7e97f73160b8974d4c33710795b99a191afd58c2ab83bc`.
+  On August 31, the owner installed this exact candidate on Windows and
+  confirmed that it installed and worked correctly. This direct candidate
+  install is platform runtime evidence, not a public updater handoff.
+- The Linux validation AppImage `Blanc-1.11.0.AppImage` had SHA-256
+  `7f631680b1ac75ee7abf803f17268bd07e1c1d0f6efc7dc6c728399d391b084c`.
+  Its automated package, payload, compliance, and fuse gates passed.
+
+## Linux manual-runtime waiver — APPROVED 2026-08-31
+
+The owner explicitly waived manual Linux runtime testing for v1.11.0 because
+Linux is not reliable in the available Parallels Desktop setup. Before the
+waiver, the remaining risk was stated: automation can miss an OS-specific
+rendering, input, or runtime regression. The owner accepted that bounded risk.
+This waiver does not replace the automated Linux gates above or the required
+authenticated public AppImage launch/render smoke after publication.
+
+## Publication evidence
+
+Pending.
+
+## Follow-up evidence
+
+Publication will not by itself prove the adjacent-version macOS or Windows
+updater restart handoffs, the authenticated public Linux launch/render smoke,
+or the release soak. Those gates will be recorded separately below.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@1password/sdk": "0.5.0",
@@ -17,7 +17,7 @@
         "@cucumber/cucumber": "^13.2.1",
         "@electron/asar": "4.3.0",
         "@ghostery/adblocker": "^2.18.2",
-        "electron": "^44.0.0",
+        "electron": "^44.1.0",
         "electron-builder": "^26.15.3",
         "playwright": "^1.62.1",
         "sharp": "^0.35.3"
@@ -2593,9 +2593,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "44.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-44.0.0.tgz",
-      "integrity": "sha512-FkTqPrFPZYljdPI5b7KORGsJTd6FgUQDefl5MrU3Xz9R87pAj9JLreIjDqcRN8hJIkFHIou0o8kKzvcpT9qiRQ==",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-44.1.0.tgz",
+      "integrity": "sha512-kmLg8axOg22DC3fXx5NCwBYW8fx0rK2zzJ3Tf67GjNCkxfoxEcd+yo0QfDjlBtHJs3xeA8fTg64b6iVzFTVErg==",
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",
@@ -59,7 +59,7 @@
     "@cucumber/cucumber": "^13.2.1",
     "@electron/asar": "4.3.0",
     "@ghostery/adblocker": "^2.18.2",
-    "electron": "^44.0.0",
+    "electron": "^44.1.0",
     "electron-builder": "^26.15.3",
     "playwright": "^1.62.1",
     "sharp": "^0.35.3"

--- a/test/unit/compliance-model.test.js
+++ b/test/unit/compliance-model.test.js
@@ -29,7 +29,7 @@ test('runtime SBOM covers npm closure, Electron, fonts, and blocker provenance',
 
   assert.equal(generated.runtime.runtimePackages.length, 32);
   assert.equal(sbom.components.length, 39);
-  assert.ok(refs.has('pkg:npm/electron@44.0.0'));
+  assert.ok(refs.has('pkg:npm/electron@44.1.0'));
   assert.ok(refs.has('pkg:npm/%401password/sdk@0.5.0'));
   assert.ok(refs.has('pkg:npm/%401password/sdk-core@0.5.0'));
   assert.ok(refs.has('asset:inter-font'));
@@ -42,7 +42,7 @@ test('runtime SBOM covers npm closure, Electron, fonts, and blocker provenance',
   assert.equal([...refs].some((ref) => ref.includes('electron-builder@')), false);
 
   const root = sbom.dependencies.find((item) => item.ref.startsWith('application:runtime:'));
-  assert.ok(root.dependsOn.includes('pkg:npm/electron@44.0.0'));
+  assert.ok(root.dependsOn.includes('pkg:npm/electron@44.1.0'));
   assert.ok(root.dependsOn.includes('asset:blanc-adblock-seed'));
   const seed = sbom.dependencies.find((item) => item.ref === 'asset:blanc-adblock-seed');
   assert.deepEqual(seed.dependsOn, [


### PR DESCRIPTION
## Summary

- bump Blanc to 1.11.0 and Electron to 44.1.0
- regenerate deterministic compliance artifacts for the locked runtime
- update the compliance regression guard for Electron 44.1.0
- add checked-in public release notes covering Mahjong, the revised Blanc mark, diagnostics, certificate UX, compliance, bounded usage measurement, and updater fixes

## Production prerequisites

- deployed the merged blanc-ping Worker; invalid product events return 400 and the statistics endpoint remains bearer-protected with 401
- deployed the current main website; Cloudflare Pages records source a76bc85 as Production on branch main and the new product-usage disclosure is live

## Verification

- 1,321 unit tests passed
- 127 desktop acceptance scenarios / 781 steps passed
- cold launch, OAuth compatibility, and DNS smoke passed
- production dependency audit reports zero vulnerabilities
- substrate, brand, icons, compliance, site build, and SEO checks passed