### PR TITLE
site: version the favicon links so cached browsers refetch Sunrise

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -63,11 +63,14 @@ const ogImageUrl = SITE + ogImage;
     {social === 'rich' && <meta name="twitter:image:alt" content={ogImageAlt}>}
   </>
 )}
-<link rel="icon" href="/favicon.ico" sizes="any">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<!-- Icon links carry a version query: browsers cache favicons far past a page
+     reload, so a mark change needs a new URL to be seen. The file paths stay
+     stable; bump the query when the mark changes again. -->
+<link rel="icon" href="/favicon.ico?v=sunrise" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=sunrise">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=sunrise">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=sunrise">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=sunrise">
 <slot name="head" />
 </head>
 <body data-page={page ?? undefined}>

--- a/test/unit/brand-assets.test.js
+++ b/test/unit/brand-assets.test.js
@@ -226,3 +226,11 @@ test('the demo island hides the favicon slot on internal pages like the shipped 
   assert.match(css, /\.demo-island \.pill-fav\.internal \{ display: none;/);
   assert.doesNotMatch(css, /\.demo-island \.pill-fav\.internal \{[^}]*logo\.png/);
 });
+
+test('the site icon links carry a version query so cached favicons refetch after a mark change', () => {
+  const layout = source('site/src/layouts/BaseLayout.astro');
+  for (const file of ['favicon.ico', 'favicon.svg', 'favicon-32x32.png', 'favicon-16x16.png', 'apple-touch-icon.png']) {
+    assert.match(layout, new RegExp('href="/' + file.replace('.', '\\.') + '\\?v=[A-Za-z0-9._-]+"'), file + ' link is versioned');
+  }
+  assert.doesNotMatch(layout, /href="\/favicon[^"?]*"/, 'no unversioned favicon link remains');
+});


### PR DESCRIPTION
## Summary

After #263 shipped Sunrise, browsers that had cached the B favicon kept showing it: favicons are cached separately from pages and the icons carry a 4-hour `max-age`. The five icon links in `BaseLayout.astro` now carry `?v=sunrise`. File paths stay stable (no renames in `public/`); bump the query when the mark changes again.

## Verification

- New unit test fails on any unversioned favicon link; suite at 1365 passing.
- `npm run site:build` + SEO check pass; every built page profile (island, standard, legal) emits the versioned links and no unversioned one remains.
- Edge already serves the Sunrise bytes for all five files (verified in #263's deploy); this only forces clients to refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
