### PR TITLE
Fix stale download attribution after consent withdrawal

### DIFF
--- a/marketing/social/ad-efficiency-review-2026-09-04.md
+++ b/marketing/social/ad-efficiency-review-2026-09-04.md
@@ -1,0 +1,75 @@
+# Blanc ad efficiency review — September 4, 2026
+
+Observed in signed-in Brave approximately 16:15–16:20 EDT. This follows the verified campaign negative-keyword change in `monitoring-check-2026-09-04-1608.md`. No additional ad settings, budgets, site code or public communications changed during this pass.
+
+## Google Ads: measurement exists; attribution remains limited
+
+Campaign: **Blanc Browser | US Search | Downloads**, ID 24027915268, Bananify Creative. Current settings: Enabled, Google Search Network, Maximize clicks, $10/day, account-default Outbound clicks goal. Maximum CPC bid limit is unchecked. AI Max is off. The bid editor was inspected and canceled without saving. The existing `apk` and `android` negatives remain present.
+
+The primary GA4-imported action **Blanc Browser (web) download_click**, conversion type ID 7696757731, imports event `download_click` from the Blanc Browser property. It counts every conversion, has a 90-day click window and data-driven Google-paid-channel attribution. Its status is Awaiting conversions, with last recorded conversion August 19, 2026 at 8:00 AM. Diagnostics explicitly says Consent mode is implemented and modeling is active. An additional generic Outbound Click website action is also primary/account-default; it must not be assumed identical to Blanc downloads or edited across brands without checking its scope.
+
+For August 28–September 3, Google Ads reports 89 clicks, $76.92 and zero conversions. This is neither proof of no real downloads nor a diagnosis of broken tracking. Do not adopt the interface recommendation to maximize conversions merely because the action exists, or increase spend because the campaign is limited by budget. A CPC cap remains a possible future experiment; no exact cap is justified by this review alone.
+
+## Analytics: two measured download clicks, both referrals
+
+Authenticated property: Bananify Creative → Blanc Browser, property 544287080. Traffic acquisition dates explicitly set to August 28–September 3, 2026, with Key events filtered to `download_click` and dimension Session source / medium.
+
+| Source / medium | Sessions | Engaged sessions | Download-click key events |
+| --- | ---: | ---: | ---: |
+| google / cpc | 6 | 5 | 0 |
+| alternativeto.net / referral | 3 | 2 | 2 |
+| (direct) / (none) | 3 | 2 | 0 |
+| google / organic | 2 | 0 | 0 |
+| (not set) | 279 | 0 | 0 |
+
+The six measured paid sessions versus 89 ad clicks warrants investigating measurement coverage and attribution, not treating the difference as confirmed waste. Clicks and sessions differ; consent, blocking, repeat clicks and collection coverage can affect the comparison. These mechanisms were not quantified here. Two recorded referral download events establish that the event has collected some recent activity; they do not verify every current browser path or a completed installation.
+
+The source code sends website analytics and the optional desktop usage mirror to the same measurement ID, `G-MN8BLY6GE9` (`site/src/scripts/site.js` and `cloudflare/ping-worker/src/index.js`). Consequently, do not report the property-wide 293 sessions or the 279 unassigned sessions as website visitors or paid-traffic failures. Do not attribute every unassigned event to app telemetry without an event-level check. The site code defines a download click handler, but a local code inspection is not proof of deployed event delivery. Existing product decisions preserve consent and blocker behavior; do not proxy analytics or weaken privacy choices to increase reported conversions.
+
+[Open the acquisition report](https://analytics.google.com/analytics/web/?authuser=1#/a3960195p544287080/reports/explorer?params=_r.explorerCard..selmet%3D%5B%22sessions%22%5D%26_r.explorerCard..seldim%3D%5B%22sessionSourceMedium%22%5D%26_u.dateOption%3Dlast7Days%26_u.comparisonOption%3Ddisabled%26_r.explorerCard..columnFilters%3D%7B%22conversionEvent%22:%22download_click%22%7D&r=lifecycle-traffic-acquisition-v2). This link uses a relative last-seven-days range; set the exact historical dates to reproduce this review later.
+
+## Meta: delivery is Facebook-only in the observed breakdown
+
+Active September 2 shield-toggle promotion: $13/day, seven-day duration, goal Get more Page visits and followers, US, minimum age 18, Advantage+ audience on. Fresh performance panel: $32.37 over three displayed days, 218 Page visits, 604 views, 455 viewers, 143 engagements, 139 link clicks, five attributed Facebook follows and two reactions. Displayed payment total was $32.36; calculations here use the performance panel's $32.37. Cost per attributed follow is $6.47, not cost per net new follower or download.
+
+Placement audience counts: Facebook mobile app feed 417, Facebook Reels 35, Facebook mobile web feed 3, Uncategorized 1. They total 456 versus 455 overall viewers, so do not force them into an exact unique-person allocation. They show neither spend nor follows by placement, and provide no verified Instagram/Threads delivery. Thus they do not support cutting Reels, narrowing ages, or claiming cross-channel growth. No Meta settings changed.
+
+View ad opens a static preview with Like/Comment/Share labels, not an inspectable live comment thread. It does not complete ad-comment coverage. Existing Facebook inbox/comments evidence remains bounded as recorded in the preceding checkpoint.
+
+## Operating decisions and next measurements
+
+1. Retain the Google `apk`/`android` exclusions and $10/day budget; measure complete post-change days before another bid or budget change. Historical affected spend is $8.32, not achieved savings.
+2. Retain Meta's existing seven-day test and $13/day budget without extension or increase. Record incremental spend and attributed follows at scheduled checks; evaluate the full test and profile-to-follow performance before continuing paid delivery beyond the current duration.
+3. Preserve ChatGPT Ads' previously verified paused state. This pass did not requery or reactivate it. Verify deployment/event delivery and the reason for the pause before any restart proposal.
+4. Keep web acquisition distinct from desktop usage. Next tracking checks should examine paid landing-page attribution, GA4 Google Ads linking/auto-tagging and web-only event coverage, without manufacturing an ad click or real conversion for testing. A clearly labeled, consented QA event needs to be excluded from growth claims.
+5. AlternativeTo is the only measured download source in this seven-day report. Preserve that listing and include its referrals in the scorecard; three sessions is too small to forecast a scalable result.
+
+## 16:26 EDT follow-up — account linking and exact tag warning
+
+Live Google Ads account settings confirm Auto-tagging Yes, no account tracking-template options, and Auto-apply off. The linked-products table confirms Blanc Browser property 544287080 was linked July 24, 2026, with app/web metrics On and audience import Off. No link, audience, consent, or account setting changed. Google's [linking documentation](https://support.google.com/google-ads/answer/6333536?hl=en_US) describes using linked Analytics key events to create Google Ads conversions; the live Blanc action already uses that route.
+
+A separate account-level Google tag, **AW-997979750 (Bananify Creative)**, shows Urgent. Its coverage table lists 264 pages: 263 tagged and one not tagged. The untagged landing page is **blancbrowser.com/**; the displayed tagged pages are primarily Aston & West. This is a specific missing-direct-Ads-tag warning, not evidence that Blanc's GA4 tag is absent. The source search finds the GA4 measurement ID but no AW-997979750 configuration in the site. Do not treat the account warning as proof of the cause of zero imported conversions. Do not install an additional ad tag, change cross-domain settings, enable audience sharing, or duplicate the download conversion simply to clear it.
+
+Concrete next tracking decision: verify consented website event collection and the existing GA4 import end to end, and establish whether direct Google Ads measurement is actually needed. Any direct-tag implementation must preserve consent choices, prevent duplicate conversion counting, distinguish download clicks from installs, and be reviewed as a site change. Current evidence supports retaining the existing imported action while investigating coverage, not replacing it with a second primary download action.
+
+## 16:26 EDT follow-up — Instagram comment coverage
+
+Business Suite's Ad replies filter explicitly reports No conversations from ads. That filter covers ads encouraging direct messages; it is not evidence that every public ad comment is clear.
+
+All four visible Instagram comment threads were opened. The August 24 friendly exchange already includes Blanc's reply and a final reaction. The August 2 post has an already-replied competitor exchange plus older opinions about competing browsers and creative. The August 4 memory question has an existing Blanc reply; do not reuse its historical benchmark percentages as current claims without the required release/evidence check. The July 12 reel contains an older hostile allegation and a comment with no readable body. No new question requiring a routine answer was found; no reply, deletion, hiding, or new outreach was performed. Opening threads marked their unread indicators as read.
+
+The older creative criticism reinforces the existing plan to use authentic release-backed demonstrations. It does not warrant reviving old hostile exchanges or reposting outdated benchmark claims. The live public comment thread for the active Facebook promotion remains distinct from the static ad preview and has not been exhaustively verified.
+
+## 17:24–17:28 EDT implementation follow-up
+
+Fresh Meta View results: $32.80, 225 Page visits, 623 views, 465 viewers, 146 link clicks and five attributed follows ($6.56 each). Increment from 16:20: $0.43 and zero additional reported follows; this short interval does not justify an efficiency conclusion. Expanded Details confirms September 9 end date and owning ad account 208039240841695, correcting the earlier navigation-link account inference. Preserve $13/day and the existing duration.
+
+The original shield-toggle post's live public thread explicitly says No comments yet; Content Library independently reports zero comments. This resolves the prior missing live-comment check for this promotion. Its separate post-level three follows and two Instagram views are not the promotion's attributed follow count or evidence of paid Instagram delivery.
+
+ChatGPT account readiness and paused campaign were freshly verified. Trailing seven days returned only the August 28 row (152 impressions, two clicks, $5.87); prior seven returned the August 27 row (12,875 impressions, 119 clicks, $360.48), each without more pages. Current evidence is too small for a new CPC/CTR recommendation. The reason for the pause remains unknown from the campaign and searched records; do not resume. No ad settings changed.
+
+The existing monitor now carries the Google September 12 comparison of September 5–11 versus August 28–September 3 and the Meta completion review. Local download-event/consent wiring was inspected; consented deployed event delivery and paid-attribution import remain an explicit pending gate. No duplicate primary event, direct Ads tag or synthetic customer conversion was introduced. See [implementation checkpoint](monitoring-check-2026-09-04-1724.md) for exact identities and limits.
+
+## 17:35 EDT — deployed event verified; remaining attribution limits narrowed
+
+[Live Tag Assistant validation](measurement-validation-2026-09-04.md) now confirms the deployed GA4 tag, consent behavior and one Mac `download_click` with expected fields. The test hit was internal and the existing Active/Exclude filter excludes that traffic from processing, explaining why this QA session cannot verify customer reporting/import. The security policy blocked specific Google/DoubleClick and Tag Manager requests; inspect purpose and consent before any narrow policy change. The allowed primary GA4 destination emitted the expected click hit, so do not call all tracking broken. A Brave client block prevented verifying asset download completion. No paid click, new customer conversion, site deployment or ad change was made; all budgets/statuses remain as above.

--- a/marketing/social/daily-scorecard-2026-09-04.md
+++ b/marketing/social/daily-scorecard-2026-09-04.md
@@ -1,5 +1,23 @@
 # Blanc daily social scorecard — September 4, 2026
 
+## Current operating authority and late 5 p.m. checkpoint
+
+Updated September 4 after the owner's explicit implementation request in Default mode. **This section supersedes historical access and approval instructions below.** Brave is available; X Chat works and is empty. Routine useful engagement replies are authorized without another approval. New posts, creator outreach, profile changes and ad changes remain separate review items. Do not create an X passcode or repeat the old access blocker.
+
+Approximately **17:24 EDT**, live profile navigation/reloads displayed X **11**, Threads **21**, Instagram **103**, Facebook **14**, TikTok **25**, and Substack **2 external subscribers** (three including Author). Substack's dashboard reports a 27-minute data delay. Totals match earlier September 4 observations. This late snapshot is not a reconstructed 17:00 or midnight baseline.
+
+Daily +10 status for each channel: **not measurable for a comparable 24-hour interval; not verified achieved**. Consecutive measured misses: **not established**. Do not increment that count from repeated same-day observations. Use met/missed/not measurable with the actual observation times on future scorecards; after three consecutive measured misses prepare one focused experiment for the affected channel. Missing checks do not count as a pass or failure.
+
+Fresh Meta results: **$32.80, five attributed follows, $6.56 per attributed follow**; promotion remains $13/day and ends **September 9**. Its live public post says **No comments yet**. ChatGPT campaign remains paused. No new useful question was found in the inspected current inbox/activity surfaces; no reply was sent.
+
+Next actions: continue the existing 9/13/17 Eastern monitor; review Meta when completion is observed; compare September 5–11 Google results with August 28–September 3 on September 12; finish consented web-only measurement/import validation without synthetic customer conversions. Full coverage, metric distinctions and exact promotion identity: [implementation checkpoint](monitoring-check-2026-09-04-1724.md).
+
+Latest measurement follow-up, approximately 17:30–17:35: deployed GA4 and a single Mac `download_click` verified in internal QA; its traffic is excluded by the existing Analytics filter. Tag Assistant found specific blocked measurement requests, and the attempted asset download was blocked in this Brave test environment. These are diagnostics, not new followers, customer downloads or savings. [Validation evidence](measurement-validation-2026-09-04.md).
+
+## Historical observations and prior instructions
+
+The material below preserves what was known at its stated time. The current authority, access status and action queue above govern subsequent runs.
+
 Prepared at 12:32 EDT; live Brave checks resumed after the owner confirmed
 unlock, approximately 12:34–12:43 EDT. The standing target remains +10
 followers/subscribers per priority platform per day. Changes below are since

--- a/marketing/social/experiment-pipeline.md
+++ b/marketing/social/experiment-pipeline.md
@@ -2,18 +2,22 @@
 
 Last release check: `v1.13.0`, September 3, 2026.
 
-> **Superseded for daily operation on September 2, 2026.** Use
-> [`follower-growth-operating-plan-2026-09-02.md`](follower-growth-operating-plan-2026-09-02.md)
-> for priorities and measurement. The source paths below were rechecked against
+> **Superseded for daily operation on September 4, 2026.** Use
+> [`reply-monitoring-growth-plan-2026-09-04.md`](reply-monitoring-growth-plan-2026-09-04.md)
+> for current targets, authorization, schedule and measurement, and the
+> reconciled September 2 operating plan for the ordered content queue.
+> The source paths below were rechecked against
 > public v1.13.0 on September 3, 2026. Each material claim still requires a
 > fresh reading of the tagged evidence and release record before copy, an asset,
 > or a demo is approved or published.
 
 This pipeline exists to prevent Blanc's small content library from collapsing
 into repeated tab-count posts. It is not a publication schedule and grants no
-approval to post. Every public action still requires Anthony's explicit
-approval in the active Codex thread and a final freshness, duplicate, claim,
-brand, crop, and destination check.
+approval to publish these experiments. New posts, creator outreach, profile
+changes and ads remain separate review items. Useful routine inbound replies
+are already authorized by the September 4 plan; read the conversation and log,
+check claims, and verify submission. Publication of an experiment requires a
+final freshness, duplicate, claim, brand, crop and destination check.
 
 ## Operating mix
 

--- a/marketing/social/follower-growth-operating-plan-2026-09-02.md
+++ b/marketing/social/follower-growth-operating-plan-2026-09-02.md
@@ -1,24 +1,31 @@
 # Blanc follower-growth operating plan — September 2, 2026
 
+Operational reconciliation, September 4: the owner's implemented
+[reply monitoring and growth plan](reply-monitoring-growth-plan-2026-09-04.md)
+controls current targets, authorization, schedule and advertising decisions.
+The September 2 performance examples below remain historical evidence.
+
 ## The reset
 
 Follower growth is the primary outcome. Replies, likes, follows, subscriptions,
 and comments are distribution tools, not the score.
 
-The standing ambition remains **+10 followers or subscribers per priority
-platform per day**. Because Blanc's accounts are still small and daily movement
-is noisy, operating decisions use a seven-day portfolio target as well:
+The operating target is **+10 net followers daily on each of X, Threads,
+Instagram, Facebook and TikTok, plus +10 external Substack subscribers**:
 
-- **minimum:** +35 qualified net followers or subscribers across the six
-  platforms in seven days;
-- **platform floors:** Instagram +8, TikTok +8, Threads +7, X +5, Facebook +5,
-  and Substack +2;
-- **breakout target:** +10 on any individual platform in one day;
+- **weekly target:** +70 on each channel separately;
+- **measurement:** comparable daily observations at 5 p.m. Eastern; record
+  met, missed or not measurable, with actual observation time and cache delay;
+- **revision trigger:** three consecutive measured misses on a channel prompt
+  one focused experiment for review; missing observations are not misses;
 - **quality check:** growth must come with relevant profile visits, meaningful
   engagement, site activity, or downloads—not indiscriminate follow-backs.
 
 These are planning thresholds, not predictions or public claims. Counts are
 recorded daily, but experiments are judged after 24 hours and seven days.
+The former +35 portfolio minimum and lower platform floors are superseded;
+growth on one channel does not offset another channel's shortfall. Exclude the
+Substack author account and keep attributed follows separate from net growth.
 
 ## Why the previous loop changes
 
@@ -65,9 +72,12 @@ slots are not quotas that need to be filled.
 6. **End-of-day decision:** scale, revise, or stop. Log the reason and carry
    only the highest-value unfinished item into the next day.
 
-Codex prepares one consolidated approval card for the day's public actions.
-Every post, reply, like, follow, subscription, outreach message, pin, featured
-placement, ad edit, or profile change still requires action-time approval.
+Useful routine inbound replies are authorized under the September 4 plan.
+Read the full conversation and shared log, verify product claims, and verify
+the submitted reply before recording success. Escalate sensitive issues.
+New posts, creator outreach, pins, profile changes and ad changes remain in
+the separate review queue. Scheduled ad reviews are recommendation-only.
+This authorization does not expand into unsolicited engagement actions.
 
 ### Work-in-progress limit
 
@@ -156,6 +166,15 @@ an explanation and introduction path, not an automated acceptance or payment
 system; terms still require a direct conversation and separate approval.
 
 ## Meta ad experiment
+
+Current instruction as of September 4: retain $13/day through the verified
+September 9 end date. Inspect the original live post's comments and measure
+incremental spend and ad-attributed follows separately from net Page growth.
+Prepare a recommendation when completion is observed; do not automatically
+extend. Use the [latest checkpoint](monitoring-check-2026-09-04-1724.md)
+for account identity and current metrics. The numbers and early review
+thresholds below describe the September 2 starting point, not a new trigger
+to repeat checks or change delivery.
 
 The September 2 Facebook Page Visits promotion is a separate paid-acquisition
 test. Its current baseline is:

--- a/marketing/social/growth-log.md
+++ b/marketing/social/growth-log.md
@@ -1836,3 +1836,104 @@ Meta promotion remains Active: $30.35 spent, 198 Page visits, 575 views,
 not be treated as website visits or installs. X Chat remains blocked on owner
 passcode setup. No public communication, spending or account-setting changes.
 Full evidence and next action: daily-scorecard-2026-09-04.md.
+
+### 12:50 ET public-surface refresh (September 4)
+
+No public action was taken. Logged-out public profiles were checked in the
+app's built-in browser after the Chrome extension disconnected. Audience: X 11,
+Threads 21, Instagram 103, Facebook 14, TikTok 25, Substack 2 public
+subscribers (3 on the dashboard including the author). All unchanged since the
+12:34–12:43 check. v1.13.0 package requests remain 28 with zero movement since
+September 3. Inbound, DMs, and the Meta ad were not inspectable in this pass.
+
+One same-day opportunity was staged in
+`approval-card-2026-09-04-pentagon-ad-tracking.md`: the Pentagon disabled ad
+tracking on troops' devices (TechCrunch, Hacker News front page). X and
+Threads posts about default-on, built-in blocking are drafted, claim-checked
+against v1.13.0, and awaiting approval. A persistent daily scheduled task,
+`blanc-daily-social-tending`, now carries this loop.
+
+### September 4, 16:14 EDT — Google mobile-query exclusions verified
+
+Using Brave, added campaign-level broad negatives `apk` and `android` to
+“Blanc Browser | US Search | Downloads” (24027915268). Both saved rows and
+40 total negatives were verified; previous count was 38. Daily budget remains
+$10. In the August 28–September 3 export, matching terms accounted for 10 clicks
+and $8.32 of $76.92 campaign spend, with zero reported conversions. This is
+historical affected spend, not achieved savings. No Meta or ChatGPT settings
+changed and no social reply was sent. Facebook's visible inbox and comments
+loaded without a new product question; exhaustive ad-comment coverage remains
+pending. Details: monitoring-check-2026-09-04-1608.md. Monitoring remains ACTIVE
+at 9 a.m., 1 p.m. and 5 p.m. Eastern.
+
+### September 4, 16:20 EDT — tracking and placement review
+
+Read-only Brave review verified Google's GA4 download action, last conversion
+August 19, consent-mode modeling active, and Maximize clicks with no CPC cap.
+Aligned GA4 August 28–September 3 shows six google/cpc sessions with zero
+download events and two download events from AlternativeTo referrals. Website
+and optional desktop telemetry share the property; total/unassigned sessions
+are not a clean website acquisition denominator. Meta reports $32.37 for five
+attributed follows ($6.47 each), with Facebook placement audience counts but
+no follows or spend by placement. No further settings changed; bid editor
+canceled. Details and next measurements: ad-efficiency-review-2026-09-04.md.
+
+### September 4, 16:26 EDT — linking and comment backlog checked
+
+Google auto-tagging is enabled and Blanc property 544287080 is linked with
+app/web metrics on. Separate account tag AW-997979750 flags blancbrowser.com/
+as its only untagged page; that warning is distinct from the existing GA4
+conversion route and was not treated as proof of a broken import. No tracking
+or ad changes made. Meta Ad replies reports no ad-message conversations.
+All four visible Instagram comment threads were inspected; existing answers,
+older opinions/reactions and an old hostile allegation do not call for a new
+routine reply. No communication or moderation action performed. Full evidence:
+ad-efficiency-review-2026-09-04.md.
+
+### September 4, approximately 17:24–17:28 EDT — approved workflow implemented
+
+Resumed in Default mode under the owner's implementation request. Created the explicit ongoing +10/day-per-channel growth goal and updated the existing native heartbeat (same task; 9/13/17 Eastern; ACTIVE), adding comparable daily statuses, the three-measured-miss experiment trigger, September 12 Google comparison and Meta completion review. No duplicate monitor created. The current section of the September 4 scorecard supersedes old X passcode and routine-reply approval blockers.
+
+Late audience observation about 17:24: X 11, Threads 21, Instagram 103, Facebook 14, TikTok 25; Substack 2 external subscribers, excluding Author (dashboard data delayed 27 minutes). Unchanged from earlier today; no comparable 24-hour achievement or miss streak established. Current activity/inboxes did not identify a useful new substantive reply; no public communication sent.
+
+Resolved active Facebook promotion comment coverage: its original public post explicitly says No comments yet. Expanded promotion Details verifies account 208039240841695, end September 9, $13/day. Performance: $32.80 and five ad-attributed follows, $6.56 each. ChatGPT remains paused and ready at account level; no justified new efficiency change. Google retains its earlier exclusions and $10/day. No ad changes or achieved savings in this pass. Deployed consented download-event/import validation remains pending. Details: monitoring-check-2026-09-04-1724.md.
+
+### September 4, approximately 17:35 EDT — live measurement QA completed
+
+Previous goal turn was progress: authoritative monitoring instructions and scorecards changed and exact Meta ownership/end/comment coverage were verified. This continuation adds live measurement evidence rather than another unchanged audience poll.
+
+Brave Tag Assistant confirms deployed G-MN8BLY6GE9, consent opt-in and a single Mac download_click (source_page=download, cta_position=platform-card, platform=mac-arm64). The outgoing hit has tt=internal; GA4's existing Active/Exclude filter exactly matches traffic_type=internal. Landing session labeled blanc_qa / diagnostic / measurement_validation_20260904. This is QA, not new audience, customer acquisition or a paid conversion. One /dl/mac-arm64 request may appear in aggregate counters; the asset navigation was blocked by this Brave session with ERR_BLOCKED_BY_CLIENT, so no completed download or install is claimed.
+
+Tag Assistant reports explicit CSP blocks for Google/DoubleClick collect and Tag Manager diagnostic requests. The main Analytics collection origin is allowed; their effect on paid attribution is unquantified. No policy, tag, filter, ad or budget change was applied. Analytics opt-out was selected afterward and confirmed on reload; debugging ended and the tool reports no active domains. The next step is a bounded consent/CSP review and verification of the existing import from normal non-internal attributed traffic. Detailed evidence: measurement-validation-2026-09-04.md.
+
+### September 4, 17:39 EDT — older operating instructions reconciled
+
+Replaced the September 2 operating plan's lower portfolio thresholds with the
+approved +10 net per channel daily / +70 per channel weekly targets and the
+three-measured-miss trigger. Reconciled routine inbound reply authorization in
+that plan and the experiment pipeline. New posts, creator outreach, profile
+changes and ad changes remain separate review items. Marked the August 29
+profile proposal's empty-Facebook-Featured assumption as superseded by the
+observed existing post; no profile was changed. Clearly labeled the main
+monitoring plan's earlier setup failures as historical so they cannot restart
+completed setup or revive resolved access blockers.
+
+Re-read the existing heartbeat configuration: ACTIVE, same task and daily
+9/13/17 schedule. No duplicate automation, public action, additional audience
+poll, ad change or asset creation in this pass. The next scheduled check is
+September 5 at 9 a.m. Eastern; daily growth awaits comparable observations.
+The existing Pentagon news approval card remains unapproved and needs a fresh
+claim check before use. It was not treated as permission to publish.
+
+### September 4, 17:41 EDT — local consent-withdrawal regression fixed
+
+Continued the bounded measurement review using current code and Google first-party
+documentation in Brave. Found and reproduced a stale ChatGPT ad reference on
+download links after consent withdrawal. Prepared a small local site-script
+fix; four failing behavioral cases now pass, and 23 targeted checks plus the
+site/brand/SEO build pass. This is uncommitted and not deployed. No real ad
+conversion, site publication, campaign edit or public communication occurred.
+Google's unspecified ad-consent states and blocked advertising destinations
+remain a separate review item; no automatic consent grant or broad security
+policy expansion was made. Full inventory, evidence and boundaries are in
+measurement-validation-2026-09-04.md. ChatGPT remains paused.

--- a/marketing/social/measurement-plan.md
+++ b/marketing/social/measurement-plan.md
@@ -1,5 +1,9 @@
 # Blanc organic-social measurement plan
 
+## September 4 validation update
+
+Current operational scorecard: [September 4](daily-scorecard-2026-09-04.md). Live Brave Tag Assistant testing verified the deployed GA4 tag, consent opt-in/opt-out, and one Mac `download_click` with the expected page, CTA and platform fields. The QA hit was marked internal and the active GA4 Internal Traffic filter excludes it; no customer growth is claimed. A security-policy review is now warranted for specific blocked Google advertising/diagnostic requests. Full paid attribution and file completion were not proved. See [live validation and exact limits](measurement-validation-2026-09-04.md). Historical observations below retain their original dates.
+
 Last updated: August 29, 2026. Existing first-party measurement paths were last
 verified August 28; the evergreen profile URLs below were prepared August 29
 and remain unexecuted.

--- a/marketing/social/measurement-validation-2026-09-04.md
+++ b/marketing/social/measurement-validation-2026-09-04.md
@@ -1,0 +1,116 @@
+# Blanc live measurement validation — September 4, 2026
+
+Observed in Brave at approximately 17:30–17:35 EDT using Google Tag Assistant and the authenticated Blanc Browser GA4 property. This is labeled internal QA, not growth or paid acquisition. No paid ad was clicked and no ad, Analytics filter, tag configuration, security policy or site code was changed.
+
+## What is now verified
+
+- The deployed homepage and download page load GA4 destination `G-MN8BLY6GE9` via the on-page configuration. Tag Assistant also identifies Google tag `GT-W6X7BMF9`. A missing direct `AW-997979750` tag is therefore not evidence that GA4 is absent.
+- The fresh homepage presents the consent dialog with analytics storage denied. Choosing Allow in the QA session produces a Granted update. After testing, No thanks was selected; a fresh reload's Config event confirms analytics storage Denied with no grant update. The diagnostic session was finished and Tag Assistant explicitly reports no actively debugging domains / Not Connected.
+- One deliberate Mac Apple Silicon download-link click produced one `download_click` command and an outgoing hit to `https://analytics.google.com/g/collect`. Its fields are `source_page=download`, `cta_position=platform-card`, `platform=mac-arm64`, measurement id `G-MN8BLY6GE9`, debug flag enabled, and consent code `G1-1`. This proves deployed click-event emission for this tested path, not completed installation or paid attribution.
+- The outgoing hit is marked `tt=internal`. The authenticated GA4 Data filters screen confirms an **Active / Exclude** Internal Traffic filter with an exact `traffic_type=internal` match. The filter was inspected and closed without saving. This session is intended to be excluded from processing; missing QA events in Realtime/DebugView are not proof of tag failure.
+
+The test's landing URL used `utm_source=blanc_qa`, `utm_medium=diagnostic`, `utm_campaign=measurement_validation_20260904` plus Tag Assistant's debug signal. Exclude this QA session from growth claims even if it appears in any diagnostic report. Do not store client identifiers or unrelated visitor data in the ledger.
+
+## Concrete issues and limits
+
+Tag Assistant's Console records the deployed security policy blocking requests to:
+
+| Directive | Blocked endpoint |
+| --- | --- |
+| connect-src | `https://stats.g.doubleclick.net/g/collect` |
+| connect-src | `https://www.google.com/g/collect` |
+| img-src | `https://www.googletagmanager.com/td` |
+| img-src | `https://www.googletagmanager.com/a` |
+
+These observations match omissions in `site/public/_headers`. The primary observed GA4 hit destination, `analytics.google.com`, is allowed. Google's [official CSP guide](https://developers.google.com/tag-platform/security/guides/csp), read live in Brave (page updated July 30, 2026), distinguishes core Analytics origins from origins needed when Google Ads or advertising features are used. The blocked Google/DoubleClick requests warrant a linked-Ads measurement review; they do **not** establish that all GA4 collection is broken or explain the historical click/session difference by themselves. Do not blindly copy the full Google Ads allowlist or add an extra Ads tag to clear warnings.
+
+The on-page consent table exposes analytics storage but shows no explicit values for `ad_storage`, `ad_user_data` or `ad_personalization`. Record this as an implementation detail requiring review against the intended measurement behavior, not a proven consent violation or a proven attribution failure. Do not grant ad consent merely to improve reported conversions.
+
+The Mac asset navigation reached `release-assets.githubusercontent.com`, where this Brave diagnostic session displayed **ERR_BLOCKED_BY_CLIENT**. No file completion or installation was verified. This is a bounded failure in the testing environment; it does not prove that ordinary customers or all Brave users cannot download Blanc. The `/dl/mac-arm64` redirect may have incremented an aggregate request counter; reserve this one QA attempt from any interpretation of customer acquisition. No download retry or blocker bypass was performed.
+
+## Next action and budget decision
+
+Keep Google $10/day, Meta $13/day through its September 9 end, and ChatGPT paused. The deployed Mac download event now has direct evidence, but the existing Google Ads import still needs a real, consented, non-internal ad-attributed event and normal processing time before an end-to-end paid attribution claim is justified.
+
+Prepare a narrowly scoped consent/CSP review before any site change: map the configured GA4/Ads purposes to the observed blocked destinations; validate needed endpoints and consent defaults/updates in an isolated preview; preserve ordinary blocking/privacy choices; test denied, granted, persisted and withdrawn consent; prove one download click emits one event. No production allowlist expansion, new primary conversion or bidding change is recommended solely from this session. Confidence is high that these requests are blocked, but the size of their impact on paid reporting is unknown.
+
+On September 12's Google comparison, exclude internal/diagnostic traffic, keep downloads distinct from installations, and do not label historical affected spend as savings. Reassess further optimization using complete post-exclusion days and customer outcomes.
+
+## 17:41 EDT — consent review and local withdrawal fix
+
+Read the current site script, consent component, privacy disclosure, security
+headers and download Worker. Before this patch, the site script, consent
+component and headers had no differences from public tag v1.15.0. This links
+the source finding to the tagged implementation; it does not replace deployed
+verification after a future publication.
+
+### Google recommendation
+
+Google's [consent guide](https://developers.google.com/tag-platform/security/guides/consent)
+and [CSP guide](https://developers.google.com/tag-platform/security/guides/csp)
+were read in Brave September 4 (both dated July 30, 2026). The first calls for
+explicit defaults and updates for the consent types in use. The second
+identifies Google/DoubleClick endpoints as advertising-related for linked
+Analytics deployments; it also lists Tag Manager image requests for Analytics
+and diagnostics. Therefore the observed `/td` and `/a` blocks must not be
+classified as harmless debug-only requests without more evidence.
+
+For Google campaign 24027915268, retain $10/day, Maximize clicks, the existing
+GA4 import and the apk/android exclusions. Current site consent explicitly
+sets only analytics_storage; ad_storage, ad_user_data and ad_personalization
+are unspecified in this code. Current security policy allows the observed
+primary Analytics endpoint and blocks the other listed requests.
+
+Proposed next technical review: define explicit Google ad-purpose consent
+states consistent with the existing disclosure, with no automatic grant for
+personalized advertising, then validate the minimum required destinations in
+an isolated preview. An exact production allowlist change is not yet justified.
+This recommendation changes no campaign settings and has **$0 immediate
+budget effect**. Attribution coverage may improve after a validated change,
+but neither additional downloads/follows nor savings can be estimated from
+the current evidence. Preserve privacy choices even if they reduce measured
+coverage. No additional tags or Google consent settings were added here.
+
+### Reproduced ChatGPT attribution bug and prepared fix
+
+An offline execution of the existing page script reproduced this sequence:
+Allow → click a download link while the page stays open → No thanks. Storage
+was cleared, but the link retained its previously appended `oppref`. A later
+click could still deliver that reference to the existing Worker, whose current
+dispatch condition is a valid reference plus its configured server secret.
+No real reference, paid click or network request was used in reproduction.
+The number of affected visitors is unknown.
+
+Local patch in `site/src/scripts/site.js` removes the reference from existing
+download links immediately on withdrawal. Before decorating any subsequent
+download click, it removes stale attribution and adds it back only if current
+consent and session storage allow it. Other query parameters, fragments,
+external destinations and non-download links are preserved. This patch is
+**a review candidate on `codex/blanc-growth-monitoring-consent`, not deployed**;
+do not describe production as fixed. The owner subsequently authorized commit
+and push of the monitoring work and this fix, without a site deployment.
+
+Verification: six new behavioral checks run the actual complete site script
+offline. Four reproduced failures before the fix and all six pass afterward.
+They cover fresh consent, withdrawal from multiple used links, changed saved
+choice, unavailable storage reads, re-grant after withdrawal, and destination
+boundaries. Together with existing public-truth and Worker conversion tests,
+23 checks pass. Site build, brand checks, SEO checks for 19 pages and
+`git diff --check` pass. No live ad conversions were emitted by these checks.
+Live browser verification of the patched build and deployment remain pending.
+
+Integration inventory for this incremental review: Astro browser script plus
+existing Cloudflare CAPI-only download handler; existing custom `blanc_download`
+event and public pixel identifier in `cloudflare/ping-worker/src/dl.js` remain
+unchanged. Authentication stays in the existing `OPENAI_CONVERSIONS_API_KEY`
+Worker secret; no secret was read or changed. There is no browser Pixel, so
+no new page-view, user-matching or browser/server deduplication path is added.
+The existing server event uses a per-request UUID, fixed sanitized Blanc
+download URL, opaque consented reference and opt_out=true, without visitor
+identity fields. No commerce, signup, lead, trial or subscription event is
+added: this patch repairs withdrawal for the already defined download-click
+boundary. Desktop telemetry, signup flows and campaign status are untouched.
+
+Before deployment, review the patch against Blanc's privacy, security, consent
+and data-handling requirements and the current launch freeze. Publishing is a
+separate action; this local fix is not authorization to resume ChatGPT Ads.

--- a/marketing/social/monitoring-check-2026-09-04-1608.md
+++ b/marketing/social/monitoring-check-2026-09-04-1608.md
@@ -1,0 +1,69 @@
+# Blanc monitoring check — September 4, 2026
+
+Observed approximately 16:05–16:08 EDT using Brave. These are displayed totals observed during this pass, not a reconstructed midnight baseline or a full 24-hour growth comparison.
+
+| Channel | Observed audience | Change from earlier September 4 observation |
+| --- | ---: | ---: |
+| X | 11 followers | 0 |
+| Instagram | 103 followers | 0 |
+| Threads | 21 followers | 0 |
+| Facebook | 14 followers | 0 |
+| TikTok | 25 followers | 0 |
+| Substack | 2 external subscribers | 0 |
+
+Substack displayed three total subscribers including one Author; its dashboard said updated 24 minutes ago. Audience displays can lag. No channel has demonstrated the +10 daily target in this observation interval.
+
+## Reply coverage and decisions
+
+- X: Chat now opens normally and explicitly displays Empty inbox. The earlier passcode blocker is no longer present. Mentions loaded; newest visible mention is August 30. Older product-related questions show existing replies and require full-thread review before any further response. No new question identified in the latest visible mentions.
+- Instagram: newest notification is a like on an existing comment, not a new question. Primary inbox shows the existing outgoing creator invitation and older conversations. One request dated August 22 contains an unsupported attachment requiring the Instagram mobile app; it was not accepted, deleted or answered. General and hidden request folders were not audited.
+- Threads: latest activity is a reaction to an existing reply; older conversational exchanges include already-replied markers. Inbox shows the outgoing creator conversation from two days ago; Requests explicitly says No message requests yet. Hidden requests were not audited.
+- TikTok: newest activity is comment likes; the earlier friendly creator reply remains visible. Inbox's latest relevant creator preview remains the outgoing invitation; other unread previews are older reactions or unsolicited business messages. The single request does not expose a Blanc product question in its visible preview. No acceptance, follow-up or reply was sent. The profile video grid returned an error even though audience and activity loaded.
+- Substack: newest activity is the existing subscription and older replies. Direct-message preview still ends with Blanc's outgoing creator invitation. A conversational reply composer was inspected, then canceled empty because it did not expose the complete prior thread needed to rule out duplication. No post or reply was submitted.
+- Facebook: latest notifications show follows and a reel reaction, not a new comment question. Messenger reports five unread items, but that badge is not evidence of five genuine leads. The Page's Business Suite inbox opened but its message content was not successfully inspected.
+
+No public communication or advertising mutation was performed. This is a bounded newest-activity check, not a claim that all historical comments and inbox folders are clear.
+
+## Advertising evidence and concrete next actions
+
+### Google Ads
+
+Business identity and Bananify Creative overview are accessible in Brave. The Blanc-specific campaign is **Blanc Browser | US Search | Downloads**. For August 28–September 3, its overview card shows $76.92 spend, 89 clicks and 7.67% CTR. Calculated average CPC is approximately $0.86. The campaign diagnostic says Eligible (Limited): limited by budget. Do not attribute account-wide totals from other brands to Blanc.
+
+Next action: inspect this campaign's download conversions and search terms before any budget decision. Preserve the current acquisition campaign and budget while preparing a relevant landing-page follow invitation; measure actual social-link actions separately from downloads. The budget diagnostic does not establish profitable growth or justify increasing spend. Specific campaign detail and conversion reporting remain unverified because Brave stopped exposing usable page content after navigation.
+
+### Meta
+
+The open promotion still displays Active, $13/day, seven-day duration, $31.85 lifetime spend, 216 Page visits, 601 views, reach 453 and five attributed follows. These displayed results match the earlier observation, not a new independently reloaded report. Cost per attributed follow is $6.37. Its link-click counter is not website visits.
+
+Next action: prepare one real-current-release demonstration with an explicit reason to follow, compare it with the existing shield-toggle promotion, and review the exact creative before changing it. Keep the $13/day budget unchanged. Check results by placement and actual follows before extending this Facebook result to Instagram or Threads. Finish the ad-comments and Messenger inspection.
+
+### ChatGPT Ads
+
+The review skill was applied to the resolved Blanc campaign. Account setup reports active, billing complete, review approved and recommended next step done. No onboarding blocker was established. The campaign was last verified paused in this task.
+
+Requested trailing seven completed days and preceding seven completed days with no time granularity. The connector returned one dated performance row in each response, with no further pages: current response 152 impressions, two clicks and $5.87 spend; preceding response 12,875 impressions, 119 clicks and $360.48 spend. Treat these as the returned rows, not proof of continuous delivery throughout either window. Current evidence is below the review skill's 1,000-impression/30-click threshold, and the paused campaign makes a like-for-like efficiency comparison inappropriate.
+
+Next action: determine why it was paused, inspect associated conversion evidence and current-release ad claims, and confirm dates before any resumption proposal. No budget, bid, targeting or creative change is supported by this small current sample. Do not infer zero conversions, broken tracking or follower attribution from these click reports.
+
+## Remaining access and next check
+
+### Budget-efficiency follow-up
+
+The owner requested savings where appropriate. The active monitoring prompt was updated and confirmed ACTIVE with this priority. ChatGPT's connected Blanc website source and non-archived “Blanc download” custom-event setting were verified; the setting is associated with the launch campaign and uses a 30-day click attribution window. The campaign conversion report for the trailing 14 completed days returns zero attributed conversions. Combined returned spend rows total $366.35 with 121 clicks, but the comparison windows are sparse and conversion lag remains possible. This warrants verifying event firing and the event's real meaning before considering reactivation; it does not prove the tracker is broken or that no real downloads occurred. The already-paused campaign offers no additional ongoing savings from another pause. No settings or spend changed, and no achieved savings are claimed.
+
+Brave again returned only the Google Ads navigation fragment after opening the campaign, despite refreshing the app state and dismissing its navigation container. This prevented completion of Google campaign details and Facebook Messenger/ad comments. Preserve those as pending; do not infer clean inboxes. The native monitoring heartbeat remains scheduled for 9 a.m., 1 p.m. and 5 p.m.; its next check should resume these pending surfaces and take the comparable 5 p.m. audience snapshot. X no longer requires a setup prompt based on this live observation.
+
+## 16:14 EDT follow-up — Google optimization applied
+
+Brave access recovered. The exact Google campaign is “Blanc Browser | US Search | Downloads”, ID 24027915268, in Bananify Creative. The August 28–September 3 search-term report contains 311 search terms plus three total rows; campaign totals are 89 clicks, 1,161 impressions, $76.92 and 0.00 reported conversions. The visible search terms account for 73 clicks/$62.56, with Other terms contributing 16 clicks/$14.36. Export: `/Users/anthonyjloria/Downloads/blanc-search-terms-2026-09-04.csv`.
+
+Twenty-three terms contain standalone apk or android; they account for 10 clicks and $8.32 (10.82% of campaign spend), with zero reported conversions. Paid examples include brave browser android, brave download apk and gologin apk variants. Existing broad negative `browser apk` did not cover the latter.
+
+**Applied and verified:** added campaign-level broad negatives `apk` and `android`. The saved table displayed both at Campaign scope with Broad match and 40 total negatives, up from 38. This only changes Blanc's campaign. Daily budget stays $10. No bids, creative, other-brand campaigns, Meta settings or ChatGPT settings changed. These exclusions may redirect spending to relevant desktop searches; $8.32 is historical affected spend, not guaranteed or realized savings.
+
+Follow-up: inspect search terms after delivery resumes under these exclusions and compare complete date windows. Verify the download conversion action and event firing before considering budget reallocations; zero reported conversions alone does not establish broken tracking or no real downloads. Reverse an exclusion only if verified relevant demand warrants it. Scheduled ad runs remain recommendation-only.
+
+**Facebook coverage update:** Business Suite All messages loaded. The latest relevant creator conversation still ends with Blanc's outgoing invitation; older previews include attachments, unsolicited messages and suspicious account-warning messages. No new genuine product question was identified in the visible list. Facebook comments loaded one August 9 post with an older positive comment and an existing reaction; no fresh question was shown. No reply was sent. This supersedes the earlier blanket access failure, but is not an exhaustive audit of ad comments, historical folders or Instagram comments. Do not follow account-warning links from unsolicited inbox messages.
+
+The native heartbeat was rechecked in its saved configuration and remains ACTIVE at 9 a.m., 1 p.m. and 5 p.m. Eastern. The next comparable audience snapshot is the 5 p.m. check.

--- a/marketing/social/monitoring-check-2026-09-04-1724.md
+++ b/marketing/social/monitoring-check-2026-09-04-1724.md
@@ -1,0 +1,57 @@
+# Blanc monitoring implementation — September 4, 2026
+
+Live Brave inspection approximately 17:22–17:28 EDT. Audience totals were read approximately 17:24 EDT after profile navigation or reload. This is a late 5 p.m. observation, not a backdated 17:00 snapshot. The Substack dashboard itself said its data was updated 27 minutes earlier.
+
+## Audience and reply decisions
+
+| Channel | Displayed total | Change from earlier September 4 observation | Daily target status |
+| --- | ---: | ---: | --- |
+| X | 11 followers | 0 | Not measurable over a comparable 24-hour interval |
+| Threads | 21 followers | 0 | Not measurable over a comparable 24-hour interval |
+| Instagram | 103 followers | 0 | Not measurable over a comparable 24-hour interval |
+| Facebook | 14 followers | 0 | Not measurable over a comparable 24-hour interval |
+| TikTok | 25 followers | 0 | Not measurable over a comparable 24-hour interval |
+| Substack | 2 external subscribers | 0 | Not measurable over a comparable 24-hour interval |
+
+Substack displays three subscribers including one Author. No channel has verified +10 daily growth. No comparable daily miss streak can be established from these intraday checks; do not turn missing measurements into misses or successes. Use future actual 5 p.m. observations for comparison and label the interval when a check is late.
+
+- X: Chat opens and explicitly says Empty inbox. Mentions show the August 30 friendly acknowledgment and older questions already carrying a reply. No new question identified.
+- Threads: latest activity is an existing reply's like, with older conversations marked Replied. Inbox's Causal conversation still ends with an outgoing September 2 post; Requests explicitly says no message requests.
+- Instagram: latest notification is yesterday's comment like; older reel likes, follows and friendly replies follow. Business Suite's combined inbox has the existing outgoing creator invitation and older conversations. No fresh substantive question identified. Earlier unread indicators do not prove a new lead.
+- Facebook: Business Suite comments show the older August 9 acknowledgment. Opened the active September 2 shield-toggle post through Professional dashboard → Content Library → post insights → timestamp permalink. The live post explicitly says **No comments yet**, and post insights reports zero comments. This resolves the previous missing live-comment check for this specific promotion.
+- TikTok: activity shows a recent comment like and the already-known friendly Gina reply. Business Suite messages still show the September 2 outgoing invitation and older messages; one request remains, previously identified as spam. Its contents were not reopened in this pass. No new useful reply opportunity identified.
+- Substack: activity shows older likes and conversational acknowledgments. Ryan's direct conversation preview still ends with Blanc's September 2 invitation. No new substantive inquiry identified.
+
+No public reply, new post, outreach, reaction or moderation action was sent. Routine replies are authorized when useful; the absence of a useful new reply is not an approval blocker.
+
+Active promotion permalink: https://www.facebook.com/blancbrowser/posts/pfbid0YmSX5TGSUPo3EWPZworwjDAMoUjidLTcDzQBqqC9Digy21e8VpNqUYhJGosoHqvSl
+
+## Meta: exact promotion and end date verified
+
+Expanded View results → Details identifies Anthony J. Loria ad account **208039240841695**, boost **1319187391277564**, post **122113356579424497**, Blanc Page **1265405683322402**. The earlier Ads Manager navigation link used a different account id; that navigation link must not be used as proof of this promotion's owning account.
+
+Active; $13/day; starts September 2 and ends **September 9, 2026**. Exact ending hour/timezone was not displayed. No extension or restart is authorized by this workflow. Check status during September 9 and produce the final recommendation on the first run that observes completion, retrying delayed reporting on the next run.
+
+Fresh results: $32.80 performance spend, 225 Page visits, 623 views, 465 viewers, 150 engagements, 146 link clicks, five attributed Facebook follows and two reactions. Payment total is $32.79; use the performance figure consistently. Since 16:20's $32.37/five follows: +$0.43 spend, +7 Page visits, +0 reported attributed follows. This short interval is not evidence of deteriorating efficiency. Lifetime cost per attributed follow is $6.56. Preserve $13/day and the current end date.
+
+Post insights separately reports 473 viewers, three follows and zero comments; do not substitute that post metric for the promotion's five attributed follows or the Page's 14 total followers. Cross-post insights reports two Instagram views, which does not establish paid Instagram delivery.
+
+## ChatGPT Ads: fresh bounded review
+
+Blanc Browser account, USD; exact launch campaign from the operating plan. Overall health check / portfolio review, maximum three recommendations; trailing seven days versus the preceding seven days at this run. Account onboarding is complete, active, reviewed/approved and billing complete. Campaign remains paused, $500 lifetime limit, clicks objective, US/web targeting, with unchanged tagged landing-page attribution.
+
+Current requested window returned one row: 152 impressions, two clicks and $5.87 spend (August 28 row). Prior window returned one row: 12,875 impressions, 119 clicks and $360.48 spend (August 27 row). Both have no further pages. These sparse rows are not continuous seven-day delivery; the current window is below the review's evidence threshold for CPC/CTR recommendations. No changes recommended this cycle. No new conversion-total claim is made from these performance reads.
+
+The campaign record and searched marketing/release records do not explain why it was paused. Preserve the pause; resolve its reason before any separately reviewed restart. Do not infer a billing problem or tracking failure from the pause. No ChatGPT setting changed.
+
+## Google measurement and follow-up
+
+Preserve the previously verified $10/day and campaign negatives `apk` and `android`. No Google mutation was made in this pass. The review on September 12 will compare full September 5–11 against August 28–September 3 in the account's reporting timezone, recording conversion lag. The historical $8.32 remains affected spend, not measured savings.
+
+Local inspection confirms download links carry `download_click`, the site's click handler includes source page/CTA/platform, consent defaults to denied, and existing choices use measurement-consent-v2. The website and optional desktop mirror share the same GA4 measurement id. Earlier live evidence confirms auto-tagging, GA4 linking and the imported download action. This is configuration/collection evidence, not a fresh end-to-end paid-click attribution test. Preserve the existing import and privacy choices; no direct Ads tag was added.
+
+Pending measurement gate: inspect consented, web-only download events and their import after normal attributable traffic arrives. Check the live deployment and supported diagnostics without making synthetic ad clicks or counting QA downloads as customer growth. If a controlled QA event becomes necessary, label and exclude it from growth evidence and preserve consent. Do not claim this gate passed from local code or the separate missing-direct-tag warning.
+
+## Workflow installed
+
+The user approved implementation in Default mode. The explicit growth goal is active; it is not marked achieved. Updated the existing `blanc-replies-and-follower-growth` heartbeat, retaining 9 a.m., 1 p.m. and 5 p.m. Eastern, the same task and quiet notification behavior. Added the dated Google comparison, Meta end-of-test review, actual-time scorecards, duplicate-send checks and three-consecutive-measured-misses experiment trigger. No duplicate schedule was created.

--- a/marketing/social/profile-and-pin-conversion-plan-2026-08-29.md
+++ b/marketing/social/profile-and-pin-conversion-plan-2026-08-29.md
@@ -5,6 +5,14 @@ or account setting changed**.
 
 Public product baseline: `v1.9.1`.
 
+September 4 reconciliation: this is a historical proposal, not current live
+profile evidence. The latest Brave check shows an existing Facebook Featured
+post (Same 12 Tabs), so the older empty-Featured assumption below is superseded.
+Reinspect each field before proposing edits, refresh claims against the current
+public release, and wait for the selected final launch release before new
+release-bound media capture. Profile changes and new posts still require
+separate review under the approved September 4 monitoring plan.
+
 Read-only capture preflight:
 [`start-here-trailer-preflight.mjs`](start-here-trailer-preflight.mjs).
 

--- a/marketing/social/reply-monitoring-growth-plan-2026-09-04.md
+++ b/marketing/social/reply-monitoring-growth-plan-2026-09-04.md
@@ -1,0 +1,86 @@
+# Blanc reply monitoring and audience growth
+
+Implementation approved and resumed in Default mode September 4. Latest operational evidence: [17:24 checkpoint](monitoring-check-2026-09-04-1724.md). The explicit growth goal is active. Routine replies remain authorized, and historical X passcode/approval blockers in older scorecards are superseded. Current Meta promotion ownership is verified from expanded details as account 208039240841695, with end date September 9; do not substitute the different account in the dashboard's Ads Manager navigation link.
+
+Prepared September 4, 2026. Browser work uses Brave Browser. The native task heartbeat `blanc-replies-and-follower-growth` is ACTIVE; creation and its saved configuration were verified September 4 at approximately 16:04 EDT. Scheduled checks are 9 a.m., 1 p.m. and 5 p.m. daily in the local America/New_York environment. Successful account inspection remains dependent on Brave access.
+
+## Goal and scope
+
+Target at least 10 net new followers daily on each of X, Threads, Instagram, Facebook and TikTok, plus 10 net new external subscribers daily on Substack. Track Substack followers separately when available; exclude the author account from subscriber growth. Weekly target is 70 per channel, and the 30-day target is 300 per channel. These are targets, not guarantees. Do not buy followers or use unsolicited mass replies.
+
+Use Blanc's existing accounts (@blancbrowser and blancbrowser.substack.com), existing content ledger, growth log and daily scorecards. Discover any additional official channel from verified account or site evidence before adding it.
+
+## Daily operating loop
+
+- Scheduled checks: 9 a.m., 1 p.m. and 5 p.m. America/New_York, every day. Use the existing Brave sessions and verify the Blanc identity before each action.
+- Inspect organic comments, mentions, direct messages and replies on active ads. Prioritize unanswered product questions, download problems, buying interest and meaningful ongoing conversations. Respond within the next scheduled check when possible; this is not continuous coverage.
+- Read the full conversation and check for an existing response before drafting. Answer the actual question, use a natural follow-up only when useful, and avoid repetitive promotions or unnecessary links. Escalate sensitive complaints, security reports, payment disputes and promises about future features.
+- The user's request authorizes necessary routine replies for engagement. Keep unrelated creator outreach, new posts, profile edits and ad changes in a separate review queue. Preserve any applicable platform-specific restrictions. X Chat was accessible and empty on September 4; re-check live on each pass and do not create credentials.
+- Verify every factual product claim under docs/marketing-claims.md against the current public release and evidence. Existing drafts based on old releases must be refreshed before use. Do not change the official launch sequence.
+- Record observation time, source, item URL, decision, reply status and verified result. If submission is uncertain, re-read the conversation before retrying. Do not store unnecessary private message text in the repository.
+- Notify only for a meaningful issue, opportunity, completed action, growth shortfall or required owner action. Stay quiet when nothing actionable changes.
+
+## Measurement
+
+Take the comparable daily audience snapshot at 5 p.m. Eastern. Daily net growth equals today's total minus the previous day's total at that check; label missing or late observations accurately. Never reconstruct midnight counts. Also record profile visits, replies waiting, response time, attributed follows and spend where available. Separate cumulative metrics from interval changes, and platform-attributed follows from net audience change.
+
+Existing September 4 scorecard reports X 11, Threads 21, Instagram 103, Facebook 14, TikTok 25 and Substack 2 external subscribers. These are historical observations from earlier today, not fresh opening baselines for this plan.
+
+Flag any missed daily target in the scorecard. Three consecutive below-target days trigger one focused revision to content, the profile's reason to follow, or advertising. A weekly review compares each channel separately with +70; growth on one channel does not compensate for another.
+
+Use met/missed/not measurable and a per-channel consecutive measured-miss count. Missing or noncomparable observations must not create a miss or a success. Record late checks and platform caching explicitly; the September 4 late baseline is approximately 17:24 EDT. On the third consecutive measured miss, prepare one focused experiment for that channel and notify once; posting or profile changes stay in the review queue.
+
+## Content and conversion plan
+
+Prepare four to five useful native posts weekly per channel using real current-release demonstrations, practical browser tips, answers to recurring questions and build updates. Adapt existing assets rather than publishing identical copy everywhere. Use a clear reason to follow. Improve profile and pinned-content conversion using the existing profile-and-pin plan after refreshing its old release assumptions. Choose one measurable experiment each week; keep downloads and Patron outcomes visible alongside follower growth.
+
+## Existing advertising
+
+Budget efficiency is an explicit owner priority. The active recurring prompt now checks for verified wasted spend, irrelevant search terms, weak placements/creative and poor cost per actual follow or download. Prepare conservative reductions, exclusions or net-neutral reallocations with current/proposed settings, dollar savings estimates and growth tradeoffs. Account for conversion lag and insufficient data; protect proven acquisition. Do not increase spend simply to force the follower target. Scheduled ad reviews remain recommendation-only; savings are not achieved until a change is applied and verified.
+
+### Meta
+
+Live Brave inspection September 4: the current Facebook promotion is Active, with a $13 daily budget and seven-day duration. It reports $31.85 lifetime spend, 216 Facebook Page visits, 601 views, reach 453 and five attributed Facebook follows. That is $6.37 per attributed follow and an aggregate follows-to-visits ratio of 2.31%, not a user-level conversion funnel. Its 139 link clicks are not verified website visits or installs.
+
+Continue measuring the existing promotion. Prepare a follower-focused creative/profile experiment within its existing budget for review. Do not scale spend based on cheap Page visits alone. Evaluate Instagram and Threads placement/account capabilities directly before proposing delivery there; Facebook results do not prove growth on those channels. At the current observed cost, buying ten attributed follows would arithmetically cost about $63.70; this is not a forecast or approved budget.
+
+### ChatGPT Ads
+
+Connected Blanc Browser account contains one campaign, “Blanc Browser ChatGPT Launch Aug 2026,” currently paused, with a $500 lifetime limit. The latest returned performance rows and zero attributed download conversions are documented in the September 4 checkpoint; sparse data and conversion lag limit conclusions. It cannot currently contribute new paid delivery. Before proposing reactivation, review current-release claims, landing page, dates, tracking and the reason it was paused. Preserve its existing tagged attribution. Treat social growth as an assisted outcome unless actually attributable; clicks are not followers. No reactivation or spend change was made.
+
+For a scheduled ChatGPT review, use ads-manager-review with the resolved Blanc account and eligible campaign scope, trailing seven days versus preceding seven days, health_check/portfolio_review, and no more than three recommendations. The current paused-only inventory must be resolved before claiming an active campaign review covers delivery.
+
+### Google Ads
+
+Verified in Brave: “Blanc Browser | US Search | Downloads” (24027915268), $10/day. August 28–September 3: $76.92, 89 clicks, 1,161 impressions and zero reported conversions. On September 4, campaign-level broad negatives `apk` and `android` were saved and verified; the existing `browser apk` exclusion missed several irrelevant mobile-download searches. Matching historical terms used $8.32 across 10 clicks. This is affected historical spend, not achieved savings; budget remains $10/day. See the checkpoint for evidence and follow-up. Review conversion setup and subsequent search terms before broader changes. No new YouTube channel or campaign is assumed.
+
+## Historical setup record — superseded by the dated follow-ups below
+
+These paragraphs preserve the sequence of earlier checks. They are not current
+blockers: the native schedule is verified ACTIVE, X Chat works, the active Meta
+post's comments have been inspected, and deployed download-event emission has
+been verified. End-to-end paid import validation remains incomplete; see the
+17:35 measurement record. Do not recreate setup from the earlier failures.
+
+Latest live checkpoint: [September 4, approximately 16:08 EDT](monitoring-check-2026-09-04-1608.md). All six displayed audience totals were observed; X Chat is now accessible and empty, superseding the earlier passcode blocker below. Google campaign-specific overview metrics and ChatGPT readiness/performance evidence are recorded there. The subsequent 16:14 EDT update records the successful Google search-term review and exclusions, plus bounded Facebook inbox/comment inspection. Google event-firing verification and exhaustive ad-comment coverage remain pending.
+
+The project growth log references blanc-daily-social-tending and an hourly follower-growth automation. Neither appeared in the local automation files inspected. A native view request for blanc-daily-social-tending rendered a card but returned no schedule or status details. Reconcile that card/current scheduler before creating a duplicate or claiming that monitoring is active.
+
+Required access: signed-in Brave sessions with Blanc identity, social notification/inbox and audience analytics access, Meta promotion insights, Google Ads reporting access, and the connected ChatGPT Ads account. Reuse existing access; do not request broader permissions merely for convenience. X Chat is currently accessible; its earlier setup blocker is superseded. If access fails, record which check failed and the last successful observation without inferring a clean inbox or zero growth.
+
+Completed now: brand and six-channel scope resolved; existing scorecard located; Brave selected; Meta promotion inspected; ChatGPT account/campaign identified; operating plan saved; recurring native heartbeat created and verified ACTIVE after the user approved proceeding. No matching existing schedule was present in the local scheduler files; the new prompt requires coordination with any separate social tending workflow and checking the shared ledger before public actions.
+
+September 4, approximately 16:04 EDT: Google Ads opened as “Overview - Bananify Creative - Google Ads” after selecting the existing business Google identity. Campaign details did not become inspectable: Brave exposed only a small navigation fragment, then returned unchanged/incomplete accessibility state even after tab navigation; screenshots were unavailable. This is an access failure, not evidence of empty inboxes, unchanged audience counts or inactive Google campaigns. No fresh six-channel audience snapshot or inbox audit was completed and no reply or ad change was sent. This historical X Chat blocker was resolved during the subsequent live check. Resume from readable Brave pages, verify the exact Blanc Google campaign, inspect all six inboxes and audience totals, and review concrete ad improvements.
+
+Latest advertising follow-up: [September 4 efficiency and tracking review](ad-efficiency-review-2026-09-04.md). GA4 records two download clicks from AlternativeTo referrals for August 28–September 3 and none from its six measured paid-search sessions. Google Ads reports 89 clicks for those dates; privacy/collection coverage and shared desktop analytics limit comparison. Meta now reports $32.37 and five attributed follows; placement reach alone does not support a cut. Budgets remain Google $10/day and Meta $13/day; ChatGPT was previously verified paused. Preserve these distinctions in scheduled reviews.
+
+September 4, 16:26 EDT: Google auto-tagging and Blanc's GA4 link are verified active. The separate direct Ads tag AW-997979750 flags Blanc's homepage as untagged; this is not proof that the existing GA4 import is broken. Follow the efficiency review's tracking decision before adding tags. Meta's ad-message filter is empty; all four visible Instagram comment threads were inspected without a new question requiring a reply. Avoid repeating existing answers or old benchmark percentages.
+
+## Implemented dated follow-ups
+
+Latest measurement evidence: [17:35 live validation](measurement-validation-2026-09-04.md). Deployed GA4 and the Mac download-click event are verified; the internally filtered QA session is not customer growth or proof of Google Ads import. Specific security-policy blocks require a bounded consent/CSP review. Do not repeat the earlier claim that deployed event firing is wholly unverified, or remove internal filtering to make QA visible.
+
+- September 9: inspect Meta delivery status at scheduled checks. Its verified existing end date is September 9, without a displayed hour/timezone. Prepare the end-of-test recommendation at the first observed completion; no automatic extension or restart. Use the live post permalink in the latest checkpoint for comments.
+- September 12, first scheduled run: compare Google September 5–11 with August 28–September 3, record reporting timezone and conversion lag, and retain the exclusions and $10/day while evaluating. Recheck provisional conversion conclusions on the next scheduled run. Historical affected spend is not realized savings.
+- Each recommendation names the campaign and gives aligned evidence, current/proposed settings, estimated dollar effect with uncertainty, growth tradeoff and verification step. Scheduled ad reviews apply no changes.
+- Keep the existing native schedule and shared logs; check the ledger before every public send and verify the posted result. Retry unavailable checks, record partial coverage, and notify only on meaningful changes.

--- a/site/src/scripts/site.js
+++ b/site/src/scripts/site.js
@@ -6,6 +6,18 @@ const openAIAttribution = (() => {
   const validOppref = (value) =>
     typeof value === 'string' && value.length > 0 && value.length <= MAX_OPPREF_LENGTH;
 
+  const clearDownloadReference = (link) => {
+    try {
+      const url = new URL(link.href, location.href);
+      if (url.origin !== location.origin || !url.pathname.startsWith('/dl/')) return null;
+      if (url.searchParams.has('oppref')) {
+        url.searchParams.delete('oppref');
+        link.href = url.href;
+      }
+      return url;
+    } catch { return null; }
+  };
+
   let pendingOppref = null;
   try {
     const landingOppref = new URL(location.href).searchParams.get('oppref');
@@ -29,15 +41,21 @@ const openAIAttribution = (() => {
     deny() {
       pendingOppref = null;
       try { sessionStorage.removeItem(STORAGE_KEY); } catch { /* No stored attribution. */ }
