### PR TITLE
Fix blank window after macOS Dock reopen

### DIFF
--- a/src/main/dock-reopen.js
+++ b/src/main/dock-reopen.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * Detach the page views that are children of the primary macOS window before
+ * the native window is destroyed. Background tabs are already detached.
+ * Keeping these views alive lets Dock activation rebuild only the chrome and
+ * reattach the exact active document.
+ */
+function preservePrimaryTabViews({
+  platform,
+  runtime,
+  primaryRuntime,
+  window,
+  tabs,
+  liveContents,
+  isQuitting,
+}) {
+  if (
+    platform !== 'darwin' || isQuitting || runtime !== primaryRuntime ||
+    !window || window.isDestroyed()
+  ) return [];
+
+  const preserved = [];
+  const ids = new Set([runtime.activeTabId, runtime.glanceTabId].filter(Boolean));
+  for (const id of ids) {
+    const tab = tabs.get(id);
+    if (!tab?.view || !liveContents(tab)) continue;
+    window.contentView.removeChildView(tab.view);
+    tab.view.setVisible(false);
+    preserved.push(id);
+  }
+  return preserved;
+}
+
+/** Return an active tab that can be reattached or woken on Dock reopen. */
+function reusableDockTabId({ activeTabId, tabs, liveContents }) {
+  if (!activeTabId) return null;
+  const tab = tabs.get(activeTabId);
+  if (!tab) return null;
+  return tab.asleep || liveContents(tab) ? activeTabId : null;
+}
+
+/**
+ * Own the two halves of a primary-window Dock reopen as one testable unit.
+ * Electron still owns event registration; callers bind these handlers to the
+ * runtime before installing them on BrowserWindow and its chrome WebContents.
+ */
+function createDockReopenLifecycle({
+  platform,
+  runtime,
+  primaryRuntime,
+  window,
+  tabs,
+  liveContents,
+  getIsQuitting,
+  ensureStartTab = false,
+  createStartTab,
+  activateTab,
+  flushExternalUrls,
+}) {
+  return {
+    onWindowClose() {
+      runtime.closing = true;
+      return preservePrimaryTabViews({
+        platform,
+        runtime,
+        primaryRuntime,
+        window,
+        tabs,
+        liveContents,
+        isQuitting: getIsQuitting(),
+      });
+    },
+
+    onChromeReady() {
+      let id = reusableDockTabId({
+        activeTabId: runtime.activeTabId,
+        tabs,
+        liveContents,
+      });
+      if (!id && ensureStartTab) id = createStartTab();
+      if (!id) return null;
+      runtime.activeTabId = null; // force activation to perform a fresh attach
+      activateTab(id);
+      flushExternalUrls();
+      return id;
+    },
+  };
+}
+
+module.exports = {
+  createDockReopenLifecycle,
+  preservePrimaryTabViews,
+  reusableDockTabId,
+};

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -106,6 +106,7 @@ const {
 } = require('./downloads');
 const { attachAddressMenu } = require('./address-menu');
 const { installDockMenu } = require('./dock-menu');
+const { createDockReopenLifecycle } = require('./dock-reopen');
 /** Handle from installDockMenu ({ update }); null until app-ready (macOS). */
 let dockMenuHandle = null;
 const { closableTabIds, pickSurvivorTabId } = require('./tab-context-menu-model');
@@ -6221,8 +6222,8 @@ function menuContextActions(owner) {
   };
 }
 
