### PR TITLE
Keep Mahjong tile-face numerals in JetBrains Mono

### DIFF
--- a/src/renderer/pages/mahjong.css
+++ b/src/renderer/pages/mahjong.css
@@ -5,6 +5,10 @@
   /* Mahjong is the fifth start-page layout, so its former mono role joins the
      same Inter-only migration while the rest of Blanc remains unchanged. */
   --font-mono: var(--font-ui);
+  /* Tile faces are exempt from that migration: numerals and wind badge
+     letters keep the bundled JetBrains Mono (a 400–700 variable face), so
+     this token restates the real mono stack rather than the alias above. */
+  --mj-face-font: "JetBrains Mono", ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
   --mj-lacquer: #0b3d31;
   --mj-lacquer-deep: #04251f;
   --mj-lacquer-ink: #021914;
@@ -507,11 +511,13 @@
 }
 
 .mj-tile svg { display: block; width: 100%; height: 100%; filter: drop-shadow(0 1px 0 rgba(255, 255, 255, 0.35)); }
-.mj-face text { font-family: var(--font-mono); font-weight: 650; }
-.mj-character-number {
-  font-family: var(--font-ui);
-  font-weight: 850;
-  font-variation-settings: "wght" 850;
+.mj-face text { font-family: var(--mj-face-font); font-weight: 650; }
+/* Element-qualified so this outranks `.mj-face text` above; the bare class
+   never won, so the numeral's declared weight had silently never applied. */
+.mj-face text.mj-character-number {
+  font-family: var(--mj-face-font);
+  font-weight: 700;
+  font-variation-settings: "wght" 700;
   fill: currentColor;
   stroke: rgba(153, 111, 44, 0.62);
   stroke-width: 0.7px;

--- a/src/renderer/pages/mahjong.css
+++ b/src/renderer/pages/mahjong.css
@@ -945,14 +945,25 @@
 .mj-tray-best strong { color: var(--mj-ivory); font: 650 12px/1 var(--font-mono); font-variant-numeric: tabular-nums; }
 
 .mj-feedback { min-height: 18px; display: grid; place-items: center; }
+/* Notices are lacquer pills with their own ground, so a two-sentence offer
+   (continue an unfinished board) reads as a card floating over the felt
+   instead of loose text wedged between the header and the table edge. */
 .mj-notice {
   display: flex;
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 7px;
+  gap: 6px 9px;
+  max-width: min(640px, 100%);
+  padding: 9px 16px;
+  border: 1px solid var(--mj-line-strong);
+  border-radius: 999px;
   color: var(--mj-muted);
-  font: 500 10px/1.4 var(--font-mono);
+  background: var(--mj-panel);
+  box-shadow: 0 14px 34px var(--mj-shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(14px) saturate(1.1);
+  font: 500 11px/1.45 var(--font-mono);
+  text-align: center;
 }
 .mj-notice button {
   all: unset;
@@ -1878,12 +1889,16 @@
   .mj-board-frame { anchor-name: --mj-table; }
   .mj-board-wrap { --mj-board-safe-side: 88px; }
 
+  /* Anchored inside the table's top edge, like the dock anchors to its left
+     edge, and kept clear of the left rail. */
   .mj-feedback {
     position: absolute;
+    position-anchor: --mj-table;
     z-index: 6;
-    top: calc(var(--mj-shell-block) + 42px + var(--mj-shell-gap) + 8px);
-    inset-inline-start: calc(var(--mj-shell-inline) + 104px);
-    inset-inline-end: calc(var(--mj-shell-inline) + 12px);
+    top: calc(anchor(top) + 14px);
+    left: anchor(center);
+    width: min(640px, calc(anchor-size(width) - 208px));
+    transform: translateX(-50%);
     min-height: 0;
     pointer-events: none;
   }
@@ -2013,7 +2028,6 @@
   .mj-meter:first-child { min-width: 88px; }
   .mj-chain-meter { min-width: 88px; }
   .mj-combo-bar { width: 78px; }
-  .mj-feedback { top: calc(var(--mj-shell-block) + 52px + var(--mj-shell-gap) + 8px); }
 }
 
 @media (max-width: 900px) {

--- a/src/renderer/pages/mahjong.css
+++ b/src/renderer/pages/mahjong.css
@@ -6,7 +6,7 @@
      same Inter-only migration while the rest of Blanc remains unchanged. */
   --font-mono: var(--font-ui);
   /* Tile faces are exempt from that migration: numerals and wind badge
-     letters keep the bundled JetBrains Mono (a 400–700 variable face), so
+     letters keep the bundled JetBrains Mono (a 400–800 variable face), so
      this token restates the real mono stack rather than the alias above. */
   --mj-face-font: "JetBrains Mono", ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
   --mj-lacquer: #0b3d31;
@@ -516,8 +516,8 @@
    never won, so the numeral's declared weight had silently never applied. */
 .mj-face text.mj-character-number {
   font-family: var(--mj-face-font);
-  font-weight: 700;
-  font-variation-settings: "wght" 700;
+  font-weight: 800;
+  font-variation-settings: "wght" 800;
   fill: currentColor;
   stroke: rgba(153, 111, 44, 0.62);
   stroke-width: 0.7px;

--- a/src/renderer/pages/pages.css
+++ b/src/renderer/pages/pages.css
@@ -12,7 +12,9 @@
   font-family: "JetBrains Mono";
   src: url("jetbrains-mono-latin.woff2") format("woff2");
   font-style: normal;
-  font-weight: 400 700;
+  /* The subset carries the full wght 400–800 axis; declaring less would
+     silently clamp heavier requests (the Mahjong tile numerals use 800). */
+  font-weight: 400 800;
   font-display: swap;
 }
 

--- a/test/unit/mahjong-page.test.js
+++ b/test/unit/mahjong-page.test.js
@@ -678,3 +678,11 @@ test('tile-face type stays JetBrains Mono while the game chrome uses Inter', () 
   // The chrome alias itself stays: meters, sheets, and dock labels remain Inter.
   assert.match(mahjongStyles, /\.mahjong-body\s*\{[^}]*--font-mono:\s*var\(--font-ui\);/);
 });
+
+test('notices are lacquer pills anchored inside the table instead of loose text at its edge', () => {
+  assert.match(mahjongStyles, /\.mj-notice\s*\{[^}]*max-width:\s*min\(640px, 100%\);[^}]*border-radius:\s*999px;[^}]*background:\s*var\(--mj-panel\);[^}]*backdrop-filter:/);
+  const desktop = mediaBlocks('(min-width: 1000px) and (min-height: 611px)')[0];
+  assert.ok(desktop, 'desktop media block present');
+  assert.match(desktop, /\.mj-feedback\s*\{[^}]*position:\s*absolute;[^}]*position-anchor:\s*--mj-table;[^}]*top:\s*calc\(anchor\(top\) \+ 14px\);[^}]*left:\s*anchor\(center\);[^}]*width:\s*min\(640px, calc\(anchor-size\(width\) - 208px\)\);[^}]*transform:\s*translateX\(-50%\);/);
+  assert.doesNotMatch(mahjongStyles, /\.mj-feedback\s*\{[^}]*top:\s*calc\(var\(--mj-shell-block\)/);
+});

