### PR TITLE
Exempt Mahjong tile faces from the start-page Inter acceptance gate

### DIFF
--- a/spec/features.md
+++ b/spec/features.md
@@ -736,7 +736,11 @@ From the desktop `DEFAULTS`:
 - All five start-page layouts use **Inter** for text that previously used the
   shared JetBrains Mono role, including the shared footer and onboarding. This
   override is local to the new-tab and embedded Mahjong documents; other
-  internal pages and browser chrome retain their existing typography. Desktop
+  internal pages and browser chrome retain their existing typography. The one
+  deliberate exception is Mahjong's tile faces: character numerals and wind
+  badge letters are game artwork and keep the bundled JetBrains Mono (at its
+  ExtraBold weight), while the game's meters, sheets, and dock labels use
+  Inter. Desktop
   acceptance exercises every layout at the default and minimum supported
   sizes and on both sides of its responsive breakpoints, with realistic long
   Billboard titles, and rejects horizontal overflow, unreachable text, or

--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -526,17 +526,25 @@ function install(refs) {
       const frame = tab.view.webContents.mainFrame.framesInSubtree
         .find((candidate) => candidate.url.startsWith('blanc://mahjong/'));
       if (!frame) return { page, mahjong: null };
+      // Tile faces (character numerals and wind badge letters inside the
+      // tile SVGs) are game artwork and deliberately keep JetBrains Mono;
+      // the Inter rule covers the game's UI text only. Report the faces
+      // separately so the step can assert both halves of that contract.
       const mahjong = await frame.executeJavaScript(`(() => {
         const selectors = ['.mj-meter-label', '.mj-timer', '.mj-dock-action', '.mj-overline'];
+        const isTileFace = (element) => element.closest('.mj-face') !== null;
+        const monoElements = [...document.querySelectorAll('body, body *')]
+          .filter((element) => getComputedStyle(element).fontFamily.includes('JetBrains Mono'));
         return {
           samples: selectors.map((selector) => ({
             selector,
             family: getComputedStyle(document.querySelector(selector)).fontFamily,
           })),
-          jetbrains: [...document.querySelectorAll('body, body *')]
-            .filter((element) => getComputedStyle(element).fontFamily.includes('JetBrains Mono'))
+          jetbrains: monoElements
+            .filter((element) => !isTileFace(element))
             .slice(0, 20)
             .map((element) => element.id || element.className || element.tagName),
+          tileFaceMono: monoElements.filter(isTileFace).length,
         };
       })()`);
       return { page, mahjong };

--- a/test/desktop/steps/newtab-layouts.steps.js
+++ b/test/desktop/steps/newtab-layouts.steps.js
@@ -129,7 +129,10 @@ Then('all start-page templates use Inter instead of JetBrains Mono', async funct
     'the new-tab and embedded Mahjong documents to expose their computed fonts',
   );
   assert.deepEqual(usage.page.jetbrains, []);
-  assert.deepEqual(usage.mahjong.jetbrains, []);
+  assert.deepEqual(usage.mahjong.jetbrains, [], 'Mahjong UI text outside the tile faces must be Inter');
+  // Tile faces are the one deliberate exception: numerals and wind badges are
+  // game artwork set in JetBrains Mono (owner decision, PR #274).
+  assert.ok(usage.mahjong.tileFaceMono > 0, 'Mahjong tile faces keep JetBrains Mono');
   for (const sample of [...usage.page.samples, ...usage.mahjong.samples]) {
     assert.match(sample.family, /Inter/, `${sample.selector} resolved to ${sample.family}`);
   }


### PR DESCRIPTION
## Summary
- The v1.15.0 release attempt stopped at the press verification gate, correctly and before any tag or draft existed: the `@F35-6` desktop scenario "Every start-page layout replaces mono UI text with Inter" scans the embedded Mahjong document for JetBrains Mono and found the tile faces that PR #274 deliberately returned to it.
- `readStartPageFontUsage` now reports tile-face elements (anything inside `.mj-face`) separately as `tileFaceMono`; the step asserts Mahjong UI text outside the faces is Inter **and** that the faces do use JetBrains Mono, so both halves of the decision are pinned.
- `spec/features.md` F35 records the exception in the same paragraph that states the Inter rule.

Test-only plus a spec sentence; no runtime change.

## Test plan
- [x] `BLANC_TEST=1 npx cucumber-js -c test/desktop/cucumber.mjs -p runnable --tags @F35-6` — 6/6 steps (was 1 failed in the release gate)
- [x] `npm run test:acceptance:dry` — 802 steps resolve
- [x] `npm run test:unit` — 1425/1425
- [ ] Re-run `npm run release` for 1.15.0 after merge (same version; no tag or draft was created by attempt one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)