### PR TITLE
Make Mahjong shuffle undoable and remember the player's table

### DIFF
--- a/docs/superpowers/specs/2026-09-02-mahjong-audit.md
+++ b/docs/superpowers/specs/2026-09-02-mahjong-audit.md
@@ -1,0 +1,89 @@
+# Mahjong audit — bugs, gameplay gaps, and a Mahjong Blast comparison
+
+**Date:** 2026-09-02
+**Scope:** `src/renderer/pages/mahjong-engine.js`, `mahjong-state.js`, `mahjong.js`, `mahjong-sound.js`, `mahjong.html`, the new-tab embed in `newtab.js`, and the four `test/unit/mahjong-*.test.js` suites (90 tests, all passing at `ff3eaad`).
+**Method:** code read of every module, node probes against the engine (900 random deals, 730 consecutive daily deals, undo/hint edge cases, localStorage churn benchmark), and a visual/interactive pass of the page served over `127.0.0.1` in the Browser pane (setup sheet, Classic win, Burst rescue, 720×560 viewport, light colour scheme). Mahjong Blast facts come from App Store / Google Play listings and user reviews, gathered by a research agent; sourced vs. inferred is marked below.
+
+## 1. What is solid
+
+- **Deals are solvable by construction** and generation never failed: 0 failures across 300 seeds per layout and 730 consecutive daily deals, ~3 ms per Turtle deal.
+- Engine, persistence, and duplicate-tab guard are pure, validated on restore, and well covered. Corrupt or forged saves fall back to a fresh deal with a notice.
+- Reduced-motion fallbacks, keyboard navigation, live-region announcements, and focus recovery all exist and work.
+- Sound is local Web Audio, lazily created, persisted per device.
+- Perf is fine: with 32 saved games a `save()` costs ~1 ms and a record read ~0.5 ms (node measurement).
+
+## 2. Bugs and defects (ranked)
+
+### B1. Shuffle is irreversible and bound to a bare `S` key — medium
+`shuffleRemaining()` clears `state.history`, and `mahjong.js` binds an unmodified `s` to it with no confirmation. One stray keypress destroys the entire undo stack mid-game, and in Burst it also drops the combo. Fix options: push a `shuffle` history action carrying the prior `kinds`/`removed`/`tray` so Undo can reverse it (bounded, since kinds are ~2.5 KB), or at minimum require a confirm on the keyboard path. The Rescue dialog's "shuffle & continue" is fine because it is explicit.
+
+### B2. Every new tab forgets the player's game and preferences — medium (UX)
+Each new tab mints a fresh `game` id (`newtab.js` `mahjongGameId()`), and `bootstrap()` hard-codes the first deal to Daily + Burst. A player who prefers Classic Turtle reconfigures through Boards on every new tab, and a half-finished board in a closed tab is unreachable from a new one (it lingers in localStorage until the 30-day expiry or the 32-game cap evicts it). Only the free-highlight toggle persists. Fix: persist last layout/mode/source under a `mahjong.prefs` key and use it for fresh tabs; add a "continue last game" entry (most recently accessed save) to the setup sheet or the bootstrap path.
+
+### B3. Undo after a Burst match erases the earlier park — low/medium (design ambiguity)
+`selectTrayTile()` calls `removeParkHistory()` on a match and records the *post*-match tray as `priorTray`. Undoing the match therefore returns both tiles to the board and leaves nothing to undo for the park. Probe: park A, match A′, undo → tray `[]`, both on board, `history.length === 0`. Coherent, but players expect Undo to step back one action (A′ back on the board, A still in the rack). If it is deliberate, document it in the engine comment; otherwise record the true prior tray and keep the park action.
+
+### B4. Hint can recommend a move that immediately triggers Rescue — low
+With three parked tiles and no rack match, `availableMoves()` returns singles, so `Hint` highlights a tile whose only outcome is filling the rack. The hint should instead say the rack needs a match (or suggest undo/shuffle) in that state. Related: in Classic, `Hint` always returns `moves[0]`, so repeated presses never show a different pair.
+
+### B5. "first clear" copy is unreachable; "new record" shows even when nothing was recorded — low
+`recordCompletion()` sets `_newRecord = !before || …`, so the first completion always reads "new record" and `showWin()`'s `'first clear'` branch is dead. Reproduced: a completion with `elapsedMs === 0` was skipped by `applyResult()` (requires `> 0`) yet the dialog still said "new record". Compute `_newRecord` from whether `after` actually changed.
+
+### B6. Arrow-key navigation clears an active hint — low (a11y)
+Arrow keys call `refreshTiles()`, which calls `clearHint()`. A keyboard user who presses `H` loses the highlight the moment they start moving toward it. Keep `.hinted` across pure focus moves.
+
+### B7. Daily mode leaves the layout buttons looking enabled — low (UI)
+`paintSetupChoices()` sets `disabled` on the layout buttons when Daily is selected, but `mahjong.css` styles only `.mj-dock > button[disabled]`. Turtle/Peaks look clickable and silently do nothing. Add a disabled style plus a one-line note ("Daily rotates the layout").
+
+### B8. "No moves remain" notice omits Shuffle — low
+The Classic dead-end notice offers undo / new deal only, while Shuffle (the natural remedy, and the one the Rescue dialog offers) sits in the dock. "New deal" also silently converts a Daily game into a random one.
+
+### B9. Match flight lands in the next empty slot, not on its mate — cosmetic
+`startTrayFlight()` uses `nextTrayTarget()` for `tray-pair` results, so the matched tile flies into an empty slot while its partner sits elsewhere in the rack; the burst anchors on whichever `is-matching` slot is later in DOM order. Target the mate's slot instead.
+
+### B10. Character tiles depend on a webfont — cosmetic
+Character faces and wind badges are SVG `<text>`; before the font loads the tiles are blank. Local fonts make this brief in the packaged app, but a `font-display`/preload or outlined numerals would remove the flash entirely.
+
+Not bugs, but verified quirks worth knowing: the page ignores `prefers-color-scheme` entirely (fixed dark lacquer table, by v2 design); the timer never starts while `document.hidden` is true, which is correct in the app; `assists` and daily results are recorded but never displayed anywhere.
+
+## 3. Gameplay enhancements (cheap, engine already supports them)
+
+1. **Undoable shuffle** (B1) and **hint cycling** (B4).
+2. **Remember preferences + continue last game** (B2).
+3. **Daily completion state in the setup sheet**: the records store already has `daily[key][mode]`; show "done · 4:12" / "best 3,450" next to the Daily toggle and on the win dialog for daily games.
+4. **Statistics panel** from existing data: games completed per layout/mode, best times/scores, assists used, average clear time, and a daily streak computed from consecutive `daily` keys. Mahjong Blast users specifically praise progress visibility and complain when rankings misbehave; a local, honest stats sheet is the Blanc-shaped answer.
+5. **Auto-clear toggle in Burst.** Mahjong Blast's most-cited gameplay complaint is auto-assist removing agency (reviews, US App Store). Blanc's every-5th-combo auto pair is the same mechanic; offer "auto clears: on/off" (off = keep the 100-point milestone bonus, skip the automatic pair). Records already carry `scoringRevision`, so a toggle can be scored separately or simply flagged.
+6. **Classic scoring option** so Classic is not time-only: a simple pair value with a time bonus, or leave Classic pure and say so in the mode description.
+7. **Distinct mismatch cue** in Classic (currently the same `select` sound), and `N`/`B` keyboard shortcuts for Boards, `Esc` to dismiss Rescue to the board with Undo.
+8. **Hint targets the mate's rack slot** and the burst anchors there (B9).
+
+## 4. New features, informed by the Mahjong Blast comparison
+
+Disambiguation: the popular "Mahjong Blast" is Nebula Studio / HURELAX PTE. LTD. (iOS id 6747492600, Play `com.nebula.mahjongtile`, formerly "Mahjong Wonders"). It is **not** a native Mac app; the Mac listing is the iPad build ("not verified for macOS"). It is free with ads plus $1.99/wk–$19.99/yr subscriptions. A closer classic-solitaire comparator is Jose Varela's "Mahjong Solitaire Blast" (564 layouts, 3 tile sets, unlimited undo/hint/shuffle).
+
+| Mahjong Blast (Nebula) | Source | Blanc today | Recommendation |
+|---|---|---|---|
+| Hundreds of progressive levels, level map, coins | listing | 3 layouts, no progression | **More layouts** (see below); a quiet "boards cleared" ledger instead of a level map |
+| Undo / hint / shuffle, unlimited | listing | Same, unlimited | Keep; make shuffle undoable |
+| Daily challenges, "fresh layouts every day" | listing | Daily deal, rotating layout, results stored but invisible | Surface daily results + streak (§3.3–3.4) |
+| Daily tournament / rankings | reviews | None (no network) | Skip. Offer **share this deal**: a `blanc://mahjong/?deal=<layout>-<seed>` link so two people can race the same board locally |
+| Auto-assist / bonus move after combos | reviews (complaint) | Auto clear every 5th combo | Add the on/off toggle (§3.5) |
+| Seasonal events with themed tile pairs | App Store Events card | One tile set | **Tile-set / table themes** (local assets only, CSP-safe): e.g. Paper (ink on paper, the original v1 direction), Lacquer (current), Ink. Costs art, not code |
+| "Large tiles", senior-friendly readability | listing | Scale-to-fit, free-tile ring toggle | **Tile size control** (fit / large with scroll) and an optional high-contrast face set |
+| Offline, no timers, zero pressure | listing | Offline; Classic has a visible timer | Add a **Zen** option: hide timer/score, no records — Classic without pressure |
+| No cloud save, sound settings reset | reviews (complaints) | Device-local; sound persists | Records could ride Profile Sync later, but that needs its own review — not a quick win |
+| 3D-rendered tiles, ads after every level | listing / reviews | 2.5D layered tiles, no ads | Nothing to copy |
+
+### More layouts (biggest content gap, cheapest per unit)
+The engine takes any list of `{x,y,z}` half-unit positions with an even count ≥ 28 (it always seats all 14 wind/dragon variant pairs). Adding a layout is: a builder in `mahjong-engine.js` with a `revision`, a `LAYOUT_IDS`/`LAYOUT_REVISIONS` entry in `mahjong-state.js`, a mini preview + button in `mahjong.html`, a `dailyLayoutId` rotation update, and a generation-success test across seeds. Good candidates with distinct feel: Pyramid (single tall stack), Fortress (walls with a courtyard), Butterfly/Dragon (wide, low), Bridge, Cross. Six to eight layouts would close most of the perceived gap without a level system.
+
+### Share a deal
+Seeds are already deterministic (`createGame({seed, layoutId})`). A `deal` query parameter that pre-seeds a Random game (validated like `game`, never trusted for state) gives Blanc a social hook with zero network. Pairs well with the daily key.
+
+## 5. Suggested first batch (one PR, low risk)
+
+**Status (2026-09-02):** implemented in this worktree — B1 (undoable shuffle; the bare `S` key stays, since Undo now reverses it), B2 (table preferences + an explicit "continue it" offer on fresh tabs), B5, B6, B7, B8, and the daily result in the setup sheet and completion card.
+
+1. B1 undoable shuffle + confirm on the `S` path. 2. B2 preference memory and continue-last-game. 3. B5 record copy fix. 4. B6 keep hint across arrow moves. 5. B7 disabled layout style. 6. B8 add Shuffle to the notice. 7. Daily result shown in setup sheet and win dialog.
+
+Then, as separate efforts: layouts (content), stats panel (UI), auto-clear toggle (scoring revision), share-a-deal (routing + validation).

