### PR TITLE
Resolve CodeQL findings in imports and development tooling

### DIFF
--- a/.github/workflows/release-windows-linux.yml
+++ b/.github/workflows/release-windows-linux.yml
@@ -191,10 +191,11 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           PRODUCT_NAME=$(node -p "require('./package.json').productName")
-          gh release upload "${{ inputs.tag }}" \
+          gh release upload "$RELEASE_TAG" \
             "dist/$PRODUCT_NAME-Setup-$VERSION.exe" \
             "dist/$PRODUCT_NAME-Setup-$VERSION.exe.blockmap" \
             "dist/windows-signature.json" \
@@ -299,10 +300,11 @@ jobs:
         if: ${{ inputs.mode == 'release' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           PRODUCT_NAME=$(node -p "require('./package.json').productName")
-          gh release upload "${{ inputs.tag }}" \
+          gh release upload "$RELEASE_TAG" \
             "dist/$PRODUCT_NAME-$VERSION.AppImage" \
             "dist/latest-linux.yml" \
             --repo "${{ github.repository }}"

--- a/copy/build.mjs
+++ b/copy/build.mjs
@@ -10,6 +10,7 @@
 // hand-synced JS copies are parsed and compared, not rewritten), mobile string
 // resources generated so the lowercase-mono command copy never forks.
 
+import { xmlEsc } from './string-escape.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -20,7 +21,6 @@ const OUT = path.join(ROOT, 'copy', 'generated');
 const spec = JSON.parse(fs.readFileSync(SPEC, 'utf8'));
 
 const keyFor = (command) => 'slash_' + command.replace(/^\//, '').replace(/-/g, '_');
-const xmlEsc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '\\"').replace(/'/g, "\\'");
 
 // ---- generators (mobile uses the primary `hint`) ----
 function genStrings() {

--- a/copy/string-escape.mjs
+++ b/copy/string-escape.mjs
@@ -1,0 +1,4 @@
+// Android string resources use backslash escapes inside XML text.
+export const xmlEsc = (s) => s.replace(/\\/g, '\\\\')
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '\\"').replace(/'/g, "\\'");

--- a/docs/codeql-triage-2026-09-04.md
+++ b/docs/codeql-triage-2026-09-04.md
@@ -14,7 +14,7 @@ Confirmed development-tool issue: the server listened on all interfaces and acce
 
 ## Import size races (#31–33)
 
-`src/main/pages.js` checks a user-selected import path's size before reading it; `src/main/browser-data-import.js` repeats the pattern for discovered browser profile files. A file can change or grow between the check and read. The observed concern is bypassing the intended memory-size bound, not demonstrated remote code execution. A bounded read from one file handle is the next correction to prepare, with deterministic growth/replacement tests. These alerts remain unresolved.
+`src/main/pages.js` checks a user-selected import path's size before reading it; `src/main/browser-data-import.js` repeats the pattern for discovered browser profile files. A file can change or grow between the check and read. The observed concern is bypassing the intended memory-size bound, not demonstrated remote code execution. The candidate now uses one open handle and a fixed byte-bounded buffer, rejecting growth beyond the configured limit before parsing. Tests exercise growth after stat, short reads, exact limits, UTF-8 and cleanup. These alerts remain unresolved on main until the fix lands and is reanalyzed. This is a runtime import change and needs affected-platform validation before merge/release.
 
 ## Other findings
 

--- a/docs/codeql-triage-2026-09-04.md
+++ b/docs/codeql-triage-2026-09-04.md
@@ -50,3 +50,7 @@ These are tooling correctness fixes in the draft, not deployed runtime fixes. Al
 ## Test-server HTML injection (#17–19)
 
 Request-derived fixture names now receive HTML text encoding. OAuth query values embedded in script elements use JSON encoding with literal less-than characters escaped, preventing closing-script-tag injection. Malformed percent encoding no longer crashes the fixture name decoder. Unit tests cover payload round trips and actual loopback HTTP responses; full OAuth/acceptance CI remains required. These corrections affect test tooling, not the shipped browser.
+
+## CI input handling
+
+Release-upload steps now pass the tag via an environment variable and quoted shell expansion rather than interpolating it into shell source. Existing tag/package validation, workflow dispatch access, conditions, artifacts and job permissions are unchanged. Parsed before/after workflow structures differ only in this transport change. Native release jobs have not been dispatched for this draft.

--- a/docs/codeql-triage-2026-09-04.md
+++ b/docs/codeql-triage-2026-09-04.md
@@ -19,3 +19,17 @@ Confirmed development-tool issue: the server listened on all interfaces and acce
 ## Other findings
 
 Remaining test-fixture, source-generator and SEO-tooling alerts need individual source review. Do not dismiss them merely because their paths are under test or scripts. No project-wide vulnerability clearance or independent audit is claimed.
+
+## Individually reviewed test-code false positives
+
+| Alerts | Evidence | Disposition rationale |
+| --- | --- | --- |
+| #2 | `test/desktop/steps/quiet-tabs.steps.js:181` | Math.random creates a synthetic page-state marker for a leakage test, not an authentication secret, key or nonce. |
+| #3, #4 | `src/main/test-hook.js:1750–1756`; `main.js` acceptanceTestMode gate | JSON.stringify encodes the supplied URL as a JS string literal. These deliberate navigation attack drivers run only in explicit unpackaged test mode, not a renderer-exposed production API. |
+| #10 | `test/unit/bookmark-import.test.js:22`; `src/main/bookmark-import.js:51` | The test asserts that a javascript bookmark fixture was dropped; it is not the production allowlist. The parser uses anchored http(s)-only acceptance. |
+| #11, #12 | `test/desktop/packaged-first-run-smoke.mjs:288,370` | urls is an array of complete page URL strings; includes is exact element membership, not substring host validation. |
+| #13, #14, #15 | `test/unit/bench-memory.test.js:916,925,954` | missing is an array of absent URLs; includes is exact element membership in test assertions. |
+| #27 | `test/unit/bench-memory.test.js:545` | Regex checks diagnostic text after asserting a benchmark cell failed. It does not authorize a host. |
+| #28, #29 | `test/unit/public-truth.test.js:18,75` | Negative source-text assertions intentionally match forbidden remote-font/favicon domains anywhere in source. Anchoring would weaken the checks, not improve URL validation. |
+
+These classifications follow the call semantics and data flow, not merely the files being tests. Other fixture/server alerts remain open.

--- a/docs/codeql-triage-2026-09-04.md
+++ b/docs/codeql-triage-2026-09-04.md
@@ -33,3 +33,16 @@ Remaining test-fixture, source-generator and SEO-tooling alerts need individual 
 | #28, #29 | `test/unit/public-truth.test.js:18,75` | Negative source-text assertions intentionally match forbidden remote-font/favicon domains anywhere in source. Anchoring would weaken the checks, not improve URL validation. |
 
 These classifications follow the call semantics and data flow, not merely the files being tests. Other fixture/server alerts remain open.
+
+## Serialization and SEO corrections
+
+- #20/#21: Android XML string generation now escapes literal backslashes before quote escapes. Existing catalog output remains byte-identical; synthetic backslash/quote tests verify the correction.
+- #44: internal-link classification compares parsed exact origins, including protocol-relative links; hostname suffix and userinfo lookalikes are rejected.
+- #45: supported HTML entities are decoded in one pass, avoiding recursive decoding of nested ampersand entities.
+
+These are tooling correctness fixes in the draft, not deployed runtime fixes. All three targeted tests, generator parity and syntax checks passed.
+
+## Additional false-positive classifications
+
+- #22–25 (`site/scripts/verify-parity.mjs`): script/comment removal creates normalized strings for equality comparison of trusted old/new build output. The result is compared in the CLI, never emitted as sanitized HTML or executed. The patterns are not an XSS sanitizer.
+- #34 (`test/unit/site-changelog.test.js`): the test creates an isolated output directory, checks generated JSON, then intentionally appends a newline to verify stale-output detection. There is no authorization decision between checking and modifying a shared sensitive file.

--- a/docs/codeql-triage-2026-09-04.md
+++ b/docs/codeql-triage-2026-09-04.md
@@ -46,3 +46,7 @@ These are tooling correctness fixes in the draft, not deployed runtime fixes. Al
 
 - #22–25 (`site/scripts/verify-parity.mjs`): script/comment removal creates normalized strings for equality comparison of trusted old/new build output. The result is compared in the CLI, never emitted as sanitized HTML or executed. The patterns are not an XSS sanitizer.
 - #34 (`test/unit/site-changelog.test.js`): the test creates an isolated output directory, checks generated JSON, then intentionally appends a newline to verify stale-output detection. There is no authorization decision between checking and modifying a shared sensitive file.
+
+## Test-server HTML injection (#17–19)
+
+Request-derived fixture names now receive HTML text encoding. OAuth query values embedded in script elements use JSON encoding with literal less-than characters escaped, preventing closing-script-tag injection. Malformed percent encoding no longer crashes the fixture name decoder. Unit tests cover payload round trips and actual loopback HTTP responses; full OAuth/acceptance CI remains required. These corrections affect test tooling, not the shipped browser.

--- a/docs/codeql-triage-2026-09-04.md
+++ b/docs/codeql-triage-2026-09-04.md
@@ -1,0 +1,21 @@
+# CodeQL triage — September 4, 2026
+
+A successful analysis job does not mean there are no findings. GitHub returned 35 open alerts during this review. Findings remain open unless individually resolved with evidence.
+
+## Error-page retry (#16, #26)
+
+The destination assignment in `src/renderer/pages/error.js:42` is preceded by an anchored, case-insensitive allowlist for `http://`, `https://` and `file://`. The parameter is assigned to the link's href, not parsed as HTML, and displayed values use textContent. Allowing an arbitrary web destination on a browser's Retry action is intended navigation, not an application redirect authorization boundary.
+
+The production file is byte-identical to public v1.15.0. `test/unit/error-page-retry.test.js` executes its actual source in an isolated VM and confirms rejection of javascript, data, vbscript, internal schemes, malformed separators, leading newlines and encoded separators, while preserving the three allowed scheme families. This is a source/DOM-property test, not a fresh packaged-browser execution claim. The two alerts are false positives for the reported executable-scheme/XSS and unintended-redirect conditions; file navigation remains governed by the browser's main-process policy.
+
+## Screenshot server (#5–9, #30)
+
+Confirmed development-tool issue: the server listened on all interfaces and accepted paths outside its preview root. The draft fix binds loopback, checks lexical and realpath containment, rejects malformed paths and reads/stats the same open handle. Tests cover traversal and symlink escapes. The local build tree remains trusted input; this is not a sandbox against a concurrent local process that can rewrite that tree.
+
+## Import size races (#31–33)
+
+`src/main/pages.js` checks a user-selected import path's size before reading it; `src/main/browser-data-import.js` repeats the pattern for discovered browser profile files. A file can change or grow between the check and read. The observed concern is bypassing the intended memory-size bound, not demonstrated remote code execution. A bounded read from one file handle is the next correction to prepare, with deterministic growth/replacement tests. These alerts remain unresolved.
+
+## Other findings
+
+Remaining test-fixture, source-generator and SEO-tooling alerts need individual source review. Do not dismiss them merely because their paths are under test or scripts. No project-wide vulnerability clearance or independent audit is claimed.

--- a/docs/codeql-triage-2026-09-04.md
+++ b/docs/codeql-triage-2026-09-04.md
@@ -54,3 +54,7 @@ Request-derived fixture names now receive HTML text encoding. OAuth query values
 ## CI input handling
 
 Release-upload steps now pass the tag via an environment variable and quoted shell expansion rather than interpolating it into shell source. Existing tag/package validation, workflow dispatch access, conditions, artifacts and job permissions are unchanged. Parsed before/after workflow structures differ only in this transport change. Native release jobs have not been dispatched for this draft.
+
+## Candidate preview lookup alerts #50/#51
+
+Both locations are realpath calls, not file reads. URL decoding and lexical root containment precede these calls; resolved-path containment precedes open/stat/read. Existing traversal and symlink-escape HTTP tests return 403 without serving file contents. The extensionless fallback only appends .html to the already confined candidate. The scanner does not model the custom containment predicate. These are false positives for the claimed path-injection read; trusted-local-build-tree and concurrent-writer limitations remain as documented above.

--- a/site/scripts/audit-live-seo.mjs
+++ b/site/scripts/audit-live-seo.mjs
@@ -1,3 +1,4 @@
+import { decodeAttribute } from './seo-url-utils.mjs';
 const SITE_ORIGIN = new URL(process.env.SITE_ORIGIN || 'https://blancbrowser.com').origin;
 const SITEMAP_URL = `${SITE_ORIGIN}/sitemap.xml`;
 const REQUEST_TIMEOUT_MS = 15_000;
@@ -7,10 +8,7 @@ const USER_AGENT = 'BlancSEOAudit/1.0 (+https://blancbrowser.com/)';
 const errors = [];
 const warnings = [];
 
-const decodeAttribute = (value = '') => value
-  .replaceAll('&amp;', '&')
-  .replaceAll('&quot;', '"')
-  .replaceAll('&#39;', "'");
+
 
 const capture = (html, patterns) => {
   for (const pattern of patterns) {

--- a/site/scripts/preview-server.mjs
+++ b/site/scripts/preview-server.mjs
@@ -1,0 +1,48 @@
+import http from 'node:http';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const TYPES = { '.html': 'text/html', '.css': 'text/css', '.js': 'text/javascript', '.svg': 'image/svg+xml', '.png': 'image/png', '.jpg': 'image/jpeg', '.ico': 'image/x-icon', '.woff2': 'font/woff2', '.xml': 'application/xml' };
+const contained = (root, file) => file === root || file.startsWith(root + path.sep);
+
+// Local screenshot tooling only. Resolve both URL traversal and symlinks before
+// opening, then inspect/read the same handle instead of checking another file.
+export async function servePreview(directory) {
+  const root = await fs.realpath(directory);
+  const server = http.createServer(async (req, res) => {
+    let handle;
+    try {
+      let pathname;
+      try { pathname = decodeURIComponent((req.url || '/').split('?')[0]); }
+      catch { res.writeHead(400); res.end(); return; }
+      if (pathname.includes('\0') || pathname.includes('\\')) {
+        res.writeHead(400); res.end(); return;
+      }
+      const relative = pathname.replace(/^\/+/, '');
+      let candidate = path.resolve(root, relative.endsWith('/') || !relative ? relative + 'index.html' : relative);
+      if (!contained(root, candidate)) { res.writeHead(403); res.end(); return; }
+      let file;
+      try { file = await fs.realpath(candidate); }
+      catch (error) {
+        if (error.code !== 'ENOENT') throw error;
+        file = await fs.realpath(candidate + '.html');
+      }
+      if (!contained(root, file)) { res.writeHead(403); res.end(); return; }
+      handle = await fs.open(file, 'r');
+      if (!(await handle.stat()).isFile()) { res.writeHead(404); res.end(); return; }
+      const body = await handle.readFile();
+      res.writeHead(200, { 'Content-Type': TYPES[path.extname(file)] || 'application/octet-stream', 'X-Content-Type-Options': 'nosniff' });
+      res.end(body);
+    } catch {
+      if (!res.headersSent) res.writeHead(404);
+      res.end();
+    } finally {
+      await handle?.close();
+    }
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  return server;
+}

--- a/site/scripts/seo-url-utils.mjs
+++ b/site/scripts/seo-url-utils.mjs
@@ -1,0 +1,15 @@
+// Decode each supported entity once; nested &amp;quot; stays literal &quot;.
+export function decodeAttribute(value = '') {
+  const entities = { '&amp;': '&', '&quot;': '"', '&#39;': "'" };
+  return value.replace(/&(?:amp|quot|#39);/g, (entity) => entities[entity]);
+}
+
+export function internalPath(href, origin) {
+  if (!href.startsWith('/') && !/^https?:\/\//i.test(href)) return null;
+  try {
+    const target = new URL(href, origin);
+    return target.origin === new URL(origin).origin ? target.pathname : null;
+  } catch {
+    return null;
+  }
+}

--- a/site/scripts/shoot-pages.mjs
+++ b/site/scripts/shoot-pages.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
+import { servePreview } from './preview-server.mjs';
 // Screenshots every page from the baseline (git archive) and from dist/,
 // at desktop and mobile widths, into site/.parity-shots/{old,new}/ for
 // side-by-side human review. Requires the repo root's playwright.
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
-import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -22,23 +22,9 @@ const SIZES = [{ tag: 'desktop', width: 1280, height: 2400 }, { tag: 'mobile', w
 const oldDir = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-site-old-'));
 execFileSync('bash', ['-c', `git archive site-pre-astro site | tar -x -C ${oldDir}`], { cwd: ROOT });
 
-function serve(dir) {
-  return new Promise((resolve) => {
-    const server = http.createServer((req, res) => {
-      const url = decodeURIComponent(req.url.split('?')[0]);
-      let file = path.join(dir, url.endsWith('/') ? url + 'index.html' : url);
-      if (!fs.existsSync(file) && fs.existsSync(file + '.html')) file += '.html';
-      if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) { res.writeHead(404); res.end(); return; }
-      const types = { '.html': 'text/html', '.css': 'text/css', '.js': 'text/javascript', '.svg': 'image/svg+xml', '.png': 'image/png', '.jpg': 'image/jpeg', '.ico': 'image/x-icon', '.woff2': 'font/woff2', '.xml': 'application/xml' };
-      res.writeHead(200, { 'Content-Type': types[path.extname(file)] || 'application/octet-stream' });
-      res.end(fs.readFileSync(file));
-    });
-    server.listen(0, () => resolve(server));
-  });
-}
 
-const oldServer = await serve(path.join(oldDir, 'site'));
-const newServer = await serve(path.join(ROOT, 'site/dist'));
+const oldServer = await servePreview(path.join(oldDir, 'site'));
+const newServer = await servePreview(path.join(ROOT, 'site/dist'));
 const browser = await chromium.launch();
 for (const [label, server] of [['old', oldServer], ['new', newServer]]) {
   for (const size of SIZES) {

--- a/site/scripts/verify-seo.mjs
+++ b/site/scripts/verify-seo.mjs
@@ -1,3 +1,4 @@
+import { internalPath } from './seo-url-utils.mjs';
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -177,10 +178,8 @@ for (const file of htmlFiles) {
     const href = match[1];
     if (href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:')) continue;
 
-    let target;
-    if (href.startsWith('/')) target = href;
-    else if (href.startsWith(SITE_ORIGIN)) target = new URL(href).pathname;
-    else continue;
+    const target = internalPath(href, SITE_ORIGIN);
+    if (target === null) continue;
 
     const clean = target.split(/[?#]/)[0] || '/';
     const normalized = clean.length > 1 ? clean.replace(/\/$/, '') : clean;

--- a/src/main/bounded-file-read.js
+++ b/src/main/bounded-file-read.js
@@ -1,0 +1,31 @@
+const fs = require('node:fs');
+
+function fileError(code) {
+  return Object.assign(new Error(code), { code });
+}
+
+// Size checks and reads share one handle, and the byte limit is enforced while
+// reading so growth after stat cannot bypass the import memory bound.
+async function readBoundedUtf8(filePath, maxBytes, fsPromises = fs.promises) {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) throw new RangeError('Invalid byte limit');
+  const handle = await fsPromises.open(filePath, 'r');
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) throw fileError('ENOTFILE');
+    if (stat.size > maxBytes) throw fileError('EFBIG');
+    let total = 0;
+    const buffer = Buffer.allocUnsafe(maxBytes + 1);
+    while (true) {
+      const length = Math.min(64 * 1024, maxBytes - total + 1);
+      const { bytesRead } = await handle.read(buffer, total, length, total);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > maxBytes) throw fileError('EFBIG');
+    }
+    return buffer.subarray(0, total).toString('utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
+module.exports = { readBoundedUtf8 };

--- a/src/main/browser-data-import.js
+++ b/src/main/browser-data-import.js
@@ -3,6 +3,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { validFolder } = require('./bookmark-validate');
+const { readBoundedUtf8 } = require('./bounded-file-read');
 
 const MAX_BROWSER_BOOKMARK_BYTES = 20 * 1024 * 1024;
 const MAX_BROWSER_BOOKMARK_NODES = 100_000;
@@ -147,9 +148,7 @@ function parseChromiumBookmarks(input, {
 
 async function readJsonIfSmall(filePath, fsPromises, maxBytes = 2 * 1024 * 1024) {
   try {
-    const stat = await fsPromises.stat(filePath);
-    if (!stat.isFile() || stat.size > maxBytes) return null;
-    return JSON.parse(await fsPromises.readFile(filePath, 'utf8'));
+    return JSON.parse(await readBoundedUtf8(filePath, maxBytes, fsPromises));
   } catch {
     return null;
   }
@@ -223,14 +222,13 @@ function createBrowserDataImportService({
       const source = (await discover()).find((candidate) => candidate.id === id);
       if (!source) return { error: 'source-unavailable' };
       try {
-        const stat = await fsPromises.stat(source.bookmarksPath);
-        if (!stat.isFile()) return { error: 'source-unavailable' };
-        if (stat.size > MAX_BROWSER_BOOKMARK_BYTES) return { error: 'too-large' };
-        const raw = await fsPromises.readFile(source.bookmarksPath, 'utf8');
+        const raw = await readBoundedUtf8(source.bookmarksPath, MAX_BROWSER_BOOKMARK_BYTES, fsPromises);
         const entries = parseChromiumBookmarks(raw);
         if (!entries.length) return { error: 'empty' };
         return { source: publicSource(source), entries };
-      } catch {
+      } catch (error) {
+        if (error.code === 'EFBIG') return { error: 'too-large' };
+        if (error.code === 'ENOTFILE') return { error: 'source-unavailable' };
         return { error: 'unreadable' };
       }
     },

--- a/src/main/pages.js
+++ b/src/main/pages.js
@@ -5,6 +5,7 @@ const { pathToFileURL } = require('url');
 const bookmarks = require('./bookmarks');
 const { parseNetscapeBookmarks } = require('./bookmark-import');
 const { createBrowserDataImportService } = require('./browser-data-import');
+const { readBoundedUtf8 } = require('./bounded-file-read');
 
 const MAX_IMPORT_BYTES = 20 * 1024 * 1024; // 20 MiB
 const history = require('./history');
@@ -154,15 +155,14 @@ function setupPages(hooks = {}) {
     });
     if (picked.canceled || !picked.filePaths.length) return { cancelled: true };
     try {
-      const stat = await fs.promises.stat(picked.filePaths[0]);
-      if (stat.size > MAX_IMPORT_BYTES) return { error: 'too-large' };
-      const html = await fs.promises.readFile(picked.filePaths[0], 'utf8');
+      const html = await readBoundedUtf8(picked.filePaths[0], MAX_IMPORT_BYTES);
       const entries = parseNetscapeBookmarks(html);
       if (!entries.length) return { error: 'empty' };
       const { added, skipped } = bookmarks.importBookmarks(entries);
       hooks.onDataChanged?.();
       return { added, skipped };
-    } catch {
+    } catch (error) {
+      if (error.code === 'EFBIG') return { error: 'too-large' };
       return { error: 'unreadable' };
     }
   });

--- a/test/desktop/support/fixtures-server.js
+++ b/test/desktop/support/fixtures-server.js
@@ -4,10 +4,14 @@
 // find-in-page scenario when that step is implemented).
 const http = require('node:http');
 const https = require('node:https');
+const { escapeHtml } = require('../../helpers/html-encoding');
 
 function pageBody(req) {
   const raw = req.url || '/';
-  const name = decodeURIComponent(raw.replace(/^\/site\//, '').split('?')[0]) || 'page';
+  let name;
+  try { name = decodeURIComponent(raw.replace(/^\/site\//, '').split('?')[0]) || 'page'; }
+  catch { name = 'invalid path'; }
+  name = escapeHtml(name);
   // Some history/wake scenarios suppress the load counter so pageState stays
   // deterministic. Ordinary site-owned sessionStorage is not unsaved user
   // work and therefore does not prevent this page from becoming quiet.

--- a/test/helpers/html-encoding.js
+++ b/test/helpers/html-encoding.js
@@ -1,0 +1,13 @@
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  })[character]);
+}
+
+// JSON string escaping alone does not prevent an HTML parser from seeing a
+// closing script tag. Preserve the value while removing literal tag starts.
+function scriptJson(value) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+module.exports = { escapeHtml, scriptJson };

--- a/test/oauth/desktop.test.js
+++ b/test/oauth/desktop.test.js
@@ -5,6 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 const { _electron } = require('playwright');
+const { scriptJson } = require('../helpers/html-encoding');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const CLIENT_HINTS = [
@@ -129,8 +130,8 @@ test('Google OAuth compatibility holds across popup and tab-style flows', { time
           'wow64',
         ]);
         const payload = {
-          mode: ${JSON.stringify(mode)},
-          userActivationTrusted: ${JSON.stringify(url.searchParams.get('trusted'))} === 'true',
+          mode: ${scriptJson(mode)},
+          userActivationTrusted: ${scriptJson(url.searchParams.get('trusted'))} === 'true',
           openerAtProvider: !!window.opener,
           userAgent: navigator.userAgent,
           brands: navigator.userAgentData?.brands || [],
@@ -141,8 +142,8 @@ test('Google OAuth compatibility holds across popup and tab-style flows', { time
           highEntropy,
           requestHeaders,
         };
-        const target = new URL(${JSON.stringify(callbackUrl)});
-        target.searchParams.set('mode', ${JSON.stringify(mode)});
+        const target = new URL(${scriptJson(callbackUrl)});
+        target.searchParams.set('mode', ${scriptJson(mode)});
         target.searchParams.set('payload', JSON.stringify(payload));
         location.replace(target);
       }, 100);
@@ -176,7 +177,7 @@ test('Google OAuth compatibility holds across popup and tab-style flows', { time
       <output id="result"></output>
       <script>
         window.oauthResults = {};
-        const provider = ${JSON.stringify(provider)};
+        const provider = ${scriptJson(provider)};
         document.getElementById('popup-login').addEventListener('click', (event) => {
           window.open(provider + '?mode=popup&trusted=' + event.isTrusted, 'google-oauth', 'popup,width=520,height=680');
         });

--- a/test/unit/bounded-file-read.test.js
+++ b/test/unit/bounded-file-read.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { readBoundedUtf8 } = require('../../src/main/bounded-file-read');
+
+test('bounded reader handles empty, exact-limit, oversized and multi-byte files', async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'blanc-bounded-'));
+  t.after(() => fs.rm(dir, { recursive: true, force: true }));
+  const file = path.join(dir, 'input');
+  for (const text of ['', 'abcd', 'éé']) {
+    await fs.writeFile(file, text);
+    assert.equal(await readBoundedUtf8(file, 4), text);
+  }
+  await fs.writeFile(file, 'abcde');
+  await assert.rejects(readBoundedUtf8(file, 4), { code: 'EFBIG' });
+  await assert.rejects(readBoundedUtf8(file, 0), RangeError);
+});
+
+test('growth after stat cannot exceed the byte budget and always closes the handle', async () => {
+  let closed = false;
+  let readBytes = 0;
+  const provider = { async open() { return {
+    async stat() { return { size: 1, isFile: () => true }; },
+    async read(buffer, offset, length) {
+      // Simulate a file that grows forever after the initial size observation.
+      buffer.fill(65);
+      readBytes += length;
+      return { bytesRead: length };
+    },
+    async close() { closed = true; },
+  }; } };
+  await assert.rejects(readBoundedUtf8('unused', 70000, provider), { code: 'EFBIG' });
+  assert.equal(readBytes, 70001);
+  assert.equal(closed, true);
+});
+
+test('reader uses the open handle even if the path changes, handles short reads, and closes on failure', async () => {
+  let closes = 0;
+  const provider = { async open() { return {
+    async stat() { return { size: 3, isFile: () => true }; },
+    async read(buffer, offset, length, position) {
+      if (position >= 3) return { bytesRead: 0 };
+      buffer[offset] = 'abc'.charCodeAt(position);
+      return { bytesRead: 1 };
+    },
+    async close() { closes++; },
+  }; }, stat() { throw Error('Path stat must not be used'); }, readFile() { throw Error('Path read must not be used'); } };
+  assert.equal(await readBoundedUtf8('replaced-path', 3, provider), 'abc');
+  assert.equal(closes, 1);
+  const failing = { async open() { return {
+    async stat() { throw Error('stat failed'); },
+    async close() { closes++; },
+  }; } };
+  await assert.rejects(readBoundedUtf8('unused', 3, failing), /stat failed/);
+  assert.equal(closes, 2);
+});

--- a/test/unit/build-serialization.test.js
+++ b/test/unit/build-serialization.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('SEO internal links require exact origin, including protocol-relative links', async () => {
+  const { internalPath } = await import('../../site/scripts/seo-url-utils.mjs');
+  const origin = 'https://blancbrowser.com';
+  for (const href of ['/about?q=1#x', origin + '/about', '//blancbrowser.com/about']) {
+    assert.equal(internalPath(href, origin), '/about');
+  }
+  for (const href of [origin + '.evil.example/about', origin + '@evil.example/about', '//evil.example/about', 'http://blancbrowser.com/about', 'javascript:alert(1)', 'https://[bad']) {
+    assert.equal(internalPath(href, origin), null, href);
+  }
+});
+
+test('SEO attribute decoding does not recursively decode nested entities', async () => {
+  const { decodeAttribute } = await import('../../site/scripts/seo-url-utils.mjs');
+  assert.equal(decodeAttribute('&amp;quot;'), '&quot;');
+  assert.equal(decodeAttribute('&amp;#39;'), '&#39;');
+  assert.equal(decodeAttribute('a&amp;b&quot;c&#39;'), 'a&b"c\'');
+});
+
+test('Android copy escaping preserves literal backslashes before escaped quotes', async () => {
+  const { xmlEsc } = await import('../../copy/string-escape.mjs');
+  assert.equal(xmlEsc('\\'), '\\\\');
+  assert.equal(xmlEsc('"'), '\\"');
+  assert.equal(xmlEsc('\\"'), '\\\\\\"');
+  assert.equal(xmlEsc('<a&b>'), '&lt;a&amp;b&gt;');
+});

--- a/test/unit/error-page-retry.test.js
+++ b/test/unit/error-page-retry.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, '../../src/renderer/pages/error.js'), 'utf8');
+function render(target) {
+  const elements = new Map();
+  const document = { getElementById(id) {
+    if (!elements.has(id)) elements.set(id, { textContent: '', href: 'blanc://newtab/' });
+    return elements.get(id);
+  } };
+  vm.runInNewContext(source, {
+    URL, document,
+    location: { href: 'blanc://error/?' + new URLSearchParams({ url: target, desc: '<img src=x onerror=alert(1)>', code: '-1' }) },
+  });
+  return document.getElementById('retryLink');
+}
+
+test('error retry rejects executable and malformed scheme prefixes', () => {
+  for (const target of [
+    'javascript:alert(1)', 'JaVaScRiPt://alert(1)', 'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)', '//example.com', '\nhttps://example.com',
+    'https:\\example.com', 'https:%2f%2fexample.com', 'java\nscript:alert(1)',
+    'blanc://settings', 'httpsjavascript://example.com',
+  ]) assert.equal(render(target).href, 'blanc://newtab/', target);
+});
+
+test('error retry preserves ordinary web and local-file destinations', () => {
+  for (const target of ['https://example.com/path?q=1', 'http://example.com/', 'file:///tmp/example.html', 'HTTPS://example.com/']) {
+    assert.equal(render(target).href, target);
+  }
+});

--- a/test/unit/fixture-html-encoding.test.js
+++ b/test/unit/fixture-html-encoding.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { escapeHtml, scriptJson } = require('../helpers/html-encoding');
+const { start } = require('../desktop/support/fixtures-server');
+
+test('fixture encoders preserve data without creating HTML or script boundaries', () => {
+  const value = '</script><script>alert("x")</script>&\'';
+  assert.equal(escapeHtml(value), '&lt;/script&gt;&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;&amp;&#39;');
+  const encoded = scriptJson(value);
+  assert.equal(encoded.includes('<'), false);
+  assert.equal(JSON.parse(encoded), value);
+  assert.equal(scriptJson(null), 'null');
+});
+
+test('actual HTTP fixture escapes request-derived title/body text and survives malformed encoding', async () => {
+  const server = await start();
+  const get = (suffix) => new Promise((resolve, reject) => {
+    http.get(server.base + suffix, (res) => {
+      let body = '';
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', () => resolve(body));
+    }).on('error', reject);
+  });
+  try {
+    const body = await get('/site/' + encodeURIComponent('<img src=x onerror=alert(1)>'));
+    assert.equal(body.includes('<img src=x'), false);
+    assert.match(body, /&lt;img src=x onerror=alert\(1\)&gt;/);
+    assert.match(await get('/site/%zz'), /invalid path/);
+  } finally {
+    await server.close();
+  }
+});

--- a/test/unit/preview-server.test.js
+++ b/test/unit/preview-server.test.js
@@ -1,0 +1,40 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const http = require('node:http');
+
+test('screenshot preview confines requests to its root and listens only on loopback', async () => {
+  const { servePreview } = await import('../../site/scripts/preview-server.mjs');
+  const temp = await fs.mkdtemp(path.join(os.tmpdir(), 'blanc-preview-test-'));
+  const root = path.join(temp, 'public');
+  await fs.mkdir(root);
+  await fs.writeFile(path.join(root, 'index.html'), 'homepage');
+  await fs.writeFile(path.join(root, 'about.html'), 'about');
+  await fs.writeFile(path.join(temp, 'private.txt'), 'must not be served');
+  await fs.symlink(path.join(temp, 'private.txt'), path.join(root, 'escape.txt'));
+  const server = await servePreview(root);
+  const request = (url) => new Promise((resolve, reject) => {
+    http.get({ host: '127.0.0.1', port: server.address().port, path: url }, (res) => {
+      let body = '';
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode, body }));
+    }).on('error', reject);
+  });
+  try {
+    assert.equal(server.address().address, '127.0.0.1');
+    assert.deepEqual(await request('/'), { status: 200, body: 'homepage' });
+    assert.deepEqual(await request('/about?test=1'), { status: 200, body: 'about' });
+    for (const url of ['/../private.txt', '/%2e%2e/private.txt', '/escape.txt']) {
+      assert.equal((await request(url)).status, 403, url);
+    }
+    for (const url of ['/%zz', '/%00', '/..%5cprivate.txt']) {
+      assert.equal((await request(url)).status, 400, url);
+    }
+    assert.equal((await request('/missing')).status, 404);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(temp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Resolve confirmed CodeQL findings across runtime imports and development tooling: the screenshot-comparison server can expose paths outside its preview root on non-loopback interfaces, and bookmark/profile imports can grow beyond the size checked before reading.

Confine screenshot previews to loopback and the resolved preview root, rejecting malformed paths and symlink escapes. Read imports through one handle into a fixed byte-bounded buffer and reject oversized/growing input before parsing. Preserve existing import error responses. Add exact-source error-page tests and document why alerts #16/#26 are false positives; those two dispositions are recorded on GitHub with evidence.

Validation: nine bounded-reader/browser-import tests pass, including post-stat growth, short reads, UTF-8, exact limits and handle cleanup. Preview HTTP and error-page tests passed in the preceding commits. Syntax and diff checks pass. Fresh hosted CI is pending for a461724.

This now includes runtime import changes: affected-platform desktop validation remains required before merge/release. No release or deployment is authorized by this draft. The preview root is trusted local input, not a hostile concurrent-writer sandbox.

Draft under the launch freeze, stacked on safeguards PR #285. Retarget after that PR lands. Alerts #5–9, #30–33 remain unresolved on main until the fixes land and are reanalyzed. Other open alerts still require individual triage. This does not claim an earned badge or a completed independent audit.

Additional tooling corrections: exact SEO origin matching, single-pass entity decoding, Android backslash escaping, and safe HTML/script encoding in local acceptance/OAuth fixtures. Targeted regression tests pass; generator parity is unchanged. Full hosted validation is pending for b9a1601. Per-alert evidence is in docs/codeql-triage-2026-09-04.md.
