### PR TITLE
Remove OpenSSF badge from footer

### DIFF
--- a/docs/openssf-baseline-badge-2026-09-04.md
+++ b/docs/openssf-baseline-badge-2026-09-04.md
@@ -10,6 +10,7 @@ to the public record. It does not describe the badge as a security
 certification or an independent audit.
 
 `site/public/openssf-baseline.svg` is an exact snapshot of the badge returned
-by the official project badge endpoint on that date. Serving the snapshot
-locally avoids a third-party request from every Blanc website page; the badge
-link still opens the live assessment so visitors can check its current state.
+by the official project badge endpoint on that date. It appears only in the
+Security page's assessment block. Serving the snapshot locally avoids a
+third-party request; its link still opens the live assessment so visitors can
+check its current state.

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -37,15 +37,6 @@ const isCurrent = (href) =>
         <BrandMark class="foot-mark" />
       </a>
       <p>A little less browser.</p>
-      <a
-        class="foot-baseline"
-        href="https://www.bestpractices.dev/en/projects/14451/baseline-1"
-        target="_blank"
-        rel="noopener"
-        aria-label="View Blanc's OpenSSF Baseline Level 1 self-assessment"
-      >
-        <img src="/openssf-baseline.svg" width="213" height="20" loading="lazy" decoding="async" alt="OpenSSF Baseline version 2026.08.28, Level 1" />
-      </a>
     </div>
     <nav class="foot-nav" aria-label="Footer">
       {GROUPS.map(({ title, links }) => (

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -1268,10 +1268,6 @@ a:focus-visible, button:focus-visible { outline: 2px solid var(--site-accent); o
   width: 44px; height: 44px; color: var(--site-text); text-decoration: none;
 }
 .site-footer .foot-mark { width: 44px; height: 44px; flex-shrink: 0; color: inherit; }
-.site-footer .foot-baseline { display: inline-flex; width: fit-content; margin-top: 24px; border-radius: 3px; text-decoration: none; transition: opacity 160ms ease; }
-.site-footer .foot-baseline:hover { opacity: 0.78; }
-.site-footer .foot-baseline:focus-visible { outline: 2px solid var(--site-accent); outline-offset: 4px; }
-.site-footer .foot-baseline img { display: block; width: 213px; max-width: 100%; height: auto; }
 .site-footer .foot-bottom { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding-top: 20px; border-top: 1px solid var(--site-border); }
 .site-footer .foot-legal { display: flex; flex-wrap: wrap; align-items: center; gap: 0 28px; min-width: 0; font-size: 12px; }
 .site-footer .foot-credit { display: flex; flex-wrap: wrap; align-items: center; gap: 0 20px; }
@@ -1309,7 +1305,6 @@ a:focus-visible, button:focus-visible { outline: 2px solid var(--site-accent); o
   .site-footer .foot-top { grid-template-columns: 1fr; gap: 36px; padding-bottom: 36px; }
   .site-footer .foot-identity { display: flex; flex-wrap: wrap; align-items: center; gap: 12px 32px; padding-bottom: 28px; border-bottom: 1px solid var(--site-border); }
   .site-footer .foot-identity p { margin: 0; }
-  .site-footer .foot-baseline { margin-top: 0; }
   .site-footer .foot-nav { width: 100%; gap: 24px; }
   .site-footer .foot-news { max-width: 440px; }
   .site-footer .foot-mark { width: 40px; height: 40px; }


### PR DESCRIPTION
The OpenSSF badge is too visually intrusive in Blanc's shared footer. This removes the badge and its footer-only styles while retaining the contextual OpenSSF assessment block on the Security page.

Validation: `npm run site:build` (19 pages and 19 sitemap URLs; SEO verification passed). The built homepage contains no footer badge, and the Security page still contains the assessment proof.
