### PR TITLE
Explain Blanc's browser security boundary plainly

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ surface, so Blanc treats runtime configuration, permissions, dependencies,
 and release integrity as explicit controls:
 
 - Public web tabs run with Chromium sandboxing enabled, Node integration
-  disabled, and context isolation enabled. Ordinary sites receive no
-  privileged Blanc bridge.
+  disabled, and context isolation enabled. Blanc-owned pages such as Settings
+  and History use a narrow internal connection to the app. Regular websites
+  do not get that connection, which helps keep a malicious or compromised site
+  from reaching tabs, history, settings, or browser controls.
 - Permissions deny by default. Camera, microphone, location, and notifications
   require per-site decisions; screen capture and other unhandled permissions
   are refused.


### PR DESCRIPTION
The README described the released tab security boundary with internal bridge terminology that was hard to understand. This replaces it with a plain explanation: Blanc-owned pages use a narrow internal connection, while regular websites do not get access to tabs, history, settings, or browser controls through it.

Validation: checked the wording against the v1.15.0 `tab-view.js`, `pages.js`, and `permissions.js` implementation; `git diff --check` passes.