+      // A prior click may have opened another tab or a download, leaving this
+      // page's link decorated. Withdrawal must also clean that live URL.
+      document.querySelectorAll('a[data-download-cta], a[data-download-link]')
+        .forEach(clearDownloadReference);
     },
     decorateDownload(link) {
+      // Remove old attribution before reading storage, which may now be denied
+      // or unavailable. Add it back only for a currently consented click.
+      const url = clearDownloadReference(link);
+      if (!url) return;
       try {
         if (localStorage.getItem(CONSENT_KEY) !== 'granted') return;
         const oppref = sessionStorage.getItem(STORAGE_KEY);
         if (!validOppref(oppref)) return;
 
-        const url = new URL(link.href, location.href);
-        if (url.origin !== location.origin || !url.pathname.startsWith('/dl/')) return;
         url.searchParams.set('oppref', oppref);
         link.href = url.href;
       } catch { /* Attribution must never affect the download path. */ }

--- a/test/unit/site-attribution-consent.test.js
+++ b/test/unit/site-attribution-consent.test.js
@@ -1,0 +1,114 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.resolve(__dirname, '../../site/src/scripts/site.js'), 'utf8');
+
+function page(choice) {
+  const local = new Map(choice ? [['measurement-consent-v2', choice]] : []);
+  const session = new Map();
+  let storageUnavailable = false;
+  const storage = (map) => ({
+    getItem(key) {
+      if (storageUnavailable) throw new Error('Storage unavailable');
+      return map.get(key) ?? null;
+    },
+    setItem: (key, value) => map.set(key, value),
+    removeItem: (key) => map.delete(key),
+  });
+  const element = () => ({
+    handlers: {}, hidden: true,
+    classList: { add() {}, remove() {} },
+    addEventListener(type, handler) { this.handlers[type] = handler; },
+  });
+  const banner = element();
+  const allow = element();
+  const deny = element();
+  const links = ['mac-arm64', 'win'].map((platform) => ({
+    href: `https://blancbrowser.com/dl/${platform}?keep=yes#download`,
+    dataset: { platform, track: 'download_click', ctaPosition: 'platform-card' },
+    closest() { return this; },
+  }));
+  const clickHandlers = [];
+  const document = {
+    head: { appendChild() {} }, body: { dataset: { page: 'download' } },
+    createElement: () => ({}),
+    getElementById: (id) => ({ consent: banner, consentAllow: allow, consentDeny: deny }[id]),
+    querySelector: () => null,
+    querySelectorAll(selector) {
+      return selector.includes('data-download-link') ? links : [];
+    },
+    addEventListener(type, handler) { if (type === 'click') clickHandlers.push(handler); },
+  };
+  const context = vm.createContext({
+    URL, document, window: {}, navigator: { userAgent: 'Macintosh' },
+    location: { href: 'https://blancbrowser.com/download?oppref=offline-fixture', origin: 'https://blancbrowser.com', pathname: '/download' },
+    localStorage: storage(local), sessionStorage: storage(session),
+    fetch: async () => ({ ok: false }),
+    setTimeout: () => 1, clearTimeout() {}, requestAnimationFrame() {},
+  });
+  vm.runInContext(source, context);
+  return {
+    links, local, session, context,
+    allow: () => allow.handlers.click(),
+    deny: () => deny.handlers.click(),
+    click: (link = links[0]) => clickHandlers.forEach((handler) => handler({ target: link })),
+    failStorage: () => { storageUnavailable = true; },
+  };
+}
+
+test('a download requires Allow before forwarding the pending ad reference', () => {
+  const p = page();
+  p.click();
+  assert.equal(new URL(p.links[0].href).searchParams.has('oppref'), false);
+  p.allow();
+  p.click();
+  assert.equal(new URL(p.links[0].href).searchParams.get('oppref'), 'offline-fixture');
+});
+
+test('withdrawing consent immediately cleans already-used links and future clicks', () => {
+  const p = page('granted');
+  p.links.forEach(p.click);
+  p.deny();
+  assert.equal(p.session.has('openai-oppref'), false);
+  for (const link of p.links) {
+    assert.equal(new URL(link.href).searchParams.has('oppref'), false);
+    assert.equal(new URL(link.href).searchParams.get('keep'), 'yes');
+    assert.equal(new URL(link.href).hash, '#download');
+    p.click(link);
+    assert.equal(new URL(link.href).searchParams.has('oppref'), false);
+  }
+});
+
+test('a changed saved choice removes a stale link reference on the next click', () => {
+  const p = page('granted');
+  p.click();
+  p.local.set('measurement-consent-v2', 'denied');
+  p.click();
+  assert.equal(new URL(p.links[0].href).searchParams.has('oppref'), false);
+});
+
+test('unavailable consent storage does not leave a previously decorated download', () => {
+  const p = page('granted');
+  p.click();
+  p.failStorage();
+  assert.doesNotThrow(() => p.click());
+  assert.equal(new URL(p.links[0].href).searchParams.has('oppref'), false);
+});
+
+test('granting again after withdrawal does not resurrect the discarded reference', () => {
+  const p = page('granted');
+  p.click(); p.deny(); p.allow(); p.click();
+  assert.equal(new URL(p.links[0].href).searchParams.has('oppref'), false);
+});
+
+test('attribution never changes an external or non-download destination', () => {
+  const p = page('granted');
+  for (const href of ['https://example.com/dl/win?oppref=external', 'https://blancbrowser.com/privacy?keep=yes']) {
+    p.links[0].href = href;
+    p.click();
+    assert.equal(p.links[0].href, href);
+  }
+});


