### PR TITLE
Use Sunrise icon in Bring Your Tabs

### DIFF
--- a/src/renderer/pages/tab-import.html
+++ b/src/renderer/pages/tab-import.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; script-src 'self'; font-src 'self'; worker-src 'self';" />
   <title>Bring Your Tabs</title>
-  <link rel="icon" href="icon.svg" />
+  <link rel="icon" type="image/png" href="icon-sunrise.png" />
   <link rel="stylesheet" href="pages.css" />
 </head>
 <body class="sheet">

--- a/test/unit/brand-assets.test.js
+++ b/test/unit/brand-assets.test.js
@@ -90,7 +90,7 @@ test('all app icon variants and platform copies use their canonical identity sou
 test('internal pages use Sunrise artwork instead of the retired B favicon', () => {
   const pages = [
     'auth', 'bookmarks', 'downloads', 'error', 'history',
-    'mahjong', 'newtab', 'settings', 'shortcuts',
+    'mahjong', 'newtab', 'settings', 'shortcuts', 'tab-handoff', 'tab-import',
   ];
   for (const page of pages) {
     const html = source(`src/renderer/pages/${page}.html`);


### PR DESCRIPTION
## Summary
- replace the retired B favicon in the Bring Your Tabs wizard with the canonical Sunrise PNG
- cover both tab-import surfaces in the shared internal-page brand regression test

## Verification
- `npm run brand:check`
- focused brand and tab-import unit tests: 18 passed
- full unit suite: 1,564 passed
- `npm run test:tab-handoff`

No release or deployment is included.