### PR TITLE
Fix Mahjong final score separator artifacts

### DIFF
--- a/src/renderer/pages/mahjong.css
+++ b/src/renderer/pages/mahjong.css
@@ -1574,6 +1574,12 @@
   letter-spacing: -0.055em;
   text-shadow: 0 1px 0 #fff, 0 3px 0 #a97925, 0 7px 0 rgba(46, 30, 6, 0.72), 0 13px 24px rgba(0, 8, 6, 0.58), 0 0 30px rgba(242, 196, 79, 0.32);
 }
+.mj-win-score-separator {
+  color: #f3deb0;
+  -webkit-text-fill-color: #f3deb0;
+  -webkit-text-stroke: 0.35px rgba(91, 57, 8, 0.52);
+  text-shadow: 0 3px 8px rgba(46, 30, 6, 0.52);
+}
 .mj-win-unit { margin-top: 11px; color: var(--mj-muted); font: 720 10px/1 var(--font-mono); letter-spacing: 0.17em; text-transform: uppercase; }
 .mj-win-best {
   min-height: 28px;

--- a/src/renderer/pages/mahjong.js
+++ b/src/renderer/pages/mahjong.js
@@ -1247,6 +1247,26 @@ function recordCompletion() {
   return Boolean(updated);
 }
 
+function renderWinScore(target, { isBurst, score, time }) {
+  if (!isBurst) {
+    target.textContent = time;
+    return;
+  }
+
+  target.replaceChildren();
+  for (const part of new Intl.NumberFormat().formatToParts(score)) {
+    if (part.type !== 'group') {
+      target.append(part.value);
+      continue;
+    }
+
+    const separator = document.createElement('span');
+    separator.className = 'mj-win-score-separator';
+    separator.textContent = part.value;
+    target.append(separator);
+  }
+}
+
 function showWin() {
   const best = bestForGame();
   const win = document.getElementById('mjWin');
@@ -1254,9 +1274,7 @@ function showWin() {
   const time = formatMs(game.elapsedMs);
   const label = isBurst ? `${game.score.toLocaleString()} points. ${time}` : time;
   win.dataset.mode = isBurst ? 'burst' : 'classic';
-  document.getElementById('mjWinScore').textContent = isBurst
-    ? game.score.toLocaleString()
-    : time;
+  renderWinScore(document.getElementById('mjWinScore'), { isBurst, score: game.score, time });
   document.getElementById('mjWinUnit').textContent = isBurst ? 'points' : 'clear time';
   document.getElementById('mjWinTime').textContent = time;
   const record = document.getElementById('mjWinBest');

--- a/test/unit/mahjong-page.test.js
+++ b/test/unit/mahjong-page.test.js
@@ -523,11 +523,14 @@ test('completion results promote the score and separate time from Burst performa
   assert.match(html, /class="mj-win-particles" src="mahjong-combo-particles\.png"/);
   assert.match(html, /class="mj-win-glint" src="mahjong-combo-glint\.png"/);
   assert.match(controller, /win\.dataset\.mode = isBurst \? 'burst' : 'classic'/);
-  assert.match(controller, /getElementById\('mjWinScore'\)\.textContent = isBurst[\s\S]*game\.score\.toLocaleString\(\)[\s\S]*: time/);
+  assert.match(controller, /renderWinScore\(document\.getElementById\('mjWinScore'\), \{ isBurst, score: game\.score, time \}\)/);
+  assert.match(controller, /new Intl\.NumberFormat\(\)\.formatToParts\(score\)/);
+  assert.match(controller, /separator\.className = 'mj-win-score-separator'/);
   assert.match(controller, /getElementById\('mjWinTime'\)\.textContent = time/);
   assert.match(controller, /record\.classList\.toggle\('is-record', game\._outcome === 'record' \|\| game\._outcome === 'first'\)/);
   assert.match(styles, /\.mj-win-result\s*\{[^}]*border-radius:\s*22px[^}]*radial-gradient[^}]*box-shadow:/);
   assert.match(styles, /\.mj-win-score\s*\{[^}]*clamp\(46px, 6\.2vw, 64px\)[^}]*text-shadow:/);
+  assert.match(styles, /\.mj-win-score-separator\s*\{[^}]*-webkit-text-fill-color:\s*#f3deb0;[^}]*text-shadow:\s*0 3px 8px/);
   assert.match(styles, /\.mj-win-stats\s*\{[^}]*grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\)/);
   assert.match(styles, /@keyframes mj-win-particles/);
   assert.match(styles, /@keyframes mj-win-glint/);


### PR DESCRIPTION
## Summary
- render locale-aware score grouping separators as isolated spans
- keep dimensional digit styling while giving separators a restrained shadow
- add regression coverage for final-score rendering

## Verification
- node --test test/unit/mahjong-page.test.js
- full unit suite passed before rebasing
- visually verified the 13,400 completion result in Chromium