### PR TITLE
Accept lowercase hex when the Sunrise site test runs against minified CSS

### DIFF
--- a/test/site/sunrise-light.test.mjs
+++ b/test/site/sunrise-light.test.mjs
@@ -52,7 +52,8 @@ test('the Patron offer sets its name and price in gold on warm ink under a light
         cta: getComputedStyle(section.querySelector('.cta')).backgroundColor,
       };
     });
-    assert.equal(patron.warmInk, '#12100B');
+    // Minified production CSS lowercases hex, the dev server does not.
+    assert.equal(patron.warmInk.toLowerCase(), '#12100b');
     assert.equal(patron.background, 'rgb(18, 16, 11)', 'Patron sits on the website-only warm ink');
     assert.match(patron.backgroundImage, /radial-gradient/, 'a gold light spill is painted on the card');
     assert.equal(patron.name, 'rgb(212, 173, 102)', 'the Patron name is gold');


### PR DESCRIPTION
## Summary

- `test/site/sunrise-light.test.mjs` compared the `--site-ink-warm` token as `#12100B`; production's minified CSS serves `#12100b`, so the test failed against https://blancbrowser.com while passing against the dev server. Compare case-insensitively.

## Test plan

- [x] `BLANC_SITE_URL=https://blancbrowser.com node --test test/site/sunrise-light.test.mjs` passes (5/5) against the deployed site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)