--- a/src/renderer/pages/mahjong-engine.js
+++ b/src/renderer/pages/mahjong-engine.js
@@ -401,13 +401,20 @@
     return { changed: true, expired, remainingMs: next };
   }
 
+  // A shuffle empties the rack, so tray indices recorded before the most
+  // recent shuffle belong to an earlier epoch. Only the current epoch's park
+  // and its priorTray references are rewritten when a parked tile matches;
+  // the shuffle action itself and everything before it stay intact so undo
+  // can walk back through the shuffle faithfully.
   function removeParkHistory(state, trayIndex) {
+    const epochStart = state.history.findLastIndex((action) => action.type === 'shuffle') + 1;
     const parkedAction = state.history.findLastIndex(
-      (action) => action.type === 'tray-park' && action.index === trayIndex
+      (action, offset) => offset >= epochStart && action.type === 'tray-park' && action.index === trayIndex
     );
     if (parkedAction >= 0) state.history.splice(parkedAction, 1);
-    for (const action of state.history) {
-      if (Array.isArray(action.priorTray)) {
+    for (let offset = epochStart; offset < state.history.length; offset++) {
+      const action = state.history[offset];
+      if (action.type !== 'shuffle' && Array.isArray(action.priorTray)) {
         action.priorTray = action.priorTray.filter((index) => index !== trayIndex);
       }
     }
@@ -584,6 +591,7 @@
     if (!state || !Array.isArray(state.history)) return false;
     const action = state.history.pop();
     if (!action) return false;
+    let restoredStatus = STATUSES.PLAYING;
     if (action.type === 'classic-pair') {
       state.removed[action.indices[0]] = false;
       state.removed[action.indices[1]] = false;
@@ -602,11 +610,17 @@
       state.maxCombo = action.priorMaxCombo;
       state.autoClears = action.priorAutoClears;
       state.selected = null;
+    } else if (action.type === 'shuffle') {
+      state.kinds = action.priorKinds.slice();
+      state.removed = action.priorRemoved.slice();
+      state.tray = action.priorTray.slice();
+      state.selected = null;
+      restoredStatus = action.priorStatus;
     } else {
       return false;
     }
     resetCombo(state);
-    state.status = STATUSES.PLAYING;
+    state.status = restoredStatus;
     state.completionRecorded = false;
     if (!state.assists) state.assists = { undo: 0, hint: 0, shuffle: 0 };
     state.assists.undo += 1;
@@ -663,11 +677,20 @@
       if (matchKey(nextKinds[first]) !== matchKey(nextKinds[second])) return false;
     }
     // Commit only after construction and replay validation both succeeded.
+    // The shuffle is itself an undoable action: it records the exact prior
+    // board (including parked rack tiles and Rescue status) so a stray
+    // keypress never destroys a game.
+    pushHistory(state, {
+      type: 'shuffle',
+      priorKinds: state.kinds.slice(),
+      priorRemoved: state.removed.slice(),
+      priorTray: (state.tray || []).slice(),
+      priorStatus: state.status,
+    });
     state.kinds = nextKinds;
     state.removed = nextRemoved;
     state.tray = [];
     state.selected = null;
-    state.history = [];
     resetCombo(state);
     state.status = STATUSES.PLAYING;
     if (!state.assists) state.assists = { undo: 0, hint: 0, shuffle: 0 };
@@ -743,6 +766,23 @@
           priorAutoClears,
           autoClear,
         });