-function createMainWindow(runtime = primaryRuntime) {
-  return withWindowRuntime(runtime, () => createMainWindowForRuntime(runtime));
+function createMainWindow(runtime = primaryRuntime, options = {}) {
+  return withWindowRuntime(runtime, () => createMainWindowForRuntime(runtime, options));
 }
 
 function profileWindowTitle(profile) {
@@ -6231,7 +6232,7 @@ function profileWindowTitle(profile) {
     : `${profile?.name ?? 'Profile'} — Blanc`;
 }
 
-function createMainWindowForRuntime(runtime) {
+function createMainWindowForRuntime(runtime, { ensureStartTab = false } = {}) {
   if (runtime.window && !runtime.window.isDestroyed()) return runtime;
   runtime.closing = false;
   installProfileSessionPolicies(runtime.profileId);
@@ -6296,9 +6297,20 @@ function createMainWindowForRuntime(runtime) {
     refreshDockMenu(); // frontmost window changed → new active-tab line
     refocusAddressBarIfWanted();
   }));
-  rt().window.on('close', bindWindowRuntime(runtime, () => {
-    runtime.closing = true;
-  }));
+  const dockReopenLifecycle = createDockReopenLifecycle({
+    platform: process.platform,
+    runtime,
+    primaryRuntime,
+    window: newWindow,
+    tabs,
+    liveContents,
+    getIsQuitting: () => isQuitting,
+    ensureStartTab,
+    createStartTab: () => createTab(newTabUrl()),
+    activateTab: (id) => setActiveTab(id),
+    flushExternalUrls,
+  });
+  rt().window.on('close', bindWindowRuntime(runtime, dockReopenLifecycle.onWindowClose));
   rt().window.on('closed', bindWindowRuntime(runtime, () => {
     // Destroy the views the window owned — detachWindow only forgets them.
     liveViewContents(runtime.overlayView)?.close();
@@ -6352,15 +6364,10 @@ function createMainWindowForRuntime(runtime) {
   // Tabs survive window close (macOS dock-reopen recreates the window);
   // re-attach the active tab's view or the new window sits over nothing.
   // First launch has no activeTabId yet — app.whenReady handles that one.
-  rt().window.webContents.once('did-finish-load', bindWindowRuntime(runtime, () => {
-    if (!rt().activeTabId || !tabs.has(rt().activeTabId)) return;
-    const id = rt().activeTabId;
-    rt().activeTabId = null; // force setActiveTab to treat it as a fresh attach
-    setActiveTab(id);
-    // An 'open-url' with no window queues; opening it is why the window
-    // was recreated (macOS dock-reopen path).
-    flushExternalUrls();
-  }));
+  rt().window.webContents.once('did-finish-load', bindWindowRuntime(
+    runtime,
+    dockReopenLifecycle.onChromeReady
+  ));
   return runtime;
 }
 
@@ -6405,7 +6412,9 @@ function focusDockActiveWindow() {
     win.focus();
     return;
   }
-  if (BrowserWindow.getAllWindows().length === 0) createMainWindow(primaryRuntime);
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createMainWindow(primaryRuntime, { ensureStartTab: true });
+  }
   focusedRuntime = primaryRuntime;
   setFocusedLocalProfile(primaryRuntime.profileId);
 }
@@ -8040,7 +8049,9 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
   setupAutoUpdater();
 
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createMainWindow(primaryRuntime);
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createMainWindow(primaryRuntime, { ensureStartTab: true });
+    }
     focusedRuntime = primaryRuntime;
     setFocusedLocalProfile(primaryRuntime.profileId);
     refreshDockMenu();

--- a/test/unit/dock-reopen.test.js
+++ b/test/unit/dock-reopen.test.js
@@ -1,0 +1,194 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  createDockReopenLifecycle,
+  preservePrimaryTabViews,
+  reusableDockTabId,
+} = require('../../src/main/dock-reopen');
+
+function view(id, { live = true } = {}) {
+  return {
+    id,
+    live,
+    visible: true,
+    setVisible(value) { this.visible = value; },
+  };
+}
+
+test('primary macOS close detaches the active and Glance page views exactly once', () => {
+  const activeView = view('active');
+  const glanceView = view('glance');
+  const tabs = new Map([
+    ['active', { view: activeView }],
+    ['glance', { view: glanceView }],
+  ]);
+  const removed = [];
+  const runtime = {
+    activeTabId: 'active',
+    glanceTabId: 'glance',
+  };
+  const preserved = preservePrimaryTabViews({
+    platform: 'darwin',
+    runtime,
+    primaryRuntime: runtime,
+    window: {
+      isDestroyed: () => false,
+      contentView: { removeChildView: (candidate) => removed.push(candidate.id) },
+    },
+    tabs,
+    liveContents: (tab) => tab.view.live ? {} : null,
+    isQuitting: false,
+  });
+
+  assert.deepEqual(preserved, ['active', 'glance']);
+  assert.deepEqual(removed, ['active', 'glance']);
+  assert.equal(activeView.visible, false);
+  assert.equal(glanceView.visible, false);
+});
+
+test('quit and secondary-window closes do not preserve attached page views', () => {
+  const primaryRuntime = {};
+  const runtime = { activeTabId: 'active', glanceTabId: null };
+  let removed = 0;
+  const args = {
+    platform: 'darwin',
+    runtime,
+    primaryRuntime,
+    window: {
+      isDestroyed: () => false,
+      contentView: { removeChildView: () => { removed += 1; } },
+    },
+    tabs: new Map([['active', { view: view('active') }]]),
+    liveContents: () => ({}),
+  };
+
+  assert.deepEqual(preservePrimaryTabViews({ ...args, isQuitting: false }), []);
+  assert.deepEqual(preservePrimaryTabViews({
+    ...args,
+    runtime: primaryRuntime,
+    isQuitting: true,
+  }), []);
+  assert.equal(removed, 0);
+});
+
+test('Windows and Linux closes keep the normal window-owned destruction path', () => {
+  for (const platform of ['win32', 'linux']) {
+    const primaryRuntime = { activeTabId: 'active', glanceTabId: null };
+    const activeView = view('active');
+    let removed = 0;
+    const preserved = preservePrimaryTabViews({
+      platform,
+      runtime: primaryRuntime,
+      primaryRuntime,
+      window: {
+        isDestroyed: () => false,
+        contentView: { removeChildView: () => { removed += 1; } },
+      },
+      tabs: new Map([['active', { view: activeView }]]),
+      liveContents: () => ({}),
+      isQuitting: false,
+    });
+
+    assert.deepEqual(preserved, [], platform);
+    assert.equal(removed, 0, platform);
+    assert.equal(activeView.visible, true, platform);
+  }
+});
+
+test('Dock reopen reuses only a live or quiet active tab', () => {
+  const live = { view: view('live') };
+  const dead = { view: view('dead', { live: false }) };
+  const quiet = { view: null, asleep: true };
+  const tabs = new Map([['live', live], ['dead', dead], ['quiet', quiet]]);
+  const liveContents = (tab) => tab.view?.live ? {} : null;
+
+  assert.equal(reusableDockTabId({ activeTabId: 'live', tabs, liveContents }), 'live');
+  assert.equal(reusableDockTabId({ activeTabId: 'quiet', tabs, liveContents }), 'quiet');
+  assert.equal(reusableDockTabId({ activeTabId: 'dead', tabs, liveContents }), null);
+  assert.equal(reusableDockTabId({ activeTabId: 'missing', tabs, liveContents }), null);
+  assert.equal(reusableDockTabId({ activeTabId: null, tabs, liveContents }), null);
+});
+
+test('macOS lifecycle detaches before native teardown and reattaches the same document', () => {
+  const activeView = view('active');
+  const tab = { view: activeView };
+  const tabs = new Map([['active', tab]]);
+  const runtime = { activeTabId: 'active', glanceTabId: null, closing: false };
+  const attached = new Set([activeView]);
+  let fallbackCount = 0;
+  let flushCount = 0;
+  const lifecycle = createDockReopenLifecycle({
+    platform: 'darwin',
+    runtime,
+    primaryRuntime: runtime,
+    window: {
+      isDestroyed: () => false,
+      contentView: { removeChildView: (candidate) => attached.delete(candidate) },
+    },
+    tabs,
+    liveContents: (candidate) => candidate.view?.live ? {} : null,
+    getIsQuitting: () => false,
+    ensureStartTab: true,
+    createStartTab: () => { fallbackCount += 1; return 'start'; },
+    activateTab: (id) => {
+      runtime.activeTabId = id;
+      activeView.setVisible(true);
+      attached.add(tabs.get(id).view);
+    },
+    flushExternalUrls: () => { flushCount += 1; },
+  });
+
+  assert.deepEqual(lifecycle.onWindowClose(), ['active']);
+  assert.equal(runtime.closing, true);
+  assert.equal(attached.has(activeView), false);
+  assert.equal(activeView.visible, false);
+
+  // BrowserWindow teardown destroys only child views. The page survived
+  // because the close handler detached it first.
+  for (const candidate of attached) candidate.live = false;
+
+  assert.equal(lifecycle.onChromeReady(), 'active');
+  assert.equal(runtime.activeTabId, 'active');
+  assert.equal(attached.has(activeView), true);
+  assert.equal(activeView.visible, true);
+  assert.equal(fallbackCount, 0);
+  assert.equal(flushCount, 1);
+});
+
+test('Dock reopen creates and activates a start tab when no document is reusable', () => {
+  const runtime = { activeTabId: null, glanceTabId: null, closing: true };
+  const tabs = new Map();
+  const activated = [];
+  const lifecycle = createDockReopenLifecycle({
+    platform: 'darwin',
+    runtime,
+    primaryRuntime: runtime,
+    window: { isDestroyed: () => false, contentView: { removeChildView() {} } },
+    tabs,
+    liveContents: () => null,
+    getIsQuitting: () => false,
+    ensureStartTab: true,
+    createStartTab: () => {
+      tabs.set('start', { view: view('start') });
+      return 'start';
+    },
+    activateTab: (id) => { runtime.activeTabId = id; activated.push(id); },
+    flushExternalUrls() {},
+  });
+
+  assert.equal(lifecycle.onChromeReady(), 'start');
+  assert.equal(runtime.activeTabId, 'start');
+  assert.deepEqual(activated, ['start']);
+});
+
+test('main installs both handlers from the tested Dock-reopen lifecycle', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const main = fs.readFileSync(path.join(__dirname, '../../src/main/main.js'), 'utf8');
+
+  assert.match(main, /const dockReopenLifecycle = createDockReopenLifecycle\(\{/);
+  assert.match(main, /\.on\('close', bindWindowRuntime\(runtime, dockReopenLifecycle\.onWindowClose\)\)/);
+  assert.match(main, /dockReopenLifecycle\.onChromeReady/);
+});


### PR DESCRIPTION
## Summary
- preserve the active and Glance WebContentsViews before the primary macOS window is destroyed
- reattach the surviving active document when Dock activation rebuilds the browser chrome
- create a real start-page tab when no reusable document remains
- keep Windows and Linux on their existing window-owned destruction path

## Verification
- npm run test:unit — 1,349 passed
- focused Dock/window-runtime tests — 22 passed
- node syntax checks and git diff check
- manual macOS Electron check: red-close the window, reactivate from the Dock, and confirm blanc://newtab/ renders the Billboard page