### PR TITLE
Patch 12 security advisories in build dependencies

### DIFF
--- a/compliance/root-lock-sbom.cdx.json
+++ b/compliance/root-lock-sbom.cdx.json
@@ -4389,14 +4389,14 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/%40xmldom/xmldom@0.8.13",
+      "bom-ref": "pkg:npm/%40xmldom/xmldom@0.8.15",
       "name": "@xmldom/xmldom",
-      "version": "0.8.13",
+      "version": "0.8.15",
       "scope": "optional",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "291633c5ea5cd781bf084a4419cdd89fe24a680793eb7b26943afebe307c8d17e04c1048f70463fe791010efae715f29f08f5b7ca2d6a77eee1e016b6e7b4fbf"
+          "content": "ff9355fef0c02d51435e02e67eccbd4d108194ac0ed8b341173a73bdbf62223fa347e79273a0cb618bd539d8af4ff8e6eccb54e9379b62e466cc4388ef0e3450"
         }
       ],
       "licenses": [
@@ -4406,7 +4406,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/%40xmldom/xmldom@0.8.13",
+      "purl": "pkg:npm/%40xmldom/xmldom@0.8.15",
       "properties": [
         {
           "name": "blanc:development",
@@ -4428,7 +4428,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz"
+          "url": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz"
         }
       ]
     },
@@ -5334,51 +5334,6 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/brace-expansion@1.1.16",
-      "name": "brace-expansion",
-      "version": "1.1.16",
-      "scope": "optional",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "203c38f0adbfda446483d2dd271babbeade557768182ad11118f3d76e12a151b618e53dd5c728c8fb12740e5d5724c73822b229dfde71dfadc13616e7c52d733"
-        }
-      ],
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        }
-      ],
-      "purl": "pkg:npm/brace-expansion@1.1.16",
-      "properties": [
-        {
-          "name": "blanc:development",
-          "value": "true"
-        },
-        {
-          "name": "blanc:lockPaths",
-          "value": "node_modules/dir-compare/node_modules/brace-expansion,node_modules/glob/node_modules/brace-expansion"
-        },
-        {
-          "name": "blanc:optional",
-          "value": "false"
-        },
-        {
-          "name": "blanc:workspace",
-          "value": "root"
-        }
-      ],
-      "externalReferences": [
-        {
-          "type": "distribution",
-          "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz"
-        }
-      ]
-    },
-    {
-      "type": "library",
       "bom-ref": "pkg:npm/brace-expansion@1.1.18",
       "name": "brace-expansion",
       "version": "1.1.18",
@@ -5404,7 +5359,7 @@
         },
         {
           "name": "blanc:lockPaths",
-          "value": "node_modules/@electron/universal/node_modules/@electron/asar/node_modules/brace-expansion,node_modules/app-builder-lib/node_modules/brace-expansion,node_modules/electron-winstaller/node_modules/brace-expansion"
+          "value": "node_modules/@electron/universal/node_modules/@electron/asar/node_modules/brace-expansion,node_modules/app-builder-lib/node_modules/brace-expansion,node_modules/dir-compare/node_modules/brace-expansion,node_modules/electron-winstaller/node_modules/brace-expansion,node_modules/glob/node_modules/brace-expansion"
         },
         {
           "name": "blanc:optional",
@@ -5424,14 +5379,14 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/brace-expansion@2.1.2",
+      "bom-ref": "pkg:npm/brace-expansion@2.1.4",
       "name": "brace-expansion",
-      "version": "2.1.2",
+      "version": "2.1.4",
       "scope": "optional",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "c3925970a81d8433a03b09bc1fe2a06e8b28a4732e19c97aa9bba5c23b73dd233b23b3f7c96d5e023ccc3cbac813e350f6f8e000d28759e3079eb4f43975b5a0"
+          "content": "8467d5ccfc6d85b7f7fb6ca383f441b3ad1c074161a814bfcef755ff8c27e3f0663746cd30c1cf73857f05b1627aa7f54ca0061801e76387928da8c29747f65e"
         }
       ],
       "licenses": [
@@ -5441,7 +5396,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/brace-expansion@2.1.2",
+      "purl": "pkg:npm/brace-expansion@2.1.4",
       "properties": [
         {
           "name": "blanc:development",
@@ -5463,20 +5418,20 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz"
+          "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz"
         }
       ]
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/brace-expansion@5.0.7",
+      "bom-ref": "pkg:npm/brace-expansion@5.0.9",
       "name": "brace-expansion",
-      "version": "5.0.7",
+      "version": "5.0.9",
       "scope": "optional",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "ee8172ef4dddc5f637fcd2f10b57e1d925024341fdae6018fb91290d57d78d44d3b3e1c4c11da761aa8bbfe196713b2e9b0c4f7e2cfa0b308d9305f0054c2a08"
+          "content": "49c43822ebc8105d533253fb66dfaf8c9ffff7394f6f64837315b13376e4f2ceade8619d27b28ed5d09c4e274e3c929e3d6df42c4ff6713ef00b23e1a3dfd6c6"
         }
       ],
       "licenses": [
@@ -5486,7 +5441,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/brace-expansion@5.0.7",
+      "purl": "pkg:npm/brace-expansion@5.0.9",
       "properties": [
         {
           "name": "blanc:development",
@@ -5508,7 +5463,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz"
+          "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz"
         }
       ]
     },
