### PR TITLE
Release Blanc 1.15.1 with Chromium security fix

### DIFF
--- a/compliance/THIRD_PARTY_NOTICES.txt
+++ b/compliance/THIRD_PARTY_NOTICES.txt
@@ -41,7 +41,7 @@ RUNTIME NPM COMPONENTS
 
 EMBEDDED FRAMEWORK
 
-- Electron 44.1.1 — MIT — https://github.com/electron/electron
+- Electron 44.2.0 — MIT — https://github.com/electron/electron
   Electron embeds Chromium, Node.js, V8, and other upstream work. LICENSE.electron.txt and
   LICENSES.chromium.html are copied beside this notice in every packaged application.
 

--- a/compliance/root-lock-sbom.cdx.json
+++ b/compliance/root-lock-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:root:blanc@1.15.0",
+      "bom-ref": "application:root:blanc@1.15.1",
       "name": "blanc dependency lock",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "description": "Complete root npm supply-chain inventory, including development and optional packages."
     },
     "properties": [
@@ -7629,14 +7629,14 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/electron@44.1.1",
+      "bom-ref": "pkg:npm/electron@44.2.0",
       "name": "electron",
-      "version": "44.1.1",
+      "version": "44.2.0",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "376582ab6b1b3a4a9082f5c9631da54ba5223bc6c5f98afaeedac39d2e8929ad96c5309142c0231a5e7b494b5d5bd87aaf93e576e0458c8871860777773bf586"
+          "content": "a0ad6272385aa69df1b1467270ef5665a2e67778499c0ee27a86c2e26a5db4ed6910df8f3c65a90379b5320cf3b9cd70cd20f659a8b8cdc1f8c9fa4626ac4530"
         }
       ],
       "licenses": [
@@ -7646,7 +7646,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/electron@44.1.1",
+      "purl": "pkg:npm/electron@44.2.0",
       "properties": [
         {
           "name": "blanc:development",
@@ -7668,7 +7668,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/electron/-/electron-44.1.1.tgz"
+          "url": "https://registry.npmjs.org/electron/-/electron-44.2.0.tgz"
         }
       ]
     },
@@ -18197,7 +18197,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:root:blanc@1.15.0",
+      "ref": "application:root:blanc@1.15.1",
       "dependsOn": [
         "pkg:npm/%401password/sdk@0.5.0",
         "pkg:npm/%40cucumber/cucumber@13.2.1",
@@ -18206,7 +18206,7 @@
         "pkg:npm/%40ghostery/adblocker@2.18.2",
         "pkg:npm/electron-builder@26.15.3",
         "pkg:npm/electron-updater@6.8.9",
-        "pkg:npm/electron@44.1.1",
+        "pkg:npm/electron@44.2.0",
         "pkg:npm/playwright@1.62.1",
         "pkg:npm/sharp@0.35.3"
       ]
@@ -19280,7 +19280,7 @@
       ]
     },
     {
-      "ref": "pkg:npm/electron@44.1.1",
+      "ref": "pkg:npm/electron@44.2.0",
       "dependsOn": [
         "pkg:npm/%40electron-internal/extract-zip@1.0.4",
         "pkg:npm/%40electron/get@5.0.0",

--- a/compliance/runtime-sbom.cdx.json
+++ b/compliance/runtime-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:runtime:blanc@1.15.0",
+      "bom-ref": "application:runtime:blanc@1.15.1",
       "name": "Blanc",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "description": "Shipped desktop runtime: npm closure, Electron framework, bundled fonts, and blocker data provenance."
     },
     "properties": [
@@ -1036,14 +1036,14 @@
     },
     {
       "type": "framework",
-      "bom-ref": "pkg:npm/electron@44.1.1",
+      "bom-ref": "pkg:npm/electron@44.2.0",
       "name": "electron",
-      "version": "44.1.1",
+      "version": "44.2.0",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "376582ab6b1b3a4a9082f5c9631da54ba5223bc6c5f98afaeedac39d2e8929ad96c5309142c0231a5e7b494b5d5bd87aaf93e576e0458c8871860777773bf586"
+          "content": "a0ad6272385aa69df1b1467270ef5665a2e67778499c0ee27a86c2e26a5db4ed6910df8f3c65a90379b5320cf3b9cd70cd20f659a8b8cdc1f8c9fa4626ac4530"
         }
       ],
       "licenses": [
@@ -1053,7 +1053,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/electron@44.1.1",
+      "purl": "pkg:npm/electron@44.2.0",
       "properties": [
         {
           "name": "blanc:declaration",
@@ -1067,7 +1067,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/electron/-/electron-44.1.1.tgz"
+          "url": "https://registry.npmjs.org/electron/-/electron-44.2.0.tgz"
         }
       ]
     },
