### PR TITLE
Refine features menu footer copy

### DIFF
--- a/docs/website-v1.15-claims.json
+++ b/docs/website-v1.15-claims.json
@@ -2408,7 +2408,7 @@
     {
       "id": "website-115-228",
       "source": "site/src/data/navigation.mjs",
-      "exactWording": "Fourteen guides. No account, no AI, no extension store.",
+      "exactWording": "Less browser. More of what you opened it for.",
       "subject": "Blanc",
       "evidenceGroups": [
         "foundations"

--- a/site/src/data/navigation.mjs
+++ b/site/src/data/navigation.mjs
@@ -30,7 +30,7 @@ export const menus = [
       ] },
     ],
     spotlight: { kind: 'image', image: '/feature-island.png', alt: 'The Blanc island resting over a web page', kicker: 'Start here', title: 'One small island. The whole browser.', copy: 'Back, forward, tabs, search and commands in one floating pill.', href: '/features/island', cta: 'See the island' },
-    foot: { note: 'Fourteen guides. No account, no AI, no extension store.', label: 'All features', href: '/features' },
+    foot: { note: 'Less browser. More of what you opened it for.', label: 'All features', href: '/features' },
   },
   {
     key: 'company',

--- a/test/unit/site-navigation.test.js
+++ b/test/unit/site-navigation.test.js
@@ -35,7 +35,6 @@ test('every feature page is reachable from the features menu with its own headli
     ['ad-blocking', 'private-tabs', 'security'],
     ['command-palette', 'reopen-closed-tabs', 'profiles', 'sync', 'workspaces'],
   ].map(group => group.map(slug => `/features/${slug}`)));
-  assert.match(features.foot.note, /^Fourteen guides\./);
   const pages = fs.readdirSync(path.join(ROOT, 'site/src/pages/features')).filter(f => f.endsWith('.astro')).map(f => `/features/${f.replace('.astro', '')}`);
   assert.deepEqual(links.map(l => l.href).sort(), pages.sort(), 'one link per feature page, no more');
   for (const link of links) {


### PR DESCRIPTION
## Summary
- replace the defensive Features megamenu footer checklist with Blanc’s benefit-led line
- keep the v1.15 website claim ledger aligned
- stop coupling navigation coverage to the old prose

## Verification
- node --test test/unit/website-feature-evidence.test.js test/unit/site-navigation.test.js
- npm run site:build