@@ -8349,14 +8304,14 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/fast-uri@3.1.4",
+      "bom-ref": "pkg:npm/fast-uri@3.1.7",
       "name": "fast-uri",
-      "version": "3.1.4",
+      "version": "3.1.7",
       "scope": "optional",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "f099db910e23b83caf62ce26805190aa0e32098b450ed52d9a9d90210ab5d5965ee42150e7072a9b5aea0e0021fd074cc92b819cfccc5222543591b937f02243"
+          "content": "74ebd95738dd65dcfba6177dbfa8c26f0c6b056ddf2ba9fc45cd02b5d98ce1bba6ccc9f1cb005886ea61e89f35f51470fe4bbeacb6de9707ccba792dbb35551e"
         }
       ],
       "licenses": [
@@ -8366,7 +8321,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/fast-uri@3.1.4",
+      "purl": "pkg:npm/fast-uri@3.1.7",
       "properties": [
         {
           "name": "blanc:development",
@@ -8388,7 +8343,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz"
+          "url": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz"
         }
       ]
     },
@@ -16226,14 +16181,14 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/tar@7.5.19",
+      "bom-ref": "pkg:npm/tar@7.5.22",
       "name": "tar",
-      "version": "7.5.19",
+      "version": "7.5.22",
       "scope": "optional",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "e0b7845a5f7ab709d2d90ec1cf8306aa06b32ea3be84937adc66715e822a8754f75707980fdf7b81b53522d36c41a7eaa974d7779585c8575178bb70bd104d8b"
+          "content": "3053bf433bed00e9896e484e6824ef6c670537d2fd6fe26e9c8b03c1a2a58d239d70b31e6b7349d64f54b33feb8dd7d25d3ab875fcdf792ed6e29e1838000778"
         }
       ],
       "licenses": [
@@ -16243,7 +16198,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/tar@7.5.19",
+      "purl": "pkg:npm/tar@7.5.22",
       "properties": [
         {
           "name": "blanc:development",
@@ -16265,7 +16220,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz"
+          "url": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz"
         }
       ]
     },
@@ -17073,14 +17028,14 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/undici@6.27.0",
+      "bom-ref": "pkg:npm/undici@6.28.1",
       "name": "undici",
-      "version": "6.27.0",
+      "version": "6.28.1",
       "scope": "optional",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "6267d5dd89c40f35d10b9959da35ad5961ca1949b5cc8b7c0217ac475b5e9ecf874cdbfe61994dfdda7a1bbdbb2cebcc27cc633fd05eed8d9276bf7a2c39bea6"
+          "content": "cd6a5d4d50f9e07e3c088c9b2f4ad6437ba4a5bf5ddb7c0cede1f946d7dd99e3fbd1c587363b5fa3b3f8bd95fee42a0370ee772783eee6e5e9ee535f8dce8344"
         }
       ],
       "licenses": [
@@ -17090,7 +17045,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/undici@6.27.0",
+      "purl": "pkg:npm/undici@6.28.1",
       "properties": [
         {
           "name": "blanc:development",
@@ -17112,7 +17067,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz"
+          "url": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz"
         }
       ]
     },
