### PR TITLE
Refresh the README with the Product Hunt tour and trust evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,65 @@
 # Blanc Browser
 
-[![Blanc's Island chrome opening into the Quick Switcher, switching tabs, and showing a live blocker count](docs/superpowers/plans/assets/island-demo.gif)](docs/superpowers/plans/assets/island-demo.mp4)
+[![Blanc — The browser that gets out of your way](site/public/og-image.png)](https://blancbrowser.com)
 
-A minimal Electron browser with **Island chrome**: instead of a tab strip
-and toolbar, a single floating pill sits top-center over the page — tab
-dots, the current site, and an ad-block counter. Click it (or hit
-`Cmd/Ctrl+L`) and it expands into a command bar: address input, slash
-commands, and a quick switcher across open tabs, favorites, and history.
-Ad/tracker blocking is wired in at the network layer, independent of
-Chrome's extension store and Manifest V3's `declarativeNetRequest` limits.
-Plus favorites, history, downloads, settings, private tabs, per-site
-permission prompts, session restore, and signed + notarized auto-updating
-macOS builds.
+<p align="center">
+  <strong>A minimal, open-source desktop browser built around one small Island.</strong><br>
+  <a href="https://blancbrowser.com">Website</a> ·
+  <a href="https://github.com/bnfy/blanc/releases/latest">Download</a> ·
+  <a href="docs/user-guide.md">User guide</a> ·
+  <a href="SECURITY.md">Security</a>
+</p>
+
+Blanc replaces the usual tab strip and toolbar with a floating command pill.
+It keeps the current site, tab switching, navigation, search, and a live
+blocker count close at hand, then expands when you need more.
+
+- **A quieter interface:** Island chrome, the Quick Switcher, tab groups,
+  Quiet Tabs, Glance, and multiple windows without a permanent toolbar.
+- **Blocking built in:** ads and trackers are filtered at the network layer
+  from bundled, hash-verified EasyList and EasyPrivacy snapshots.
+- **Private and local choices:** private tabs use a separate in-memory session;
+  local profiles separate site data, history, Favorites, downloads, and
+  remembered permissions.
+- **Desktop releases:** signed and notarized macOS builds, signed Windows
+  installers, and Linux AppImages, all distributed through GitHub Releases.
+
+## Watch Blanc in action
+
+[![Watch Blanc Browser — A little less browser. (v1.15.0)](https://i.ytimg.com/vi/xqUFMUcCjT0/maxresdefault.jpg)](https://www.youtube.com/watch?v=xqUFMUcCjT0)
+
+[Watch the 42-second v1.15.0 Product Hunt tour on YouTube.](https://www.youtube.com/watch?v=xqUFMUcCjT0)
+
+For a quicker look at the Island, this short demo opens the Quick Switcher,
+changes tabs, and shows a live blocker count:
+
+[![Blanc's Island opening into the Quick Switcher, switching tabs, and showing a live blocker count](docs/superpowers/plans/assets/island-demo.gif)](docs/superpowers/plans/assets/island-demo.mp4)
+
+## Security and trust
+
+Blanc uses Electron and Chromium. Electron is part of the browser's attack
+surface, so Blanc treats runtime configuration, permissions, dependencies,
+and release integrity as explicit controls:
+
+- Public web tabs run with Chromium sandboxing enabled, Node integration
+  disabled, and context isolation enabled. Ordinary sites receive no
+  privileged Blanc bridge.
+- Permissions deny by default. Camera, microphone, location, and notifications
+  require per-site decisions; screen capture and other unhandled permissions
+  are refused.
+- Published macOS builds are signed and notarized, and Windows installers are
+  timestamp-signed. The current release includes a Sigstore-authenticated
+  checksum manifest, a CycloneDX SBOM, and provenance evidence.
+- Vulnerabilities can be reported privately under the response targets and
+  safe-harbor terms in [SECURITY.md](SECURITY.md).
+
+Blanc has earned the
+[OpenSSF Best Practices Baseline Level 1](https://www.bestpractices.dev/en/projects/14451/baseline-1)
+self-certification. It is a voluntary assessment of documented project
+practices, not an independent security audit or endorsement. Blanc currently
+has one human maintainer and has not completed an independent external audit.
+The evidence and limits for the current release are recorded in the
+[v1.15.0 release report](docs/release-incidents/2026-09-02-v1.15.0.md).
 
 > **Current release:** v1.15.0 expands Mahjong to eight layouts, rotates the
 > Daily board across them, adds device-local records and streaks, resumes
@@ -307,21 +355,13 @@ entirely.
   credential-manager passkeys still await Apple's grant of the
   `com.apple.developer.web-browser.public-key-credential` entitlement
   (requested).
-## Rebrand cleanup still pending
 
-This app was renamed from "Bowser" to Blanc — the code, package identity,
-and visual assets are done, but a few infra steps are deliberately not yet
-live:
+## Naming continuity
 
-- The marketing site (`site/`) is live on the Cloudflare Pages project
-  `blancbrowser` (direct upload: `npm run site:deploy`, which builds the
-  Astro site and uploads `site/dist`), served at the canonical domain
-  `blancbrowser.com`. `getbowser.com` 301-redirects there path-for-path
-  (live since 2026-07-11), so search consolidates onto the canonical domain.
-- This file's still-old-name architecture references were updated, but a
-  fuller pass to make sure nothing else in the repo (scripts, docs, comments)
-  assumes "Bowser" would be worth a final sweep before the first real
-  "Blanc" release ships.
+The app was renamed from Bowser to Blanc in July 2026. It keeps the bundle
+identifier `me.bnfy.bowser` so existing macOS signing and Gatekeeper identity,
+installed user data, and the auto-update chain continue to work. The former
+`getbowser.com` domain redirects path-for-path to `blancbrowser.com`.
 
 ## Known rough edges
 


### PR DESCRIPTION
The repository landing page led with an older inline demo and buried the current trust evidence. This refresh gives Blanc a release-backed hero, adds the 42-second v1.15.0 Product Hunt tour and short Island demo, summarizes the product clearly, and brings the Electron security model, signed release evidence, OpenSSF Baseline Level 1 self-certification, maintainer count, and independent-audit limit into the first screenfuls.

It also replaces stale pre-release rebrand wording with the intentional bundle-identity continuity note.

Validation:

- `git diff --check`
- all local README links and media targets resolve
- OpenSSF Baseline Level 1 link and YouTube thumbnail return HTTP 200
- YouTube tour opened and played in Brave as “Blanc Browser — A little less browser. (v1.15.0)”