--- a/test/unit/mahjong-page.test.js
+++ b/test/unit/mahjong-page.test.js
@@ -188,7 +188,7 @@ test('character numerals fill their tile faces in ink without underline marks', 
   assert.doesNotMatch(controller, /family === 'chr'[\s\S]{0,180}el\('rect'/);
   assert.match(styles, /\.mj-tile\[data-suit="chr"\]\s*\{\s*color:\s*var\(--mj-ink\);\s*\}/);
   assert.doesNotMatch(styles, /\.mj-tile\[data-suit="chr"\][^{]*\{[^}]*var\(--mj-red\)/);
-  assert.match(styles, /\.mj-character-number\s*\{[^}]*font-weight:\s*850;[^}]*stroke-width:\s*0\.7px;[^}]*paint-order:\s*stroke fill;/);
+  assert.match(styles, /\.mj-character-number\s*\{[^}]*font-weight:\s*700;[^}]*stroke-width:\s*0\.7px;[^}]*paint-order:\s*stroke fill;/);
 });
 
 test('the bamboo suit uses a panda emblem plus the supplied jade and gold stick artwork', () => {
@@ -662,4 +662,16 @@ test('the Records sheet opens from the dock and R, paints from the pure summary,
   assert.match(controller, /tr\.setAttribute\('aria-current', 'true'\)/);
   assert.match(controller, /'No dailies cleared in the last 28 days\.'/);
   assert.match(controller, /`cleared \$\{clearedDays\.length\} of the last 28 dailies`/);
+});
+
+test('tile-face type stays JetBrains Mono while the game chrome uses Inter', () => {
+  // The v1.13.0 start-page typography pass aliased --font-mono to Inter inside
+  // the game. Tile faces are exempt: numerals and wind badge letters keep the
+  // bundled mono stack through a game-local token that bypasses the alias.
+  assert.match(mahjongStyles, /\.mahjong-body\s*\{[^}]*--mj-face-font:\s*"JetBrains Mono", ui-monospace/);
+  assert.match(mahjongStyles, /\.mj-face text\s*\{[^}]*font-family:\s*var\(--mj-face-font\)/);
+  assert.match(mahjongStyles, /\.mj-character-number\s*\{[^}]*font-family:\s*var\(--mj-face-font\);[^}]*font-weight:\s*700;[^}]*font-variation-settings:\s*"wght" 700;/);
+  assert.doesNotMatch(mahjongStyles, /\.mj-character-number\s*\{[^}]*var\(--font-ui\)/);
+  // The chrome alias itself stays: meters, sheets, and dock labels remain Inter.
+  assert.match(mahjongStyles, /\.mahjong-body\s*\{[^}]*--font-mono:\s*var\(--font-ui\);/);
 });