@@ -1704,7 +1704,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:runtime:blanc@1.15.0",
+      "ref": "application:runtime:blanc@1.15.1",
       "dependsOn": [
         "asset:blanc-adblock-seed",
         "asset:inter-font",
@@ -1712,7 +1712,7 @@
         "pkg:npm/%401password/sdk@0.5.0",
         "pkg:npm/%40ghostery/adblocker-electron@2.18.2",
         "pkg:npm/electron-updater@6.8.9",
-        "pkg:npm/electron@44.1.1"
+        "pkg:npm/electron@44.2.0"
       ]
     },
     {
@@ -1856,7 +1856,7 @@
       ]
     },
     {
-      "ref": "pkg:npm/electron@44.1.1",
+      "ref": "pkg:npm/electron@44.2.0",
       "dependsOn": []
     },
     {

--- a/docs/press/release-notes/v1.15.1.md
+++ b/docs/press/release-notes/v1.15.1.md
@@ -1,0 +1,9 @@
+# Blanc 1.15.1
+
+## Security
+
+- **Chromium's actively exploited V8 vulnerability is patched.** Blanc now runs on Electron 44.2.0, which carries the upstream fix for CVE-2026-85046. The flaw allowed a malicious page to execute code inside Chromium's renderer sandbox; it was not itself a sandbox escape. Update promptly.
+
+## Fixed
+
+- Thousands separators on the Mahjong Burst completion score now render cleanly instead of inheriting the score's dimensional text effect.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18,7 +18,7 @@
         "@cucumber/cucumber": "^13.2.1",
         "@electron/asar": "4.3.0",
         "@ghostery/adblocker": "^2.18.2",
-        "electron": "^44.1.1",
+        "electron": "^44.2.0",
         "electron-builder": "^26.15.3",
         "playwright": "^1.62.1",
         "sharp": "^0.35.3"
@@ -2594,9 +2594,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "44.1.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-44.1.1.tgz",
-      "integrity": "sha512-N2WCq2sbOkqQgvXJYx2lS6UiO8bF+Yr67trDnS6JKa2WxTCRQsAjGl57SUtdW9h6r5PlduBFjIhxhgd3dzv1hg==",
+      "version": "44.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-44.2.0.tgz",
+      "integrity": "sha512-oK1icjhapp3xsUZycO9WZaLmd3hJnA7ieobC4mpdtO1pEN+PPGWpA3m1Mgzzuc1wzSD2Wai4zcH4yfpGJqxFMA==",
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",
@@ -62,7 +62,7 @@
     "@cucumber/cucumber": "^13.2.1",
     "@electron/asar": "4.3.0",
     "@ghostery/adblocker": "^2.18.2",
-    "electron": "^44.1.1",
+    "electron": "^44.2.0",
     "electron-builder": "^26.15.3",
     "playwright": "^1.62.1",
     "sharp": "^0.35.3"

--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -746,16 +746,23 @@ function install(refs) {
               await new Promise((resolve) => requestAnimationFrame(() => resolve()));
             }
             const actionRect = lastAction.getBoundingClientRect();
+            const bodyRect = document.body.getBoundingClientRect();
+            const cardStyle = getComputedStyle(card);
             return {
               card: { left: cardRect.left, top: cardRect.top, right: cardRect.right, bottom: cardRect.bottom },
               wrap: { left: wrapRect.left, top: wrapRect.top, right: wrapRect.right, bottom: wrapRect.bottom },
+              body: { left: bodyRect.left, top: bodyRect.top, right: bodyRect.right, bottom: bodyRect.bottom },
               viewport: { left: 0, top: 0, right: innerWidth, bottom: innerHeight },
               centerDeltaX: Math.abs((cardRect.left + cardRect.right - innerWidth) / 2),
               centerDeltaY: Math.abs((cardRect.top + cardRect.bottom - innerHeight) / 2),
+              documentClientWidth: document.documentElement.clientWidth,
+              bodyClientWidth: document.body.clientWidth,
+              bodyScrollWidth: document.body.scrollWidth,
+              computedLeft: cardStyle.left,
               clientHeight: card.clientHeight,
               scrollHeight: card.scrollHeight,
               scrollTop: card.scrollTop,
-              overflowY: getComputedStyle(card).overflowY,
+              overflowY: cardStyle.overflowY,
               actionInitiallyVisible,
               actionVisibleAfterScroll:
                 actionRect.top >= cardRect.top - 1 && actionRect.bottom <= cardRect.bottom + 1,

--- a/src/renderer/pages/mahjong.css
+++ b/src/renderer/pages/mahjong.css
@@ -1491,7 +1491,9 @@
 .mj-win {
   position: fixed;
   z-index: 40;
-  inset: 50% auto auto 50%;
+  /* Viewport units keep the card centered even when the page's vertical
+     scrollbar briefly changes the fixed-position containing block width. */
+  inset: 50% auto auto 50vw;
   transform: translate(-50%, -50%);
   width: min(520px, calc(100% - 28px));
   max-height: calc(100% - 28px);

--- a/test/desktop/steps/newtab-layouts.steps.js
+++ b/test/desktop/steps/newtab-layouts.steps.js
@@ -226,7 +226,10 @@ Then('the embedded mahjong game is ready', async function () {
   assert.ok(game.dockButtonGap >= 13.5, `dock controls are too close (${game.dockButtonGap}px)`);
   const completion = await this.call('readMahjongCompletionGeometry');
   assert.ok(completion, 'completion geometry should be measurable');
-  assert.ok(completion.centerDeltaX <= 1, `completion x center drifted ${completion.centerDeltaX}px`);
+  assert.ok(
+    completion.centerDeltaX <= 1,
+    `completion x center drifted ${completion.centerDeltaX}px: ${JSON.stringify(completion)}`
+  );
   assert.ok(
     completion.centerDeltaY <= 1,
     `completion y center drifted ${completion.centerDeltaY}px: ${JSON.stringify(completion)}`

--- a/test/unit/compliance-model.test.js
+++ b/test/unit/compliance-model.test.js
@@ -29,7 +29,7 @@ test('runtime SBOM covers npm closure, Electron, fonts, and blocker provenance',
 
   assert.equal(generated.runtime.runtimePackages.length, 32);
   assert.equal(sbom.components.length, 39);
-  assert.ok(refs.has('pkg:npm/electron@44.1.1'));
+  assert.ok(refs.has('pkg:npm/electron@44.2.0'));
   assert.ok(refs.has('pkg:npm/%401password/sdk@0.5.0'));
   assert.ok(refs.has('pkg:npm/%401password/sdk-core@0.5.0'));
   assert.ok(refs.has('asset:inter-font'));
@@ -42,7 +42,7 @@ test('runtime SBOM covers npm closure, Electron, fonts, and blocker provenance',
   assert.equal([...refs].some((ref) => ref.includes('electron-builder@')), false);
 
   const root = sbom.dependencies.find((item) => item.ref.startsWith('application:runtime:'));
-  assert.ok(root.dependsOn.includes('pkg:npm/electron@44.1.1'));
+  assert.ok(root.dependsOn.includes('pkg:npm/electron@44.2.0'));
   assert.ok(root.dependsOn.includes('asset:blanc-adblock-seed'));
   const seed = sbom.dependencies.find((item) => item.ref === 'asset:blanc-adblock-seed');
   assert.deepEqual(seed.dependsOn, [


### PR DESCRIPTION
## Summary
- bump Blanc to 1.15.1 and Electron to 44.2.0
- carry Electron's V8 backport for CVE-2026-85046
- regenerate shipped compliance notices and SBOMs
- keep the Mahjong completion card viewport-centered under the new Chromium build and improve failure diagnostics
- add truthful security release notes (renderer code execution, not a sandbox escape)

## Verification
- `npm run release:verify:press`
- 1,443 unit tests passed
- 130 desktop scenarios / 802 steps passed
- cold launch, OAuth, DNS, production dependency audit, compliance, site build, and SEO passed
- Mahjong F35-3 passed 10 consecutive no-retry Electron runs

## Upstream evidence
- Electron 44.2.0 release: https://github.com/electron/electron/releases/tag/v44.2.0
- Electron V8 backport: https://github.com/electron/electron/pull/53479
- Chrome advisory: https://chromereleases.googleblog.com/2026/09/stable-channel-update-for-desktop_01882797386.html