@@ -18805,7 +18760,7 @@
       ]
     },
     {
-      "ref": "pkg:npm/%40xmldom/xmldom@0.8.13",
+      "ref": "pkg:npm/%40xmldom/xmldom@0.8.15",
       "dependsOn": []
     },
     {
@@ -18820,7 +18775,7 @@
       "ref": "pkg:npm/ajv@8.20.0",
       "dependsOn": [
         "pkg:npm/fast-deep-equal@3.1.3",
-        "pkg:npm/fast-uri@3.1.4",
+        "pkg:npm/fast-uri@3.1.7",
         "pkg:npm/json-schema-traverse@1.0.0",
         "pkg:npm/require-from-string@2.0.2"
       ]
@@ -18878,7 +18833,7 @@
         "pkg:npm/proper-lockfile@4.1.2",
         "pkg:npm/resedit@1.7.2",
         "pkg:npm/semver@7.7.4",
-        "pkg:npm/tar@7.5.19",
+        "pkg:npm/tar@7.5.22",
         "pkg:npm/temp-file@3.4.0",
         "pkg:npm/tiny-async-pool@1.3.0",
         "pkg:npm/unzipper@0.12.5",
@@ -18946,13 +18901,6 @@
       "dependsOn": []
     },
     {
-      "ref": "pkg:npm/brace-expansion@1.1.16",
-      "dependsOn": [
-        "pkg:npm/balanced-match@1.0.2",
-        "pkg:npm/concat-map@0.0.1"
-      ]
-    },
-    {
       "ref": "pkg:npm/brace-expansion@1.1.18",
       "dependsOn": [
         "pkg:npm/balanced-match@1.0.2",
@@ -18960,13 +18908,13 @@
       ]
     },
     {
-      "ref": "pkg:npm/brace-expansion@2.1.2",
+      "ref": "pkg:npm/brace-expansion@2.1.4",
       "dependsOn": [
         "pkg:npm/balanced-match@1.0.2"
       ]
     },
     {
-      "ref": "pkg:npm/brace-expansion@5.0.7",
+      "ref": "pkg:npm/brace-expansion@5.0.9",
       "dependsOn": [
         "pkg:npm/balanced-match@4.0.4"
       ]
@@ -19359,7 +19307,7 @@
       "dependsOn": []
     },
     {
-      "ref": "pkg:npm/fast-uri@3.1.4",
+      "ref": "pkg:npm/fast-uri@3.1.7",
       "dependsOn": []
     },
     {
@@ -19835,26 +19783,25 @@
     {
       "ref": "pkg:npm/minimatch@10.2.5",
       "dependsOn": [
-        "pkg:npm/brace-expansion@5.0.7"
+        "pkg:npm/brace-expansion@5.0.9"
       ]
     },
     {
       "ref": "pkg:npm/minimatch@3.1.5",
       "dependsOn": [
-        "pkg:npm/brace-expansion@1.1.16",
         "pkg:npm/brace-expansion@1.1.18"
       ]
     },
     {
       "ref": "pkg:npm/minimatch@5.1.9",
       "dependsOn": [
-        "pkg:npm/brace-expansion@2.1.2"
+        "pkg:npm/brace-expansion@2.1.4"
       ]
     },
     {
       "ref": "pkg:npm/minimatch@9.0.9",
       "dependsOn": [
-        "pkg:npm/brace-expansion@2.1.2"
+        "pkg:npm/brace-expansion@2.1.4"
       ]
     },
     {
@@ -19902,9 +19849,9 @@
         "pkg:npm/nopt@9.0.0",
         "pkg:npm/proc-log@6.1.0",
         "pkg:npm/semver@7.8.5",
-        "pkg:npm/tar@7.5.19",
+        "pkg:npm/tar@7.5.22",
         "pkg:npm/tinyglobby@0.2.17",
-        "pkg:npm/undici@6.27.0",
+        "pkg:npm/undici@6.28.1",
         "pkg:npm/which@6.0.1"
       ]
     },