+      } else if (raw.type === 'shuffle') {
+        if (!Array.isArray(raw.priorKinds) || raw.priorKinds.length !== length
+          || !raw.priorKinds.every((kind) => typeof kind === 'string' && KNOWN_KINDS.has(kind))
+          || !Array.isArray(raw.priorRemoved) || raw.priorRemoved.length !== length
+          || !raw.priorRemoved.every((value) => typeof value === 'boolean')
+          || !Array.isArray(raw.priorTray) || raw.priorTray.length > TRAY_SIZE
+          || new Set(raw.priorTray).size !== raw.priorTray.length
+          || !raw.priorTray.every((index) => validIndex(index, length) && raw.priorRemoved[index])
+          || ![STATUSES.PLAYING, STATUSES.RESCUE].includes(raw.priorStatus)
+          || (raw.priorStatus === STATUSES.RESCUE) !== (raw.priorTray.length === TRAY_SIZE)) return null;
+        result.push({
+          type: 'shuffle',
+          priorKinds: raw.priorKinds.slice(),
+          priorRemoved: raw.priorRemoved.slice(),
+          priorTray: raw.priorTray.slice(),
+          priorStatus: raw.priorStatus,
+        });
       } else return null;
     }
     return result;
@@ -766,6 +806,8 @@
         ...action,
         ...(action.indices ? { indices: action.indices.slice() } : {}),
         ...(action.priorTray ? { priorTray: action.priorTray.slice() } : {}),
+        ...(action.priorKinds ? { priorKinds: action.priorKinds.slice() } : {}),
+        ...(action.priorRemoved ? { priorRemoved: action.priorRemoved.slice() } : {}),
         ...(action.autoClear ? { autoClear: { ...action.autoClear, indices: action.autoClear.indices.slice() } } : {}),
       })),
       score: restored.score,

--- a/src/renderer/pages/mahjong-state.js
+++ b/src/renderer/pages/mahjong-state.js
@@ -12,6 +12,7 @@
   const GAME_INDEX_KEY = 'mahjong.game-index.v2';
   const RECORDS_KEY = 'mahjong.records.v2';
   const RECORD_EVENT_PREFIX = 'mahjong.record-event.v2.';
+  const PREFS_KEY = 'mahjong.prefs.v2';
   const LEGACY_BEST_KEY = 'mahjong.best';
   const SOUND_KEY = 'mahjong.sound';
   const MAX_SAVED_GAMES = 32;
@@ -24,6 +25,8 @@
   // into the wider revision-2 board.
   const LAYOUT_REVISIONS = Object.freeze({ turtle: 1, arch: 2, peaks: 1 });
   const MODES = Object.freeze(['classic', 'tray']);
+  const SOURCES = Object.freeze(['random', 'daily']);
+  const DEFAULT_PREFS = Object.freeze({ layoutId: 'turtle', mode: 'tray', source: 'daily' });
   const TRAY_SCORING_REVISION = 2;
   const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   const DAILY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -330,7 +333,88 @@
       return cleanup(now());
     }
 
-    return Object.freeze({ save, load, discard, cleanup, list, forkSavedGame });
+    // Read-only projection of every retained save for "continue last game".
+    // Wrappers were validated by cleanup; nothing here writes access times,
+    // so peeking never promotes a stale save above the one being played.
+    function summaries() {
+      const result = [];
+      for (const entry of cleanup(now())) {
+        let wrapper;
+        try { wrapper = JSON.parse(safeGet(storage, gameStorageKey(entry.gameId))); } catch { wrapper = null; }
+        const payload = wrapper && wrapper.payload;
+        if (!isObject(payload) || !Array.isArray(payload.kinds) || !Array.isArray(payload.removed)) continue;
+        const tray = Array.isArray(payload.tray) ? payload.tray : [];
+        const history = Array.isArray(payload.history) ? payload.history : [];
+        const removedCount = payload.removed.filter(Boolean).length;
+        result.push({
+          gameId: entry.gameId,
+          lastAccessAt: entry.lastAccessAt,
+          layoutId: payload.layoutId,
+          mode: payload.mode,
+          dailyKey: payload.dailyKey == null ? null : payload.dailyKey,
+          status: payload.status,
+          started: history.length > 0 || tray.length > 0 || payload.selected != null
+            || (Number(payload.elapsedMs) || 0) > 0,
+          pairsLeft: Math.max(0, Math.floor((payload.kinds.length - removedCount + tray.length) / 2)),
+        });
+      }
+      return result;
+    }
+
+    return Object.freeze({ save, load, discard, cleanup, list, summaries, forkSavedGame });
+  }
+
+  function resumeCandidate(summaries, { excludeGameId } = {}) {
+    if (!Array.isArray(summaries)) return null;
+    const excluded = typeof excludeGameId === 'string' ? excludeGameId.toLowerCase() : null;
+    return summaries.find((entry) => entry && entry.started && entry.status !== 'won'
+      && isValidGameId(entry.gameId) && entry.gameId.toLowerCase() !== excluded) || null;
+  }
+
+  function normalizePrefs(value) {
+    const source = isObject(value) ? value : {};
+    return {
+      layoutId: LAYOUT_IDS.includes(source.layoutId) ? source.layoutId : DEFAULT_PREFS.layoutId,
+      mode: MODES.includes(source.mode) ? source.mode : DEFAULT_PREFS.mode,
+      source: SOURCES.includes(source.source) ? source.source : DEFAULT_PREFS.source,
+    };
+  }
+
+  // The last chosen table (layout, mode, deal source). Device-local like the
+  // sound and free-highlight preferences; a fresh tab starts from it instead
+  // of always dealing Daily Burst.
+  function createPrefsStore({ storage = defaultStorage() } = {}) {
+    function read() {
+      const raw = safeGet(storage, PREFS_KEY);
+      if (!raw) return { ...DEFAULT_PREFS };
+      try { return normalizePrefs(JSON.parse(raw)); } catch { return { ...DEFAULT_PREFS }; }
+    }
+    function write(prefs) {
+      return safeSet(storage, PREFS_KEY, JSON.stringify({ version: 1, ...normalizePrefs(prefs) }));
+    }
+    return Object.freeze({ read, write });
+  }
+
+  // 'first' when a layout gains its first record, 'record' when an existing
+  // record improved, 'none' when nothing was stored (or nothing changed).
+  function completionOutcome({ mode, before, after } = {}) {
+    if (!isObject(after)) return 'none';
+    if (!isObject(before)) return 'first';
+    if (mode === 'classic') return after.bestTimeMs < before.bestTimeMs ? 'record' : 'none';
+    if (after.bestScore > before.bestScore) return 'record';
+    if (after.bestScore === before.bestScore && after.bestTimeMs < before.bestTimeMs) return 'record';
+    return 'none';
+  }
+
+  function describeDailyResult(records, key, mode, formatMs) {
+    if (!isDailyKey(key) || !MODES.includes(mode) || typeof formatMs !== 'function') return null;
+    const day = normalizeRecords(records).daily[key];
+    const result = day && day[mode];
+    if (!result || !result.completed) return null;
+    const time = formatMs(result.elapsedMs);
+    return mode === 'tray'
+      ? `cleared · ${result.score.toLocaleString()} pts · ${time}`
+      : `cleared · ${time}`;
   }
 
   function emptyRecords() {
@@ -769,6 +853,7 @@
     GAME_INDEX_KEY,
     RECORDS_KEY,
     RECORD_EVENT_PREFIX,
+    PREFS_KEY,
     LEGACY_BEST_KEY,
     SOUND_KEY,
     MAX_SAVED_GAMES,
@@ -785,6 +870,10 @@
     gameStorageKey,
     gameAccessKey,
     createGameStore,
+    resumeCandidate,
+    createPrefsStore,
+    completionOutcome,
+    describeDailyResult,
     emptyRecords,
     normalizeAssists,
     normalizeRecords,

--- a/src/renderer/pages/mahjong.css
+++ b/src/renderer/pages/mahjong.css
@@ -1519,6 +1519,20 @@
   background: rgba(216, 185, 105, 0.08);
   font: 650 11px/1 var(--font-mono);
 }