### PR DESCRIPTION
A download link could retain its ChatGPT ad reference after the visitor withdrew measurement consent, allowing a later click from the same page to forward stale attribution. Clear references from existing download links on withdrawal and remove stale references before each consent-checked click. Preserve unrelated URL parameters and destinations.

Also records the approved six-channel growth targets, existing monitoring schedule, dated ad/measurement evidence, and routine inbound-reply authorization. Advertising budgets and delivery settings are unchanged.

Validation: 23 targeted consent, public-truth and Worker conversion checks pass; clean production site build, brand check, and SEO verification for 19 pages pass. Four new withdrawal/storage regression cases fail before the fix and pass afterward. The owner explicitly approved deployment of the website fix.

Production verification (September 4, 2026): Cloudflare deployment `b58f22e7-a7d6-4181-9856-d85976d03c1f` reports Production, branch main, source `40bf6b5`. The canonical download page serves all three scripts byte-for-byte identical to the clean build, and its Content-Security-Policy matches the approved headers. The downloaded production consent bundle passes all six behavioral regression checks offline. Brave confirms Privacy choices opens, No thanks persists across reload, and the three visible desktop download destinations remain clean. No paid ad click, download request, or real conversion was generated during this deployment validation. The historical measurement report's not-deployed status is superseded by this evidence.
