### PR TITLE
Release Blanc 1.15.0

### DIFF
--- a/compliance/root-lock-sbom.cdx.json
+++ b/compliance/root-lock-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:root:blanc@1.14.0",
+      "bom-ref": "application:root:blanc@1.15.0",
       "name": "blanc dependency lock",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "description": "Complete root npm supply-chain inventory, including development and optional packages."
     },
     "properties": [
@@ -18197,7 +18197,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:root:blanc@1.14.0",
+      "ref": "application:root:blanc@1.15.0",
       "dependsOn": [
         "pkg:npm/%401password/sdk@0.5.0",
         "pkg:npm/%40cucumber/cucumber@13.2.1",

--- a/compliance/runtime-sbom.cdx.json
+++ b/compliance/runtime-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:runtime:blanc@1.14.0",
+      "bom-ref": "application:runtime:blanc@1.15.0",
       "name": "Blanc",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "description": "Shipped desktop runtime: npm closure, Electron framework, bundled fonts, and blocker data provenance."
     },
     "properties": [
@@ -1704,7 +1704,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:runtime:blanc@1.14.0",
+      "ref": "application:runtime:blanc@1.15.0",
       "dependsOn": [
         "asset:blanc-adblock-seed",
         "asset:inter-font",

--- a/docs/press/release-notes/v1.15.0.md
+++ b/docs/press/release-notes/v1.15.0.md
@@ -1,0 +1,18 @@
+# Blanc 1.15.0
+
+## Added
+
+- **Five more Mahjong boards.** Pyramid, Fortress, Butterfly, Bridge, and Cross join Turtle, Arch, and Peaks. Every deal is still solvable by construction, and the Daily deal now rotates through all eight layouts.
+- **A Records sheet** opens from a new dock control or the R key. It shows boards cleared, your current and longest daily streak, dailies cleared, the best Classic time and Burst score for each board, and the last four weeks of dailies. Everything stays on this device.
+- **Pick up where you left off.** A fresh Mahjong tab starts with your last layout, mode, and deal choice, and offers to continue an unfinished board from another tab instead of silently dealing a new one.
+
+## Updated
+
+- **Shuffle can be undone.** Shuffle records the board it replaced, so Undo restores it exactly, including from the Burst rescue dialog.
+- **Tile faces keep JetBrains Mono.** Character numerals and wind badges return to the bundled monospace at its full ExtraBold weight, while the game's meters and sheets stay in Inter.
+- **Notices float as lacquer pills** inside the table instead of loose text along its edge, and the desktop control rail now sizes itself to the embedded table so all six controls always fit.
+
+## Fixed
+
+- The first clear of a board reads "first clear" rather than "new record", hints survive arrow-key navigation, Daily layout cards read as disabled, the dead-end notice offers Shuffle, and the daily result appears in the Boards sheet and on the completion card.
+- Mahjong completion totals are counted exactly once, even when a storage write or an old-event prune fails.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "license": "MIT",
       "dependencies": {
         "@1password/sdk": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",


### PR DESCRIPTION
## Summary
- Bump `version` to 1.15.0 in `package.json` and `package-lock.json`; regenerate the two compliance SBOMs that embed it (`npm run compliance:build`, `compliance:check` current).
- Add `docs/press/release-notes/v1.15.0.md` covering the Mahjong work merged since v1.14.0: five more layouts with an eight-way Daily rotation and the Records sheet (#271), undoable shuffle plus remembered table and continue offer (#270), and the tile-face JetBrains Mono revert with the notice pill (#274).
- Electron stays at `^44.1.1` (current stable). The migration base in `release.sh` stays at 1.14.0 for this release and advances afterwards, per the runbook.

Same file set as the v1.14.0 release commit (`8da3738`). Site-only merges since v1.14.0 (#272, #273) are deliberately not in the app notes.

## Test plan
- [x] `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- [x] `npm run compliance:check` — current after regeneration
- [ ] CI (parity guards, CodeQL) green on this PR before merge
- [ ] `npm run release` from a checkout at `origin/main` after merge (terminal operator mode), then the v1.14.0 → v1.15.0 macOS and Windows updater handoffs, changelog commit, site deploy, and the dated incident record

🤖 Generated with [Claude Code](https://claude.com/claude-code)