--- a/test/unit/mahjong-page.test.js
+++ b/test/unit/mahjong-page.test.js
@@ -188,7 +188,7 @@ test('character numerals fill their tile faces in ink without underline marks', 
   assert.doesNotMatch(controller, /family === 'chr'[\s\S]{0,180}el\('rect'/);
   assert.match(styles, /\.mj-tile\[data-suit="chr"\]\s*\{\s*color:\s*var\(--mj-ink\);\s*\}/);
   assert.doesNotMatch(styles, /\.mj-tile\[data-suit="chr"\][^{]*\{[^}]*var\(--mj-red\)/);
-  assert.match(styles, /\.mj-character-number\s*\{[^}]*font-weight:\s*700;[^}]*stroke-width:\s*0\.7px;[^}]*paint-order:\s*stroke fill;/);
+  assert.match(styles, /\.mj-character-number\s*\{[^}]*font-weight:\s*800;[^}]*stroke-width:\s*0\.7px;[^}]*paint-order:\s*stroke fill;/);
 });
 
 test('the bamboo suit uses a panda emblem plus the supplied jade and gold stick artwork', () => {
@@ -670,7 +670,10 @@ test('tile-face type stays JetBrains Mono while the game chrome uses Inter', () 
   // bundled mono stack through a game-local token that bypasses the alias.
   assert.match(mahjongStyles, /\.mahjong-body\s*\{[^}]*--mj-face-font:\s*"JetBrains Mono", ui-monospace/);
   assert.match(mahjongStyles, /\.mj-face text\s*\{[^}]*font-family:\s*var\(--mj-face-font\)/);
-  assert.match(mahjongStyles, /\.mj-character-number\s*\{[^}]*font-family:\s*var\(--mj-face-font\);[^}]*font-weight:\s*700;[^}]*font-variation-settings:\s*"wght" 700;/);
+  assert.match(mahjongStyles, /\.mj-character-number\s*\{[^}]*font-family:\s*var\(--mj-face-font\);[^}]*font-weight:\s*800;[^}]*font-variation-settings:\s*"wght" 800;/);
+  // The bundled JetBrains Mono file carries wght 400–800; the shared @font-face
+  // must expose the full range or 800 silently clamps to 700.
+  assert.match(styles, /font-family:\s*"JetBrains Mono";\s*src:\s*url\("jetbrains-mono-latin\.woff2"\)[^}]*font-weight:\s*400 800;/);
   assert.doesNotMatch(mahjongStyles, /\.mj-character-number\s*\{[^}]*var\(--font-ui\)/);
   // The chrome alias itself stays: meters, sheets, and dock labels remain Inter.
   assert.match(mahjongStyles, /\.mahjong-body\s*\{[^}]*--font-mono:\s*var\(--font-ui\);/);


### PR DESCRIPTION
## Summary
- The September 2 start-page typography pass (`5e0f0ef`, shipped in v1.13.0) aliased `--font-mono` to Inter inside the Mahjong page, which moved the wind badge letters to Inter; the character numerals had already moved to Inter in the v2 redesign (#256). The owner wants the **tile faces left out of that migration**.
- A game-local `--mj-face-font` restates the bundled JetBrains Mono stack for `.mj-face text` and the character numerals. Meters, sheets, and dock labels keep Inter via the existing alias.
- The numeral rule is now `.mj-face text.mj-character-number`, so its declared weight actually applies: the bare class always lost to `.mj-face text`, so the "850" had never taken effect and every shipped build rendered numerals at 650.
- **Weight 800.** The bundled `jetbrains-mono-latin.woff2` carries the full wght 400–800 axis, but the shared `@font-face` in `pages.css` declared `400 700`, silently clamping heavier requests. It now declares the real range and the numerals pin 800 (JetBrains Mono ExtraBold, not synthesized). No other rule requests a weight above 700.
- **Notices as lacquer pills.** The feedback strip sat on the table's top edge as loose text, which wedged the two-sentence "continue your unfinished board" offer (from #270) between the header and the frame border. Notices now carry their own panel ground, border, and blur; on desktop the strip anchors inside the table's top edge (`position-anchor: --mj-table`, clear of the left rail) and in the stacked layout it sits between the board and the dock. Applies to the continue offer, "No moves remain", and the recovery notice.

## Test plan
- [x] `node --test test/unit/mahjong-page.test.js` — 43/43; new tests pin the face token, both face rules, the 800 weight, the widened `@font-face` range, and the anchored pill (each written failing first)
- [x] `npm run test:unit` — 1423/1424; the single failure is the pre-existing `compliance-model` license-file check for `@ghostery/adblocker-content`
- [x] Browser check over 127.0.0.1: face at `400 800 loaded`, numerals `"JetBrains Mono"` at 800, wind badges `"JetBrains Mono"`, pairs meter `Inter`; the continue offer renders inside the table (top 86 vs frame 72 at 1280×800), centered, clear of the rail, and between board and dock at 900×700
- [x] Owner reviewed the tiles and the notice placement in the dev instance running from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)