@@ -20016,7 +19963,7 @@
     {
       "ref": "pkg:npm/plist@3.1.0",
       "dependsOn": [
-        "pkg:npm/%40xmldom/xmldom@0.8.13",
+        "pkg:npm/%40xmldom/xmldom@0.8.15",
         "pkg:npm/base64-js@1.5.1",
         "pkg:npm/xmlbuilder@15.1.1"
       ]
@@ -20361,7 +20308,7 @@
       "dependsOn": []
     },
     {
-      "ref": "pkg:npm/tar@7.5.19",
+      "ref": "pkg:npm/tar@7.5.22",
       "dependsOn": [
         "pkg:npm/%40isaacs/fs-minipass@4.0.1",
         "pkg:npm/chownr@3.0.0",
@@ -20462,7 +20409,7 @@
       "dependsOn": []
     },
     {
-      "ref": "pkg:npm/undici@6.27.0",
+      "ref": "pkg:npm/undici@6.28.1",
       "dependsOn": []
     },
     {

--- a/docs/security-dependency-triage-2026-09-04.md
+++ b/docs/security-dependency-triage-2026-09-04.md
@@ -1,0 +1,72 @@
+# Dependency advisory triage — September 4, 2026
+
+The 12 advisories reported by OpenSSF Scorecard against
+`188b4ed4269a6aa0b65e438f84494b46330485ee` match **development dependencies**
+in the root lockfile. No affected version for these advisories occurs in its
+production dependency entries or the website lockfile. The v1.15.0 root
+lockfile is byte-equivalent as parsed JSON to this baseline.
+
+This patch updates nine development-only lockfile entries within existing
+dependency ranges, regenerates the root lock SBOM, and updates its component
+count assertion from 400 to 399. The count falls because brace-expansion
+1.1.16 now shares the already-present 1.1.18 version. `package.json`, all
+production entries, the runtime SBOM, and the website lockfile are unchanged.
+There is no application version bump or release in this change.
+
+## Findings and fixes
+
+| Package | Affected locked versions | Updated to | Dependency route / exposure |
+| --- | --- | --- | --- |
+| @xmldom/xmldom | 0.8.13 | 0.8.15 | electron-builder → app-builder-lib → plist; build-time XML processing |
+| brace-expansion | 1.1.16, 2.1.2, 5.0.7 | 1.1.18, 2.1.4, 5.0.9 | ASAR, glob, universal build, directory comparison, and file-list tooling; build-time glob expansion |
+| fast-uri | 3.1.4 | 3.1.7 | electron-builder → app-builder-lib → ajv; build configuration/schema processing |
+| tar | 7.5.19 | 7.5.22 | app-builder-lib and node-gyp; build-time archive processing |
+| undici | 6.27.0 | 6.28.1 | electron-builder → app-builder-lib → @electron/rebuild → node-gyp; build-time HTTP requests |
+
+The root Undici 7.29.0 and website Undici 8.10.0 are outside the three affected
+Undici ranges and remain unchanged. npm's production graph retains the root
+copy through an Electron peer dependency, which is why its missing `dev` flag
+alone did not establish exposure. The affected nested 6.27.0 copy is dev-only.
+
+Build dependencies are still security-relevant: compromised or malicious
+inputs can affect build machines and generated artifacts. Development-only
+classification is not a dismissal. This is a scoped dependency-range review,
+not proof that the browser has no vulnerabilities or an independent audit of
+Electron/Chromium and their bundled internals.
+
+## Advisory sources
+
+- XML: [GHSA-6gmq-8vp8-gcm6](https://github.com/xmldom/xmldom/security/advisories/GHSA-6gmq-8vp8-gcm6).
+- Glob expansion: [GHSA-mh99-v99m-4gvg](https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-mh99-v99m-4gvg), [GHSA-rgw5-rvv9-x895](https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-rgw5-rvv9-x895).
+- URI processing: [GHSA-5jgf-p345-68v8](https://github.com/fastify/fast-uri/security/advisories/GHSA-5jgf-p345-68v8), [GHSA-7p8r-x3mc-p8w7](https://github.com/fastify/fast-uri/security/advisories/GHSA-7p8r-x3mc-p8w7), [GHSA-f65p-4m7j-42xc](https://github.com/fastify/fast-uri/security/advisories/GHSA-f65p-4m7j-42xc), [GHSA-fph4-wmhf-6fwf](https://github.com/fastify/fast-uri/security/advisories/GHSA-fph4-wmhf-6fwf), [GHSA-jqff-g426-hqxp](https://github.com/fastify/fast-uri/security/advisories/GHSA-jqff-g426-hqxp).
+- Archive processing: [GHSA-r292-9mhp-454m](https://github.com/isaacs/node-tar/security/advisories/GHSA-r292-9mhp-454m).
+- HTTP: [GHSA-8xcm-r25x-g524](https://github.com/nodejs/undici/security/advisories/GHSA-8xcm-r25x-g524), [GHSA-m8rv-5g2x-5cg5](https://github.com/nodejs/undici/security/advisories/GHSA-m8rv-5g2x-5cg5), [GHSA-v3r7-h72x-cjcm](https://github.com/nodejs/undici/security/advisories/GHSA-v3r7-h72x-cjcm).
+
+The machine-readable [triage](security-evidence/dependency-triage-2026-09-04.json)
+maps each advisory's OSV semver ranges to exact lockfile paths before and after
+the change. All 12 have dev-only matches before, zero matches after, and zero
+website matches. npm groups these into five vulnerable package names; its
+count of five is not a contradiction of Scorecard's 12 distinct advisories.
+
+## Validation
+
+- Fresh `npm ci --ignore-scripts --no-audit --no-fund`: successful, 405 packages.
+- Full root `npm audit --json`: five vulnerable package groups before; zero
+  after. Original production-only audit: zero. Website audit: zero.
+- `npm run substrate:check`: passed, including generated compliance inventory.
+- `npm run test:acceptance:dry`: all 130 scenarios / 802 steps resolve; the dry
+  run does not execute desktop behavior.
+- `npm run test:unit`: 1,428 passed, zero failed/cancelled/skipped; the normal
+  runner exits successfully after the existing sync fixture's 65-second
+  optional-store retry timer drains. No forced-exit option is needed.
+- All 43 production/non-dev lock entries are identical before and after;
+  runtime SBOM contents are identical and contain none of the five affected
+  package names. `git diff --check` passed.
+
+Audit snapshots are checked in under `docs/security-evidence/` with this date.
+These are point-in-time database checks. A public Scorecard rescan of main
+will continue to see the old lockfile until the patch is merged.
+
+The repository's launch freeze still applies. This candidate is prepared for
+review on `codex/security-dependency-triage`; merging and native release gates
+are separate from this dependency remediation work.

--- a/docs/security-evidence/dependency-triage-2026-09-04.json
+++ b/docs/security-evidence/dependency-triage-2026-09-04.json
@@ -1,0 +1,226 @@
+{
+  "date": "2026-09-04",
+  "baseCommit": "188b4ed4269a6aa0b65e438f84494b46330485ee",
+  "releaseLockIdentical": true,
+  "changedLockEntries": [
+    "node_modules/@electron/universal/node_modules/brace-expansion",
+    "node_modules/@xmldom/xmldom",
+    "node_modules/brace-expansion",
+    "node_modules/dir-compare/node_modules/brace-expansion",
+    "node_modules/fast-uri",
+    "node_modules/filelist/node_modules/brace-expansion",
+    "node_modules/glob/node_modules/brace-expansion",
+    "node_modules/node-gyp/node_modules/undici",
+    "node_modules/tar"
+  ],
+  "advisories": [
+    {
+      "id": "GHSA-6gmq-8vp8-gcm6",
+      "summary": "xmldom: XML fragment injection via invalid EntityReference.nodeName during requireWellFormed serialization",
+      "source": "https://github.com/xmldom/xmldom/security/advisories/GHSA-6gmq-8vp8-gcm6",
+      "before": [
+        {
+          "path": "node_modules/@xmldom/xmldom",
+          "version": "0.8.13",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-mh99-v99m-4gvg",
+      "summary": "brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash",
+      "source": "https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-mh99-v99m-4gvg",
+      "before": [
+        {
+          "path": "node_modules/@electron/universal/node_modules/brace-expansion",
+          "version": "2.1.2",
+          "dev": true
+        },
+        {
+          "path": "node_modules/brace-expansion",
+          "version": "5.0.7",
+          "dev": true
+        },
+        {
+          "path": "node_modules/dir-compare/node_modules/brace-expansion",
+          "version": "1.1.16",
+          "dev": true
+        },
+        {
+          "path": "node_modules/filelist/node_modules/brace-expansion",
+          "version": "2.1.2",
+          "dev": true
+        },
+        {
+          "path": "node_modules/glob/node_modules/brace-expansion",
+          "version": "1.1.16",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-rgw5-rvv9-x895",
+      "summary": "brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation",
+      "source": "https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-rgw5-rvv9-x895",
+      "before": [
+        {
+          "path": "node_modules/@electron/universal/node_modules/brace-expansion",
+          "version": "2.1.2",
+          "dev": true
+        },
+        {
+          "path": "node_modules/brace-expansion",
+          "version": "5.0.7",
+          "dev": true
+        },
+        {
+          "path": "node_modules/dir-compare/node_modules/brace-expansion",
+          "version": "1.1.16",
+          "dev": true
+        },
+        {
+          "path": "node_modules/filelist/node_modules/brace-expansion",
+          "version": "2.1.2",
+          "dev": true
+        },
+        {
+          "path": "node_modules/glob/node_modules/brace-expansion",
+          "version": "1.1.16",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-5jgf-p345-68v8",
+      "summary": "fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references",
+      "source": "https://github.com/fastify/fast-uri/security/advisories/GHSA-5jgf-p345-68v8",
+      "before": [
+        {
+          "path": "node_modules/fast-uri",
+          "version": "3.1.4",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-7p8r-x3mc-p8w7",
+      "summary": "fast-uri vulnerable to host confusion via backslash authority introducer",
+      "source": "https://github.com/fastify/fast-uri/security/advisories/GHSA-7p8r-x3mc-p8w7",
+      "before": [
+        {
+          "path": "node_modules/fast-uri",
+          "version": "3.1.4",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-f65p-4m7j-42xc",
+      "summary": "fast-uri vulnerable to server-side request forgery via malformed IPv6 normalization",
+      "source": "https://github.com/fastify/fast-uri/security/advisories/GHSA-f65p-4m7j-42xc",
+      "before": [
+        {
+          "path": "node_modules/fast-uri",
+          "version": "3.1.4",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-fph4-wmhf-6fwf",
+      "summary": "fast-uri vulnerable to server-side request forgery via repeated hostname percent-decoding",
+      "source": "https://github.com/fastify/fast-uri/security/advisories/GHSA-fph4-wmhf-6fwf",
+      "before": [
+        {
+          "path": "node_modules/fast-uri",
+          "version": "3.1.4",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-jqff-g426-hqxp",
+      "summary": "fast-uri vulnerable to host confusion via percent-encoded scheme normalization",
+      "source": "https://github.com/fastify/fast-uri/security/advisories/GHSA-jqff-g426-hqxp",
+      "before": [
+        {
+          "path": "node_modules/fast-uri",
+          "version": "3.1.4",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-r292-9mhp-454m",
+      "summary": "node-tar: Uncontrolled recursion in mapHas/filesFilter allows uncatchable stack-overflow DoS via crafted long-path tar with member selection",
+      "source": "https://github.com/isaacs/node-tar/security/advisories/GHSA-r292-9mhp-454m",
+      "before": [
+        {
+          "path": "node_modules/tar",
+          "version": "7.5.19",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-8xcm-r25x-g524",
+      "summary": "undici vulnerable to downstream response desynchronization via retry interceptor",
+      "source": "https://github.com/nodejs/undici/security/advisories/GHSA-8xcm-r25x-g524",
+      "before": [
+        {
+          "path": "node_modules/node-gyp/node_modules/undici",
+          "version": "6.27.0",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-m8rv-5g2x-5cg5",
+      "summary": "undici vulnerable to CRLF Injection via blob-like body 'type' property",
+      "source": "https://github.com/nodejs/undici/security/advisories/GHSA-m8rv-5g2x-5cg5",
+      "before": [
+        {
+          "path": "node_modules/node-gyp/node_modules/undici",
+          "version": "6.27.0",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    },
+    {
+      "id": "GHSA-v3r7-h72x-cjcm",
+      "summary": "undici vulnerable to cookie attribute injection via unsanitized domain and unparsed setCookie fields",
+      "source": "https://github.com/nodejs/undici/security/advisories/GHSA-v3r7-h72x-cjcm",
+      "before": [
+        {
+          "path": "node_modules/node-gyp/node_modules/undici",
+          "version": "6.27.0",
+          "dev": true
+        }
+      ],
+      "after": [],
+      "site": []
+    }
+  ]
+}

--- a/docs/security-evidence/npm-audit-after-2026-09-04.json
+++ b/docs/security-evidence/npm-audit-after-2026-09-04.json
@@ -1,0 +1,22 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {},
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    },
+    "dependencies": {
+      "prod": 42,
+      "dev": 386,
+      "optional": 52,
+      "peer": 17,
+      "peerOptional": 0,
+      "total": 428
+    }
+  }
+}

--- a/docs/security-evidence/npm-audit-before-2026-09-04.json
+++ b/docs/security-evidence/npm-audit-before-2026-09-04.json
@@ -1,0 +1,357 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {
+    "@xmldom/xmldom": {
+      "name": "@xmldom/xmldom",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1158518,
+          "name": "@xmldom/xmldom",
+          "dependency": "@xmldom/xmldom",
+          "title": "xmldom: XML fragment injection via invalid EntityReference.nodeName during requireWellFormed serialization",
+          "url": "https://github.com/advisories/GHSA-6gmq-8vp8-gcm6",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-116"
+          ],
+          "cvss": {
+            "score": 0,
+            "vectorString": null
+          },
+          "range": ">=0.7.0 <=0.8.14"
+        }
+      ],
+      "effects": [],
+      "range": "<=0.8.14",
+      "nodes": [
+        "node_modules/@xmldom/xmldom"
+      ],
+      "fixAvailable": true
+    },
+    "brace-expansion": {
+      "name": "brace-expansion",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1130588,
+          "name": "brace-expansion",
+          "dependency": "brace-expansion",
+          "title": "brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash",
+          "url": "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
+          "severity": "high",
+          "cwe": [
+            "CWE-400",
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": "<1.1.17"
+        },
+        {
+          "source": 1130589,
+          "name": "brace-expansion",
+          "dependency": "brace-expansion",
+          "title": "brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash",
+          "url": "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
+          "severity": "high",
+          "cwe": [
+            "CWE-400",
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=2.0.0 <2.1.3"
+        },
+        {
+          "source": 1130591,
+          "name": "brace-expansion",
+          "dependency": "brace-expansion",
+          "title": "brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash",
+          "url": "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
+          "severity": "high",
+          "cwe": [
+            "CWE-400",
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=4.0.0 <5.0.8"
+        },
+        {
+          "source": 1130734,
+          "name": "brace-expansion",
+          "dependency": "brace-expansion",
+          "title": "brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation",
+          "url": "https://github.com/advisories/GHSA-rgw5-rvv9-x895",
+          "severity": "high",
+          "cwe": [
+            "CWE-400",
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=4.0.0 <5.0.9"
+        },
+        {
+          "source": 1130736,
+          "name": "brace-expansion",
+          "dependency": "brace-expansion",
+          "title": "brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation",
+          "url": "https://github.com/advisories/GHSA-rgw5-rvv9-x895",
+          "severity": "high",
+          "cwe": [
+            "CWE-400",
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=2.0.0 <2.1.4"
+        },
+        {
+          "source": 1130737,
+          "name": "brace-expansion",
+          "dependency": "brace-expansion",
+          "title": "brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation",
+          "url": "https://github.com/advisories/GHSA-rgw5-rvv9-x895",
+          "severity": "high",
+          "cwe": [
+            "CWE-400",
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": "<1.1.18"
+        }
+      ],
+      "effects": [],
+      "range": "<=1.1.17 || 2.0.0 - 2.1.3 || 4.0.0 - 5.0.8",
+      "nodes": [
+        "node_modules/@electron/universal/node_modules/brace-expansion",
+        "node_modules/brace-expansion",
+        "node_modules/dir-compare/node_modules/brace-expansion",
+        "node_modules/filelist/node_modules/brace-expansion",
+        "node_modules/glob/node_modules/brace-expansion"
+      ],
+      "fixAvailable": true
+    },
+    "fast-uri": {
+      "name": "fast-uri",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1130720,
+          "name": "fast-uri",
+          "dependency": "fast-uri",
+          "title": "fast-uri vulnerable to host confusion via backslash authority introducer",
+          "url": "https://github.com/advisories/GHSA-7p8r-x3mc-p8w7",
+          "severity": "high",
+          "cwe": [
+            "CWE-436"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+          },
+          "range": ">=3.0.0 <3.1.5"
+        },
+        {
+          "source": 1158521,
+          "name": "fast-uri",
+          "dependency": "fast-uri",
+          "title": "fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references",
+          "url": "https://github.com/advisories/GHSA-5jgf-p345-68v8",
+          "severity": "high",
+          "cwe": [
+            "CWE-436"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+          },
+          "range": ">=3.1.3 <3.1.6"
+        },
+        {
+          "source": 1158524,
+          "name": "fast-uri",
+          "dependency": "fast-uri",
+          "title": "fast-uri vulnerable to server-side request forgery via malformed IPv6 normalization",
+          "url": "https://github.com/advisories/GHSA-f65p-4m7j-42xc",
+          "severity": "high",
+          "cwe": [
+            "CWE-20",
+            "CWE-918"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+          },
+          "range": ">=3.0.0 <3.1.6"
+        },
+        {
+          "source": 1158527,
+          "name": "fast-uri",
+          "dependency": "fast-uri",
+          "title": "fast-uri vulnerable to server-side request forgery via repeated hostname percent-decoding",
+          "url": "https://github.com/advisories/GHSA-fph4-wmhf-6fwf",
+          "severity": "high",
+          "cwe": [
+            "CWE-174",
+            "CWE-918"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+          },
+          "range": ">=3.1.2 <3.1.6"
+        },
+        {
+          "source": 1158530,
+          "name": "fast-uri",
+          "dependency": "fast-uri",
+          "title": "fast-uri vulnerable to host confusion via percent-encoded scheme normalization",
+          "url": "https://github.com/advisories/GHSA-jqff-g426-hqxp",
+          "severity": "high",
+          "cwe": [
+            "CWE-177"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+          },
+          "range": ">=3.0.0 <3.1.6"
+        }
+      ],
+      "effects": [],
+      "range": "3.0.0 - 3.1.5",
+      "nodes": [
+        "node_modules/fast-uri"
+      ],
+      "fixAvailable": true
+    },
+    "tar": {
+      "name": "tar",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1145647,
+          "name": "tar",
+          "dependency": "tar",
+          "title": "node-tar: Uncontrolled recursion in mapHas/filesFilter allows uncatchable stack-overflow DoS via crafted long-path tar with member selection",
+          "url": "https://github.com/advisories/GHSA-r292-9mhp-454m",
+          "severity": "high",
+          "cwe": [
+            "CWE-400",
+            "CWE-674"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": "<=7.5.20"
+        }
+      ],
+      "effects": [],
+      "range": "<=7.5.20",
+      "nodes": [
+        "node_modules/tar"
+      ],
+      "fixAvailable": true
+    },
+    "undici": {
+      "name": "undici",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1130716,
+          "name": "undici",
+          "dependency": "undici",
+          "title": "undici vulnerable to downstream response desynchronization via retry interceptor",
+          "url": "https://github.com/advisories/GHSA-8xcm-r25x-g524",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-444"
+          ],
+          "cvss": {
+            "score": 4.8,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+          },
+          "range": "<6.28.0"
+        },
+        {
+          "source": 1130727,
+          "name": "undici",
+          "dependency": "undici",
+          "title": "undici vulnerable to CRLF Injection via blob-like body 'type' property",
+          "url": "https://github.com/advisories/GHSA-m8rv-5g2x-5cg5",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-93"
+          ],
+          "cvss": {
+            "score": 4.2,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N"
+          },
+          "range": "<6.28.0"
+        },
+        {
+          "source": 1130732,
+          "name": "undici",
+          "dependency": "undici",
+          "title": "undici vulnerable to cookie attribute injection via unsanitized domain and unparsed setCookie fields",
+          "url": "https://github.com/advisories/GHSA-v3r7-h72x-cjcm",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-74"
+          ],
+          "cvss": {
+            "score": 4.8,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+          },
+          "range": "<6.28.0"
+        }
+      ],
+      "effects": [],
+      "range": "<=6.27.0",
+      "nodes": [
+        "node_modules/node-gyp/node_modules/undici"
+      ],
+      "fixAvailable": true
+    }
+  },
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 2,
+      "high": 3,
+      "critical": 0,
+      "total": 5
+    },
+    "dependencies": {
+      "prod": 42,
+      "dev": 386,
+      "optional": 52,
+      "peer": 17,
+      "peerOptional": 0,
+      "total": 428
+    }
+  }
+}

--- a/docs/security-evidence/npm-audit-production-before-2026-09-04.json
+++ b/docs/security-evidence/npm-audit-production-before-2026-09-04.json
@@ -1,0 +1,22 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {},
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    },
+    "dependencies": {
+      "prod": 42,
+      "dev": 386,
+      "optional": 52,
+      "peer": 17,
+      "peerOptional": 0,
+      "total": 428
+    }
+  }
+}

--- a/docs/security-evidence/npm-audit-site-2026-09-04.json
+++ b/docs/security-evidence/npm-audit-site-2026-09-04.json
@@ -1,0 +1,22 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {},
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    },
+    "dependencies": {
+      "prod": 191,
+      "dev": 26,
+      "optional": 105,
+      "peer": 2,
+      "peerOptional": 0,
+      "total": 295
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -632,9 +632,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1610,9 +1610,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2016,16 +2016,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-from": {
@@ -2486,9 +2486,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2950,9 +2950,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -3018,9 +3018,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3211,9 +3211,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4039,9 +4039,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5085,9 +5085,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/test/unit/compliance-model.test.js
+++ b/test/unit/compliance-model.test.js
@@ -117,7 +117,9 @@ test('both lock SBOMs include every unique locked name/version with audited lice
   const generated = createComplianceArtifacts();
   const root = JSON.parse(generated.files['compliance/root-lock-sbom.cdx.json']);
   const site = JSON.parse(generated.files['compliance/site-lock-sbom.cdx.json']);
-  assert.equal(root.components.length, 400);
+  // Updating the remaining brace-expansion 1.1.16 copies to 1.1.18 merges
+  // their name/version entry with the already-patched copies in the SBOM.
+  assert.equal(root.components.length, 399);
   assert.equal(site.components.length, 295);
   const onePassword = root.components.find((component) => component.name === '@1password/sdk');
   assert.deepEqual(onePassword.licenses, [{ license: { id: 'MIT' } }]);


### PR DESCRIPTION
The September 4 OpenSSF Scorecard scan reported 12 advisories across five dependency packages. All affected lockfile entries are development-only; the production and website versions are outside these advisory ranges.

Update nine transitive build-dependency entries within their existing ranges, regenerate the root lock SBOM, and adjust its expected component count after brace-expansion versions consolidate. Production dependencies, the runtime SBOM, package manifests, and application version stay unchanged. The included triage maps every advisory to its exact before/after paths and preserves audit evidence.

Validation: clean dependency installation, full root audit (zero advisories), production baseline and website audits (zero), substrate/compliance checks, acceptance dry run (130 scenarios / 802 steps), and all 1,428 unit tests passing. GitHub CI passed on 3e7572f: [Parity guards including OAuth compatibility](https://github.com/bnfy/blanc/actions/runs/33921966022) and [CodeQL](https://github.com/bnfy/blanc/actions/runs/33921965984). See the dated triage record for complete results.

Prepared as a draft under the launch freeze. This does not publish a release or claim an improved public-main Scorecard score before merge. Native packaging/signing gates have not been rerun for this development-tool patch.