+.mj-layout-choice:disabled {
+  opacity: 0.45;
+  cursor: default;
+  filter: saturate(0.6);
+}
+.mj-layout-choice:disabled:hover { transform: none; }
+.mj-win-daily {
+  display: block;
+  margin-top: 9px;
+  color: var(--mj-muted);
+  font: 600 10px/1.4 var(--font-mono);
+  letter-spacing: 0.04em;
+}
+.mj-win-daily[hidden] { display: none; }
 .mj-win-best.is-record {
   border-color: rgba(255, 219, 119, 0.78);
   color: #fff1bd;

--- a/src/renderer/pages/mahjong.html
+++ b/src/renderer/pages/mahjong.html
@@ -97,6 +97,7 @@
         <strong id="mjWinScore" class="mj-win-score">0</strong>
         <span id="mjWinUnit" class="mj-win-unit">points</span>
         <div id="mjWinBest" class="mj-win-best"></div>
+        <div id="mjWinDaily" class="mj-win-daily" hidden></div>
       </div>
       <div id="mjWinStats" class="mj-win-stats" hidden>
         <span><small>time</small><strong id="mjWinTime">0:00</strong></span>
@@ -113,8 +114,16 @@
       <div id="mjNotice" class="mj-notice" hidden>
         <span>No moves remain.</span>
         <button id="mjNoticeUndo" type="button">undo</button>
+        <span aria-hidden="true">·</span>
+        <button id="mjNoticeShuffle" type="button">shuffle</button>
         <span aria-hidden="true">or</span>
         <button id="mjNoticeNew" type="button">new deal</button>
+      </div>
+      <div id="mjResumeNotice" class="mj-notice" hidden>
+        <span id="mjResumeCopy">You left a board unfinished.</span>
+        <button id="mjResumeContinue" type="button">continue it</button>
+        <span aria-hidden="true">or</span>
+        <button id="mjResumeDismiss" type="button">keep this deal</button>
       </div>
       <div id="mjError" class="mj-notice mj-notice-error" hidden>
         <span>That deal could not be built.</span>

--- a/src/renderer/pages/mahjong.js
+++ b/src/renderer/pages/mahjong.js
@@ -410,9 +410,9 @@ function renderTray() {
   document.getElementById('mjTrayRail')?.toggleAttribute('hidden', game.mode !== 'tray');
 }
 
-function refreshTiles({ recoverFocus = false } = {}) {
+function refreshTiles({ recoverFocus = false, keepHint = false } = {}) {
   if (!game) return;
-  clearHint();
+  if (!keepHint) clearHint();
   let nextFocus = focusIndex;
   tileButtons.forEach((b, i) => {
     b.disabled = false;
@@ -900,6 +900,7 @@ function activateTile(i, tile = tileButtons[i]) {
   const wasWon = E.isWon(game);
   const result = E.selectTile(game, i);
   if (!result?.ok) return;
+  dismissResume();
   focusIndex = i;
   const cue = cueForResult(result);
   const semitones = cue === 'comboStep' ? Math.min(7, Math.max(0, result.comboCount - 2)) : 0;
@@ -956,7 +957,7 @@ document.addEventListener('keydown', (event) => {
   if (event.key.startsWith('Arrow') && game) {
     event.preventDefault();
     focusIndex = spatialNeighbor(focusIndex, event.key);
-    refreshTiles();
+    refreshTiles({ keepHint: true });
     tileButtons[focusIndex]?.focus({ preventScroll: true });
     return;
   }
@@ -986,14 +987,20 @@ document.addEventListener('keydown', (event) => {
 });
 
 document.getElementById('mjUndo').addEventListener('click', () => {
+  const undone = game?.history.at(-1)?.type;
   if (!game || !E.undo(game)) return;
   invalidateTileAnimations();
   sound.play('undo');
   resumeTimerAfterUndo();
   saveAfterMutation();
+  if (undone === 'shuffle') {
+    // A reversed shuffle changes tile faces, not just visibility.
+    renderBoard();
+    fitBoard();
+  }
   refreshTiles({ recoverFocus: true });
   checkEndStates();
-  announce('Last move undone.');
+  announce(undone === 'shuffle' ? 'Shuffle undone. The previous board is back.' : 'Last move undone.');
 });
 document.getElementById('mjNoticeUndo').addEventListener('click', () =>
   document.getElementById('mjUndo').click());
@@ -1048,10 +1055,11 @@ function shuffleGame() {
   fitBoard();
   checkEndStates();
   if (wasRescue) resumeTimerAfterUndo();
-  announce('Remaining tiles shuffled into a new solvable deal.');
+  announce('Remaining tiles shuffled into a new solvable deal. Undo restores the previous board.');
   return true;
 }
 document.getElementById('mjShuffle').addEventListener('click', shuffleGame);
+document.getElementById('mjNoticeShuffle').addEventListener('click', shuffleGame);
 document.getElementById('mjRescueUndo')?.addEventListener('click', () =>
   document.getElementById('mjUndo').click());
 document.getElementById('mjRescueShuffle')?.addEventListener('click', shuffleGame);
@@ -1169,7 +1177,6 @@ function stopTimer() { pauseTimer(); }
 
 function resumeTimerAfterUndo() {
   if (!game) return;
-  game.status = 'playing';
   if (hasStarted) startTimer();
 }
 
@@ -1226,13 +1233,8 @@ function recordCompletion() {
     scoringRevision: game.scoringRevision,
   });
   game.completionRecorded = Boolean(updated);
-  const after = updated && (game.mode === 'classic'
-    ? updated.classic[game.layoutId]
-    : updated.tray[game.layoutId]);
-  game._newRecord = !before || (game.mode === 'classic'
-    ? after?.bestTimeMs < before.bestTimeMs
-    : after?.bestScore > before.bestScore ||
-      (after?.bestScore === before.bestScore && after?.bestTimeMs < before.bestTimeMs));
+  const after = bestForGame();
+  game._outcome = S.completionOutcome({ mode: game.mode, before, after });
   saveAfterMutation();
   return Boolean(updated);
 }
@@ -1250,14 +1252,24 @@ function showWin() {
   document.getElementById('mjWinUnit').textContent = isBurst ? 'points' : 'clear time';
   document.getElementById('mjWinTime').textContent = time;
   const record = document.getElementById('mjWinBest');
-  record.textContent = game._newRecord
+  record.textContent = game._outcome === 'record'
     ? 'new record'
-    : best
-      ? (game.mode === 'classic'
-          ? `best ${formatMs(best.bestTimeMs)}`
-          : `best ${best.bestScore.toLocaleString()} · ${formatMs(best.bestTimeMs)}`)
-      : 'first clear';
-  record.classList.toggle('is-record', Boolean(game._newRecord));
+    : game._outcome === 'first'
+      ? 'first clear'
+      : best
+        ? (game.mode === 'classic'
+            ? `best ${formatMs(best.bestTimeMs)}`
+            : `best ${best.bestScore.toLocaleString()} · ${formatMs(best.bestTimeMs)}`)
+        : 'no record';
+  record.classList.toggle('is-record', game._outcome === 'record' || game._outcome === 'first');
+  const dailyLine = document.getElementById('mjWinDaily');
+  if (dailyLine) {
+    const dailyResult = game.dailyKey && recordStore
+      ? S.describeDailyResult(recordStore.read(), game.dailyKey, game.mode, formatMs)
+      : null;
+    dailyLine.hidden = !dailyResult;
+    dailyLine.textContent = dailyResult ? `daily ${game.dailyKey} · ${dailyResult}` : '';
+  }
   const stats = document.getElementById('mjWinStats');
   if (stats) stats.hidden = !isBurst;
   document.getElementById('mjWinCombo').textContent = `×${game.maxCombo || 0}`;
@@ -1272,6 +1284,8 @@ const FREE_HIGHLIGHT_KEY = 'mahjong.free-highlight';
 let gameId = null;
 let gameStore = null;
 let recordStore = null;
+let prefsStore = null;
+let resumeTarget = null;
 let duplicateGuard = null;
 let duplicateChannel = null;
 let embedActive = true;
@@ -1300,6 +1314,7 @@ function configureGame(nextGame) {
   document.getElementById('mjNotice').hidden = true;
   document.getElementById('mjError').hidden = true;
   document.getElementById('mjRecoveryNotice').hidden = true;
+  dismissResume();
   setDialogVisible(document.getElementById('mjWin'), false);
   setDialogVisible(document.getElementById('mjRescue'), false);
   renderBoard();
@@ -1312,6 +1327,8 @@ function configureGame(nextGame) {
 
 function startGame({ layoutId, mode, seed, dailyKey = null }, { soundCue = true } = {}) {
   pauseTimer();
+  // Remember the table so the next fresh tab deals the same kind of game.
+  prefsStore?.write({ layoutId, mode, source: dailyKey ? 'daily' : 'random' });
   try {
     const next = E.createGame({ seed, layoutId, mode, gameId, dailyKey });
     next.gameId = gameId;
@@ -1331,6 +1348,71 @@ function startGame({ layoutId, mode, seed, dailyKey = null }, { soundCue = true 
   }
   return true;
 }
+
+function startPreferredGame({ soundCue = false } = {}) {
+  const prefs = prefsStore ? prefsStore.read() : { layoutId: 'turtle', mode: 'tray', source: 'daily' };
+  if (prefs.source === 'daily') {
+    return startGame({ ...S.dailyDeal(new Date()), mode: prefs.mode }, { soundCue });
+  }
+  return startGame({ layoutId: prefs.layoutId, mode: prefs.mode, seed: randomSeed() }, { soundCue });
+}
+
+// --- continue last game ------------------------------------------------------
+// A fresh tab mints a fresh game id, so a half-finished board in a closed tab
+// would otherwise be unreachable. Offer it explicitly; never adopt silently.
+
+function dismissResume() {
+  resumeTarget = null;
+  const notice = document.getElementById('mjResumeNotice');
+  if (notice) notice.hidden = true;
+}
+
+function offerResume() {
+  if (!gameStore) return;
+  const candidate = S.resumeCandidate(gameStore.summaries(), { excludeGameId: gameId });
+  const notice = document.getElementById('mjResumeNotice');
+  const copy = document.getElementById('mjResumeCopy');
+  if (!candidate || !notice || !copy) return;
+  resumeTarget = candidate.gameId;
+  const layoutName = E.LAYOUTS[candidate.layoutId]?.name || 'Mahjong';
+  const modeName = candidate.mode === 'tray' ? 'Burst' : 'Classic';
+  const pairs = `${candidate.pairsLeft} ${candidate.pairsLeft === 1 ? 'pair' : 'pairs'} left`;
+  copy.textContent = `Your unfinished ${layoutName} ${modeName} board is waiting · ${pairs}.`;
+  notice.hidden = false;
+}
+
+function adoptGame(targetId) {
+  if (!gameStore || !S.isValidGameId(targetId)) return false;
+  pauseTimer();
+  const previousId = gameId;
+  const previous = game;
+  const adopted = gameStore.load(targetId);
+  if (!adopted) {
+    dismissResume();
+    document.getElementById('mjRecoveryNotice').hidden = false;
+    return false;
+  }
+  const changed = S.forkGameId({ href: location.href, history, uuid: () => targetId });
+  gameId = changed.gameId;
+  configureGame(adopted);
+  // The untouched deal this tab made moments ago would otherwise linger as an
+  // orphan save until expiry.
+  if (previous && previousId !== gameId && previous.history.length === 0
+    && previous.elapsedMs === 0 && previous.tray.length === 0) {
+    gameStore.discard(previousId);
+  }
+  saveAfterMutation();
+  notifyParentGameId();
+  disposeDuplicateGuard();
+  installDuplicateGuard();
+  announce('Continuing your unfinished board.');
+  return true;
+}
+
+document.getElementById('mjResumeContinue')?.addEventListener('click', () => {
+  if (resumeTarget) adoptGame(resumeTarget);
+});
+document.getElementById('mjResumeDismiss')?.addEventListener('click', dismissResume);
 
 function newGameFromControl() {
   const layoutId = game?.layoutId || 'turtle';
@@ -1361,9 +1443,17 @@ function paintSetupChoices() {
     ? 'Build rapid matches in a four-slot Burst rack.'
     : 'Match two free tiles directly.';
   const sourceDescription = document.getElementById('mjSourceDescription');
-  if (sourceDescription) sourceDescription.textContent = setupChoice.source === 'daily'
-    ? `${S.dailyDeal(new Date()).dailyKey} · ${E.LAYOUTS[setupChoice.layoutId].name}`
-    : 'A fresh, guaranteed-solvable board.';
+  if (sourceDescription) {
+    if (setupChoice.source === 'daily') {
+      const daily = S.dailyDeal(new Date());
+      const done = recordStore
+        ? S.describeDailyResult(recordStore.read(), S.dailyDeal(new Date()).dailyKey, setupChoice.mode, formatMs)
+        : null;
+      sourceDescription.textContent = `${daily.dailyKey} · ${E.LAYOUTS[setupChoice.layoutId].name} · ${done || 'layout rotates daily'}`;
+    } else {
+      sourceDescription.textContent = 'A fresh, guaranteed-solvable board.';
+    }
+  }
 }
 
 function openSetup() {
@@ -1515,6 +1605,7 @@ function bootstrap() {
   gameId = identity.gameId;
   gameStore = S.createGameStore({ storage: localStorage, engine: E });
   recordStore = S.createRecordStore({ storage: localStorage });
+  prefsStore = S.createPrefsStore({ storage: localStorage });
   recordStore.migrateLegacy();
 
   let hadSave = false;
@@ -1525,9 +1616,9 @@ function bootstrap() {
     configureGame(restored);
     announce('Saved game restored.');
   } else {
-    const daily = S.dailyDeal(new Date());
-    startGame({ ...daily, mode: 'tray' }, { soundCue: false });
+    startPreferredGame();
     if (hadSave) document.getElementById('mjRecoveryNotice').hidden = false;
+    else offerResume();
   }
   notifyParentGameId();
   installDuplicateGuard();

--- a/test/unit/mahjong-engine.test.js
+++ b/test/unit/mahjong-engine.test.js
@@ -582,7 +582,8 @@ test('four unmatched Tray tiles enter rescue; undo and shuffle both recover', ()
   assert.equal(shuffleState.removed.filter(Boolean).length, 0);
   assert.deepEqual(shuffleState.kinds.slice().sort(), multiset);
   assert.equal(shuffleState.comboCount, 0);
-  assert.equal(shuffleState.history.length, 0);
+  assert.equal(shuffleState.history.length, 5);
+  assert.equal(shuffleState.history.at(-1).type, 'shuffle');
   assert.equal(shuffleState.assists.shuffle, 1);
   assert.ok(E.availableMoves(shuffleState).length > 0);
 });
@@ -690,4 +691,98 @@ test('v2 serialization round-trips independent state and rejects corruption', ()
   assert.ok(restoredLegacyKinds, 'unsuffixed V2 winds and dragons remain restorable');
   assert.equal(restoredLegacyKinds.kinds.filter((kind) => kind === 'wind-n').length, 2);
   assert.equal(restoredLegacyKinds.kinds.filter((kind) => kind === 'drg-c').length, 2);
+});
+
+test('shuffle is an undoable action that restores the exact prior board', () => {
+  const state = E.createGame({ seed: 4101, layoutId: 'peaks', mode: 'classic' });
+  const { solution } = E.generateDeal({ seed: 4101, layoutId: 'peaks' });
+  for (let offset = 0; offset < 3; offset++) assert.equal(E.removePair(state, ...solution[offset]), true);
+  const kinds = state.kinds.slice();
+  const removed = state.removed.slice();
+  assert.equal(E.shuffleRemaining(state, E.createRng(9)), true);
+  assert.notDeepEqual(state.kinds, kinds);
+  assert.equal(state.history.length, 4);
+  assert.equal(E.undo(state), true);
+  assert.deepEqual(state.kinds, kinds);
+  assert.deepEqual(state.removed, removed);
+  assert.equal(state.status, 'playing');
+  assert.equal(state.assists.shuffle, 1);
+  assert.equal(state.assists.undo, 1);
+  // the three earlier pairs are still undoable after the shuffle is reversed
+  assert.equal(state.history.length, 3);
+  assert.equal(E.undo(state), true);
+  assert.equal(state.removed.filter(Boolean).length, 4);
+});
+
+test('undoing a Tray rescue shuffle returns the full rack and rescue status', () => {
+  const state = E.createGame({ seed: 4102, layoutId: 'peaks', mode: 'tray' });
+  const picked = fillUnmatchedTray(state);
+  assert.equal(state.status, 'rescue');
+  const kinds = state.kinds.slice();
+  assert.equal(E.shuffleRemaining(state, E.createRng(3)), true);
+  assert.deepEqual(state.tray, []);
+  assert.equal(E.undo(state), true);
+  assert.deepEqual(state.tray, picked);
+  assert.equal(state.status, 'rescue');
+  assert.deepEqual(state.kinds, kinds);
+  assert.ok(E.restoreGame(E.serializeGame(state)), 'restored rescue state is valid');
+  // one more undo steps back the last pick exactly as before
+  assert.equal(E.undo(state), true);
+  assert.equal(state.status, 'playing');
+  assert.equal(state.tray.length, 3);
+});
+
+test('shuffle actions survive serialization and malformed ones are rejected', () => {
+  const state = E.createGame({ seed: 4103, layoutId: 'arch', mode: 'classic' });
+  assert.equal(E.shuffleRemaining(state, E.createRng(1)), true);
+  const payload = E.serializeGame(state);
+  assert.equal(payload.history[0].type, 'shuffle');
+  const restored = E.restoreGame(payload);
+  assert.ok(restored);
+  assert.equal(E.undo(restored), true);
+  assert.deepEqual(restored.kinds, payload.history[0].priorKinds);
+
+  for (const mutate of [
+    (action) => { action.priorKinds = action.priorKinds.slice(1); },
+    (action) => { action.priorKinds[0] = 'not-a-tile'; },
+    (action) => { action.priorRemoved = action.priorRemoved.map(() => 'yes'); },
+    (action) => { action.priorTray = [0, 0]; },
+    (action) => { action.priorStatus = 'won'; },
+    (action) => { action.priorTray = [0, 1, 2, 3]; action.priorStatus = 'playing'; },
+  ]) {
+    const broken = JSON.parse(JSON.stringify(payload));
+    mutate(broken.history[0]);
+    assert.equal(E.restoreGame(broken), null);
+  }
+});
+
+test('matching a re-parked position after a shuffle never corrupts pre-shuffle undo', () => {
+  // Find a Tray deal where a parked position comes back free with a free mate
+  // after the shuffle, so the post-shuffle match erases only its own park.
+  let exercised = false;
+  for (let seed = 4200; seed < 4400 && !exercised; seed++) {
+    const state = E.createGame({ seed, layoutId: 'peaks', mode: 'tray' });
+    const parkedIndex = state.kinds.findIndex((_, index) => E.isFree(state, index));
+    assert.equal(E.selectTile(state, parkedIndex).type, 'tray-park');
+    assert.equal(E.shuffleRemaining(state, E.createRng(seed)), true);
+    const mate = E.availableMoves({ ...state, mode: 'classic' })
+      .find(([a, b]) => a === parkedIndex || b === parkedIndex);
+    if (!mate) continue;
+    exercised = true;
+    const mateIndex = mate[0] === parkedIndex ? mate[1] : mate[0];
+    assert.equal(E.selectTile(state, parkedIndex).type, 'tray-park');
+    assert.equal(E.selectTile(state, mateIndex).type, 'tray-pair');
+    assert.ok(E.restoreGame(E.serializeGame(state)));
+    assert.equal(E.undo(state), true); // the match
+    assert.ok(E.restoreGame(E.serializeGame(state)));
+    assert.equal(E.undo(state), true); // the shuffle
+    assert.deepEqual(state.tray, [parkedIndex]);
+    assert.equal(state.removed[parkedIndex], true);
+    assert.ok(E.restoreGame(E.serializeGame(state)));
+    assert.equal(E.undo(state), true); // the original park
+    assert.deepEqual(state.tray, []);
+    assert.equal(state.removed.filter(Boolean).length, 0);
+    assert.equal(E.undo(state), false);
+  }
+  assert.ok(exercised, 'expected at least one seed to exercise the re-park path');
 });

--- a/test/unit/mahjong-page.test.js
+++ b/test/unit/mahjong-page.test.js
@@ -92,7 +92,7 @@ test('bonus families use full-scale lacquer artwork and hints clear stale emphas
   assert.match(controller, /let hintTimer = null;/);
   assert.match(controller, /function clearHint\(\)\s*\{[\s\S]*classList\.remove\('hinted'\)/);
   assert.match(controller, /hintTimer = window\.setTimeout\(clearHint, 2200\);/);
-  assert.match(controller, /function refreshTiles[\s\S]*if \(!game\) return;\s*clearHint\(\);/);
+  assert.match(controller, /function refreshTiles[\s\S]*if \(!game\) return;\s*if \(!keepHint\) clearHint\(\);/);
 
   const expected = new Map([
     ['mahjong-flower.png', '81dbfb0478ab92974406a9f174234f7bea308c4e849625fc2a73c4351c11bd39'],
@@ -278,14 +278,18 @@ test('every game interaction is wired to its sound cue and bootstrap stays silen
     assert.match(controller, new RegExp(`'${cue}'`), `missing ${cue} cue`);
   }
   assert.match(controller, /if \(soundCue\) sound\.play\('deal'\)/);
-  assert.match(controller, /const daily = S\.dailyDeal\(new Date\(\)\);[\s\S]*startGame\(\{ \.\.\.daily, mode: 'tray' \}, \{ soundCue: false \}\)/);
+  assert.match(controller, /function startPreferredGame\(\{ soundCue = false \} = \{\}\)/);
+  assert.match(controller, /startGame\(\{ \.\.\.S\.dailyDeal\(new Date\(\)\), mode: prefs\.mode \}, \{ soundCue \}\)/);
   assert.match(controller, /document\.getElementById\('mjNew'\)\.addEventListener\('click', newGameFromControl\);/);
   assert.match(controller, /\nbootstrap\(\);\s*$/);
 });
 
-test('a fresh table defaults to Daily Burst while the tray id preserves saved-game compatibility', () => {
-  assert.match(controller, /setupChoice = \{ layoutId: S\.dailyDeal\(new Date\(\)\)\.layoutId, mode: 'tray', source: 'daily' \}/);
-  assert.match(controller, /if \(restored\) \{[\s\S]*configureGame\(restored\);[\s\S]*\} else \{[\s\S]*startGame\(\{ \.\.\.daily, mode: 'tray' \}/);
+test('a fresh table deals the remembered table (Daily Burst by default) while the tray id preserves saved-game compatibility', () => {
+  assert.match(controller, /prefsStore = S\.createPrefsStore\(/);
+  assert.match(controller, /function startPreferredGame\(\{ soundCue = false \} = \{\}\)/);
+  assert.match(controller, /if \(restored\) \{[\s\S]*configureGame\(restored\);[\s\S]*\} else \{[\s\S]*startPreferredGame\(\)/);
+  // every explicit start records the table for the next fresh tab
+  assert.match(controller, /function startGame\([\s\S]*?prefsStore\?\.write\(\{ layoutId, mode, source: dailyKey \? 'daily' : 'random' \}\)/);
   assert.match(html, /id="mjModeTray"[^>]*data-mode="tray"[^>]*>Burst<\/button>/);
   assert.match(html, /burst rack/i);
   assert.match(html, /id="mjBurstScoreWrap"[^>]*>[\s\n]*<strong id="mjBurstScore">0<\/strong>/);
@@ -492,7 +496,7 @@ test('desktop Mahjong overlays its left rail inside a centered full-width table'
 
 test('starting another board clears a stale recovery notice', () => {
   assert.match(controller, /function configureGame\(nextGame\)[\s\S]*getElementById\('mjRecoveryNotice'\)\.hidden = true;/);
-  assert.match(controller, /const daily = S\.dailyDeal\(new Date\(\)\);[\s\S]*startGame\(\{ \.\.\.daily, mode: 'tray' \}[\s\S]*if \(hadSave\) document\.getElementById\('mjRecoveryNotice'\)\.hidden = false;/);
+  assert.match(controller, /startPreferredGame\(\);\s*if \(hadSave\) document\.getElementById\('mjRecoveryNotice'\)\.hidden = false;\s*else offerResume\(\);/);
 });
 
 test('best records are scoped to the active layout revision', () => {
@@ -521,7 +525,7 @@ test('completion results promote the score and separate time from Burst performa
   assert.match(controller, /win\.dataset\.mode = isBurst \? 'burst' : 'classic'/);
   assert.match(controller, /getElementById\('mjWinScore'\)\.textContent = isBurst[\s\S]*game\.score\.toLocaleString\(\)[\s\S]*: time/);
   assert.match(controller, /getElementById\('mjWinTime'\)\.textContent = time/);
-  assert.match(controller, /record\.classList\.toggle\('is-record', Boolean\(game\._newRecord\)\)/);
+  assert.match(controller, /record\.classList\.toggle\('is-record', game\._outcome === 'record' \|\| game\._outcome === 'first'\)/);
   assert.match(styles, /\.mj-win-result\s*\{[^}]*border-radius:\s*22px[^}]*radial-gradient[^}]*box-shadow:/);
   assert.match(styles, /\.mj-win-score\s*\{[^}]*clamp\(46px, 6\.2vw, 64px\)[^}]*text-shadow:/);
   assert.match(styles, /\.mj-win-stats\s*\{[^}]*grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\)/);
@@ -553,4 +557,49 @@ test('mahjong reports play only after a real free-tile move', () => {
     controller,
     /if \(!E\.isFree\(game, i\)\) \{[\s\S]*return;[\s\S]*reportPlayOnce\(\);\s*startTimer\(\);/,
   );
+});
+
+test('undo re-renders the board after reversing a shuffle and never forces a status', () => {
+  assert.match(controller, /const undone = game\?\.history\.at\(-1\)\?\.type;[\s\S]*?if \(!game \|\| !E\.undo\(game\)\) return;[\s\S]*?if \(undone === 'shuffle'\) \{[\s\S]*?renderBoard\(\);[\s\S]*?fitBoard\(\);/);
+  assert.doesNotMatch(controller, /function resumeTimerAfterUndo\(\) \{[\s\S]{0,120}game\.status = 'playing'/);
+  assert.match(controller, /announce\('Remaining tiles shuffled into a new solvable deal\. Undo restores the previous board\.'\)/);
+});
+
+test('arrow-key navigation keeps an active hint visible', () => {
+  assert.match(controller, /function refreshTiles\(\{ recoverFocus = false, keepHint = false \} = \{\}\)[\s\S]*?if \(!keepHint\) clearHint\(\);/);
+  assert.match(controller, /event\.key\.startsWith\('Arrow'\) && game\) \{[\s\S]*?refreshTiles\(\{ keepHint: true \}\);/);
+});
+
+test('the dead-end notice offers shuffle alongside undo and a new deal', () => {
+  assert.match(html, /id="mjNotice"[\s\S]*?id="mjNoticeUndo"[\s\S]*?id="mjNoticeShuffle"[\s\S]*?id="mjNoticeNew"/);
+  assert.match(controller, /getElementById\('mjNoticeShuffle'\)\.addEventListener\('click', shuffleGame\)/);
+});
+
+test('daily layout choices read as disabled and the sheet explains the rotation', () => {
+  assert.match(mahjongStyles, /\.mj-layout-choice:disabled\s*\{[^}]*opacity/);
+  assert.match(controller, /layout rotates daily/);
+});
+
+test('completion copy distinguishes first clear from a new record using the stored outcome', () => {
+  assert.match(controller, /S\.completionOutcome\(\{ mode: game\.mode, before, after \}\)/);
+  assert.match(controller, /game\._outcome === 'record'[\s\S]*?'new record'[\s\S]*?game\._outcome === 'first'[\s\S]*?'first clear'/);
+  assert.doesNotMatch(controller, /game\._newRecord/);
+});
+
+test('daily results surface in the setup sheet and the completion card', () => {
+  assert.match(html, /id="mjWinDaily"/);
+  assert.match(controller, /S\.describeDailyResult\(recordStore\.read\(\), S\.dailyDeal\(new Date\(\)\)\.dailyKey, setupChoice\.mode, formatMs\)/);
+  assert.match(controller, /S\.describeDailyResult\(recordStore\.read\(\), game\.dailyKey, game\.mode, formatMs\)/);
+});
+
+test('a fresh tab offers to continue the most recent unfinished board without auto-adopting it', () => {
+  for (const id of ['mjResumeNotice', 'mjResumeCopy', 'mjResumeContinue', 'mjResumeDismiss']) {
+    assert.match(html, new RegExp(`id="${id}"`), `missing ${id}`);
+  }
+  assert.match(controller, /S\.resumeCandidate\(gameStore\.summaries\(\), \{ excludeGameId: gameId \}\)/);
+  assert.match(controller, /function adoptGame\(targetId\)/);
+  // adopting re-points this tab's id, tells the embedding start page, and re-arms the duplicate guard
+  assert.match(controller, /function adoptGame[\s\S]*?S\.forkGameId\(\{ href: location\.href, history, uuid: \(\) => targetId \}\)[\s\S]*?notifyParentGameId\(\);[\s\S]*?disposeDuplicateGuard\(\);[\s\S]*?installDuplicateGuard\(\);/);
+  // the untouched fresh deal this tab just made is discarded rather than orphaned
+  assert.match(controller, /function adoptGame[\s\S]*?gameStore\.discard\(previousId\)/);
 });

--- a/test/unit/mahjong-state.test.js
+++ b/test/unit/mahjong-state.test.js
@@ -596,3 +596,75 @@ test('duplicate guard forks the newer live instance and announces its new id', (
   first.dispose();
   second.dispose();
 });
+
+test('game summaries expose resumable saves without touching access times', () => {
+  const storage = new MemoryStorage();
+  let clock = 1000;
+  const store = S.createGameStore({ storage, engine: E, now: () => clock });
+  const untouched = E.createGame({ seed: 1, layoutId: 'peaks', mode: 'tray' });
+  store.save(uuid(1), untouched);
+  clock = 2000;
+  const played = E.createGame({ seed: 2, layoutId: 'arch', mode: 'classic', dailyKey: '2026-09-02' });
+  const [first, second] = E.generateDeal({ seed: 2, layoutId: 'arch' }).solution[0];
+  E.removePair(played, first, second);
+  store.save(uuid(2), played);
+  clock = 3000;
+  const won = E.createGame({ seed: 3, layoutId: 'peaks', mode: 'classic' });
+  for (const pair of E.generateDeal({ seed: 3, layoutId: 'peaks' }).solution) E.removePair(won, ...pair);
+  store.save(uuid(3), won);
+
+  clock = 9000;
+  const summaries = store.summaries();
+  assert.deepEqual(summaries.map((entry) => entry.gameId), [uuid(3), uuid(2), uuid(1)]);
+  assert.deepEqual(summaries[1], {
+    gameId: uuid(2), lastAccessAt: 2000, layoutId: 'arch', mode: 'classic',
+    dailyKey: '2026-09-02', status: 'playing', started: true, pairsLeft: 47,
+  });
+  assert.equal(summaries[0].status, 'won');
+  assert.equal(summaries[2].started, false);
+  assert.equal(JSON.parse(storage.getItem(S.gameAccessKey(uuid(2)))).lastAccessAt, 2000, 'summaries never touch access');
+
+  assert.equal(S.resumeCandidate(summaries, { excludeGameId: uuid(9) }).gameId, uuid(2));
+  assert.equal(S.resumeCandidate(summaries, { excludeGameId: uuid(2) }), null);
+  assert.equal(S.resumeCandidate([], {}), null);
+});
+
+test('table preferences persist the last layout, mode, and deal source with safe defaults', () => {
+  const storage = new MemoryStorage();
+  const prefs = S.createPrefsStore({ storage });
+  assert.deepEqual(prefs.read(), { layoutId: 'turtle', mode: 'tray', source: 'daily' });
+  assert.equal(prefs.write({ layoutId: 'arch', mode: 'classic', source: 'random' }), true);
+  assert.deepEqual(prefs.read(), { layoutId: 'arch', mode: 'classic', source: 'random' });
+  assert.deepEqual(S.createPrefsStore({ storage }).read(), { layoutId: 'arch', mode: 'classic', source: 'random' });
+  storage.setItem(S.PREFS_KEY, JSON.stringify({ version: 1, layoutId: 'castle', mode: 'zen', source: 'random' }));
+  assert.deepEqual(prefs.read(), { layoutId: 'turtle', mode: 'tray', source: 'random' });
+  storage.setItem(S.PREFS_KEY, '{not json');
+  assert.deepEqual(prefs.read(), { layoutId: 'turtle', mode: 'tray', source: 'daily' });
+});
+
+test('completion outcome distinguishes a first clear, a new record, and no change', () => {
+  const classicBefore = { bestTimeMs: 90_000 };
+  assert.equal(S.completionOutcome({ mode: 'classic', before: null, after: null }), 'none');
+  assert.equal(S.completionOutcome({ mode: 'classic', before: null, after: { bestTimeMs: 100 } }), 'first');
+  assert.equal(S.completionOutcome({ mode: 'classic', before: classicBefore, after: { bestTimeMs: 80_000 } }), 'record');
+  assert.equal(S.completionOutcome({ mode: 'classic', before: classicBefore, after: { bestTimeMs: 90_000 } }), 'none');
+  const trayBefore = { bestScore: 3000, bestTimeMs: 100_000 };
+  assert.equal(S.completionOutcome({ mode: 'tray', before: trayBefore, after: { bestScore: 3100, bestTimeMs: 200_000 } }), 'record');
+  assert.equal(S.completionOutcome({ mode: 'tray', before: trayBefore, after: { bestScore: 3000, bestTimeMs: 90_000 } }), 'record');
+  assert.equal(S.completionOutcome({ mode: 'tray', before: trayBefore, after: { bestScore: 3000, bestTimeMs: 100_000 } }), 'none');
+});
+
+test('daily results describe a cleared day per mode', () => {
+  const formatMs = (ms) => `${Math.floor(ms / 60000)}:${String(Math.floor(ms / 1000) % 60).padStart(2, '0')}`;
+  const records = S.applyResult(S.emptyRecords(), {
+    layoutId: 'arch', layoutRevision: 2, mode: 'tray', elapsedMs: 252_000, score: 3450,
+    scoringRevision: 2, completed: true, dailyKey: '2026-09-02', assists: {},
+  }, 5);
+  assert.equal(S.describeDailyResult(records, '2026-09-02', 'tray', formatMs), 'cleared · 3,450 pts · 4:12');
+  assert.equal(S.describeDailyResult(records, '2026-09-02', 'classic', formatMs), null);
+  const classic = S.applyResult(records, {
+    layoutId: 'arch', layoutRevision: 2, mode: 'classic', elapsedMs: 61_000, completed: true, dailyKey: '2026-09-02', assists: {},
+  }, 6);
+  assert.equal(S.describeDailyResult(classic, '2026-09-02', 'classic', formatMs), 'cleared · 1:01');
+  assert.equal(S.describeDailyResult(classic, '2026-09-03', 'classic', formatMs), null);
+});


### PR DESCRIPTION
## Summary
- **Undoable shuffle.** `shuffleRemaining()` now records the prior tiles, rack, and status as a `shuffle` history action instead of clearing history, so Undo restores the exact board (including a Rescue-rack shuffle). Park-history rewriting is scoped to the current shuffle epoch so undo chains through a shuffle stay valid; saves with shuffle actions round-trip through `restoreGame` and malformed ones are rejected.
- **Remembered table + continue.** The last layout/mode/deal source persists per device (`mahjong.prefs.v2`), a fresh tab deals that table instead of always Daily Burst, and if another tab left a board unfinished the fresh tab offers "continue it / keep this deal" explicitly (never auto-adopts). Continue re-points the tab's game id, notifies the start page, re-arms the duplicate guard, and discards the untouched deal it replaces.
- **Smaller fixes from the audit.** Completion copy distinguishes first clear / new record / no change from the stored outcome; arrow keys keep an active hint; disabled Daily layout cards read as disabled with a "layout rotates daily" note; the dead-end notice offers Shuffle; the daily result shows in the setup sheet and completion card; undo no longer forces status to playing. Audit write-up: `docs/superpowers/specs/2026-09-02-mahjong-audit.md`.

## Test plan
- [x] `node --test test/unit/mahjong-*.test.js` — 105/105 (15 new tests, each written failing first)
- [x] `npm run test:unit` — 1404/1405; the single failure is the pre-existing `compliance-model` license-file check for `@ghostery/adblocker-content`, unrelated to this change
- [x] `npm run test:acceptance:dry` — resolves
- [x] Browser pass (page served over 127.0.0.1): shuffle → undo restores kinds, rack, and faces; a fresh load shows the continue offer, adopts the old game, and removes the orphan save; Daily layout cards render disabled at 0.45 opacity with the rotation note
- [ ] Hand-check in the packaged/dev app: undo after a Rescue "shuffle & continue" returns to the Rescue dialog; a new tab after closing a half-played tab shows the continue offer

Note: product merges for the launch train stop Thu Sep 3 noon ET; this is product work, so it should either land before then or wait for after launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)