### PR TITLE
Default tab handoffs to the current Blanc window

### DIFF
--- a/plugins/blanc-tab-import/skills/import-open-tabs/SKILL.md
+++ b/plugins/blanc-tab-import/skills/import-open-tabs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: import-open-tabs
-description: Copy the current Chrome, Edge, Brave, Opera, or Vivaldi window into a new Blanc window through a private one-time handoff. Use when a user asks to open, move, copy, or import their current browser tabs into Blanc.
+description: Copy the current Chrome, Edge, Brave, Opera, or Vivaldi window into the current Blanc window through a private one-time handoff, with a new window available as an explicit choice in Blanc. Use when a user asks to open, move, copy, or import their current browser tabs into Blanc.
 ---
 
 # Import open tabs into Blanc

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1339,17 +1339,24 @@ function flushExternalUrls() {
   openExternalUrls(pendingExternalUrls.splice(0));
 }
 
-function acceptPendingTabHandoff() {
+function acceptPendingTabHandoff(destination = 'current-window') {
+  if (!['current-window', 'new-window'].includes(destination)) {
+    return { ok: false, error: 'invalid-destination' };
+  }
   if (pendingTabHandoff?.state !== 'ready' || pendingTabHandoff.runtimeId !== rt().id) {
     return { ok: false, error: 'unavailable' };
   }
   const accepted = pendingTabHandoff;
-  pendingTabHandoff = null;
-  hideUtilitySheet({ refocusContent: false });
   const result = openTabHandoffWindow({
+    destination,
+    reviewRuntime: rt(),
     profileId: accepted.profileId,
     handoffTabs: accepted.payload.tabs,
   });
+  if (result.ok) {
+    pendingTabHandoff = null;
+    hideUtilitySheet({ refocusContent: false });
+  }
   return result;
 }
 
@@ -7258,22 +7265,35 @@ function focusDockActiveWindow() {
   setFocusedLocalProfile(primaryRuntime.profileId);
 }
 
-function openTabHandoffWindow({ profileId: requestedProfileId, handoffTabs } = {}) {
+/** Import into the review window, or an explicitly requested scratch window,
+ * through the same transactional quiet-tab batch
+ * seam used by Bring Your Tabs. The relay supplies no groups, pins, or
+ * favicons; source order remains authoritative and its active row wakes. */
+function openTabHandoffWindow({
+  profileId: requestedProfileId, handoffTabs, reviewRuntime,
+  destination = 'current-window',
+} = {}) {
+  if (!['current-window', 'new-window'].includes(destination)) {
+    return { ok: false, error: 'invalid-destination' };
+  }
   if (!Array.isArray(handoffTabs) || !handoffTabs.length
     || handoffTabs.length > MAX_TAB_IMPORT_TABS) {
     return { ok: false, error: 'invalid-handoff' };
   }
-  const profileId = localProfiles.getLocalProfile(requestedProfileId)?.id
-    ?? DEFAULT_PROFILE_ID;
-  if (profileDeletions.hasPendingProfileDeletion(profileId)) {
+  const profileId = localProfiles.getLocalProfile(requestedProfileId)?.id;
+  if (!profileId || profileDeletions.hasPendingProfileDeletion(profileId)) {
     return { ok: false, error: 'profile-unavailable' };
   }
-
-  const runtime = windowRuntimes.createRuntime({
+  if (!reviewRuntime?.window || reviewRuntime.window.isDestroyed()
+    || reviewRuntime.profileId !== profileId) {
+    return { ok: false, error: 'unavailable' };
+  }
+  const createdWindow = destination === 'new-window';
+  const runtime = createdWindow ? windowRuntimes.createRuntime({
     id: createWindowRuntimeId(),
     profileId,
-  });
-  createMainWindow(runtime);
+  }) : reviewRuntime;
+  if (createdWindow) createMainWindow(runtime);
 
   const result = withWindowRuntime(runtime, () => {
     const tabSpecs = handoffTabs.map((tab, index) => ({
@@ -7285,20 +7305,40 @@ function openTabHandoffWindow({ profileId: requestedProfileId, handoffTabs } = {
       pinned: false,
     }));
     const priorPersistenceSuspended = sessionPersistenceSuspended;
+    const priorTabOrder = [...runtime.tabOrder];
+    const priorActiveTabId = runtime.activeTabId;
+    const priorActivationHistory = [...runtime.activationHistory];
+    const priorLastActiveByCluster = new Map(runtime.lastActiveByCluster);
     let batch;
     let activeTabId = null;
     sessionPersistenceSuspended = true;
     tabStateBroadcastSuppressionDepth += 1;
     try {
-      batch = createQuietTabsBatch(runtime, tabSpecs, { insertAt: 0 });
-      if (batch.error) return { ok: false, error: batch.error };
+      batch = createQuietTabsBatch(runtime, tabSpecs, { insertAt: priorTabOrder.length });
+      if (batch.error) throw new Error(batch.error);
       const activeIndex = handoffTabs.findIndex((tab) => tab.active === true);
       activeTabId = batch.tabIds[activeIndex >= 0 ? activeIndex : 0] ?? null;
-      if (!activeTabId) return { ok: false, error: 'invalid-handoff' };
-      setActiveTab(activeTabId, { focusContent: true });
+      if (!activeTabId) throw new Error('invalid-handoff');
+      setActiveTab(activeTabId, { focusContent: true, dismissUtilitySheet: false });
       if (rt().activeTabId !== activeTabId || !liveContents(tabs.get(activeTabId))) {
-        return { ok: false, error: 'activation-failed' };
+        throw new Error('activation-failed');
       }
+    } catch {
+      // The selected import may already own a live view. Close through the
+      // normal disposal path without creating undo entries or replacement tabs.
+      for (const id of batch?.tabIds ?? []) {
+        closeTab(id, { record: false, selectReplacement: false });
+      }
+      runtime.tabOrder = priorTabOrder;
+      if (priorActiveTabId && tabs.has(priorActiveTabId)) {
+        // Force reattachment even if activation threw after detaching the old view.
+        runtime.activeTabId = null;
+        setActiveTab(priorActiveTabId, { focusContent: false, dismissUtilitySheet: false });
+      }
+      runtime.activationHistory = priorActivationHistory;
+      runtime.lastActiveByCluster = priorLastActiveByCluster;
+      liveUtilitySheet(reviewRuntime)?.wc.focus();
+      return { ok: false, error: batch?.error ?? 'activation-failed', retryable: true };
     } finally {
       tabStateBroadcastSuppressionDepth -= 1;
       sessionPersistenceSuspended = priorPersistenceSuspended;
@@ -7315,7 +7355,7 @@ function openTabHandoffWindow({ profileId: requestedProfileId, handoffTabs } = {
     return { ok: true, runtimeId: runtime.id, tabIds: batch.tabIds };
   });
 
-  if (!result?.ok && runtime.window && !runtime.window.isDestroyed()) {
+  if (!result?.ok && createdWindow && runtime.window && !runtime.window.isDestroyed()) {
     runtime.window.destroy();
   }
   return result ?? { ok: false, error: 'unavailable' };
@@ -8181,7 +8221,7 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
     },
     tabHandoff: {
       get: () => pendingTabHandoffProjection(),
-      accept: () => acceptPendingTabHandoff(),
+      accept: (destination) => acceptPendingTabHandoff(destination),
       cancel: () => cancelPendingTabHandoff(),
     },
     tabImport: {
@@ -8509,12 +8549,12 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
         };
       },
       queueTabHandoffForTest: queueTabHandoff,
-      acceptTabHandoffForTest: () => {
+      acceptTabHandoffForTest: (destination) => {
         const owner = pendingTabHandoff
           ? windowRuntimes.all().find((runtime) => runtime.id === pendingTabHandoff.runtimeId)
           : null;
         return owner
-          ? withWindowRuntime(owner, acceptPendingTabHandoff)
+          ? withWindowRuntime(owner, () => acceptPendingTabHandoff(destination))
           : { ok: false, error: 'unavailable' };
       },
       cancelTabHandoffForTest: () => {

--- a/src/main/pages.js
+++ b/src/main/pages.js
@@ -138,8 +138,8 @@ function setupPages(hooks = {}) {
   // owns blanc://tab-import/ and its richer local-session organizer.
   handle('pages:tab-handoff:get', 'tab-handoff', () =>
     hooks.tabHandoff?.get?.() ?? { state: 'empty' });
-  handle('pages:tab-handoff:accept', 'tab-handoff', () =>
-    hooks.tabHandoff?.accept?.() ?? { ok: false, error: 'unavailable' });
+  handle('pages:tab-handoff:accept', 'tab-handoff', (destination) =>
+    hooks.tabHandoff?.accept?.(destination) ?? { ok: false, error: 'unavailable' });
   handle('pages:tab-handoff:cancel', 'tab-handoff', () =>
     hooks.tabHandoff?.cancel?.() ?? { ok: true });
 

--- a/src/main/tab-preload.js
+++ b/src/main/tab-preload.js
@@ -60,7 +60,7 @@ if (window.location.protocol === 'blanc:') {
       surface,
       tabHandoff: {
         get: () => invoke('pages:tab-handoff:get'),
-        accept: () => invoke('pages:tab-handoff:accept'),
+        accept: (destination) => invoke('pages:tab-handoff:accept', destination),
         cancel: () => invoke('pages:tab-handoff:cancel'),
       },
     };

--- a/src/main/test-hook.js
+++ b/src/main/test-hook.js
@@ -2128,7 +2128,7 @@ function install(refs) {
     serializedTabsPayload() { return serializedTabsPayload(); },
     tabHandoffState() { return getTabHandoffTestState(); },
     queueTabHandoff(url) { return queueTabHandoffForTest(String(url)); },
-    acceptTabHandoff() { return acceptTabHandoffForTest(); },
+    acceptTabHandoff(destination) { return acceptTabHandoffForTest(destination); },
     cancelTabHandoff() { return cancelTabHandoffForTest(); },
     sessionSyncSnapshot() {
       return syncSnapshot(getTabOrder().map((id) => tabs.get(id)), getGroups());

--- a/src/renderer/pages/tab-handoff.css
+++ b/src/renderer/pages/tab-handoff.css
@@ -30,6 +30,12 @@
   padding: 12px;
   line-height: 1.45;
 }
+.tab-handoff-destination {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 16px;
+}
 .tab-handoff-actions {
   display: flex;
   justify-content: flex-end;

--- a/src/renderer/pages/tab-handoff.html
+++ b/src/renderer/pages/tab-handoff.html
@@ -16,9 +16,12 @@
     <div id="error" class="tab-handoff-error" role="alert" hidden></div>
     <div id="list" class="row-list tab-handoff-list" aria-label="Tabs to import" hidden></div>
     <p id="skipped" class="hint" hidden></p>
+    <label class="tab-handoff-destination">
+      <input id="newWindow" type="checkbox" disabled /> Open in a new window
+    </label>
     <div class="tab-handoff-actions">
       <button id="cancel" type="button">Cancel</button>
-      <button id="accept" type="button" class="tab-handoff-primary" disabled>Open in new window</button>
+      <button id="accept" type="button" class="tab-handoff-primary" disabled>Open in this window</button>
     </div>
   </div>
   <script src="sheet.js"></script>

--- a/src/renderer/pages/tab-handoff.js
+++ b/src/renderer/pages/tab-handoff.js
@@ -7,6 +7,19 @@ const list = document.getElementById('list');
 const skipped = document.getElementById('skipped');
 const accept = document.getElementById('accept');
 const cancel = document.getElementById('cancel');
+const newWindow = document.getElementById('newWindow');
+let readyData = null;
+
+function updateDestination() {
+  accept.textContent = newWindow.checked ? 'Open in new window' : 'Open in this window';
+  if (!readyData) return;
+  const source = SOURCE_LABELS[readyData.sourceBrowser] || 'your other browser';
+  const count = readyData.tabs.length;
+  const destination = newWindow.checked
+    ? `a new ${readyData.profileName || 'Personal'} window`
+    : `this ${readyData.profileName || 'Personal'} window`;
+  summary.textContent = `${count} ${count === 1 ? 'tab' : 'tabs'} from ${source} will open in ${destination}. Only the selected imported tab loads now; the rest start quiet.`;
+}
 
 const SOURCE_LABELS = {
   chrome: 'Chrome',
@@ -25,6 +38,7 @@ function showError(message) {
   list.hidden = true;
   skipped.hidden = true;
   accept.disabled = true;
+  newWindow.disabled = true;
 }
 
 function render(data) {
@@ -40,9 +54,8 @@ function render(data) {
     showError(data?.message);
     return;
   }
-  const source = SOURCE_LABELS[data.sourceBrowser] || 'your other browser';
-  const count = data.tabs.length;
-  summary.textContent = `${count} ${count === 1 ? 'tab' : 'tabs'} from ${source} will open in a new ${data.profileName || 'Personal'} window. Only the selected tab loads now; the rest start quiet.`;
+  readyData = data;
+  updateDestination();
   list.replaceChildren();
   for (const tab of data.tabs) {
     const row = document.createElement('div');
@@ -73,19 +86,32 @@ function render(data) {
     skipped.hidden = false;
   }
   accept.disabled = false;
+  newWindow.disabled = false;
 }
+
+newWindow.addEventListener('change', updateDestination);
 
 accept.addEventListener('click', async () => {
   accept.disabled = true;
   cancel.disabled = true;
+  newWindow.disabled = true;
+  error.hidden = true;
   accept.textContent = 'Opening…';
   try {
-    const result = await api.accept();
-    if (!result?.ok) showError('This handoff is no longer available.');
+    const result = await api.accept(newWindow.checked ? 'new-window' : 'current-window');
+    if (!result?.ok) {
+      if (result?.retryable) {
+        error.textContent = 'Blanc could not open these tabs. Your existing tabs are unchanged. Try again.';
+        error.hidden = false;
+        accept.disabled = false;
+        newWindow.disabled = false;
+      } else showError('This handoff is no longer available.');
+    }
   } catch {
     showError('Blanc could not open this tab set. Try the handoff again.');
   } finally {
     cancel.disabled = false;
+    updateDestination();
   }
 });
 

--- a/test/desktop/tab-handoff-smoke.mjs
+++ b/test/desktop/tab-handoff-smoke.mjs
@@ -60,6 +60,13 @@ const closeServer = () => new Promise((resolve) => {
   server.close(resolve);
 });
 const deepLinkFor = (handoff) => `blanc-import://tabs?v=1&id=${handoff.id}&key=${handoff.key}`;
+// Page titles and wake completion can change independently while another
+// window imports; ownership, order, selection, and membership must not.
+const windowIdentity = (window) => ({
+  id: window.id, profileId: window.profileId, activeTabId: window.activeTabId,
+  tabs: window.tabs.map(({ id, url, private: isPrivate, pinned, groupId }) =>
+    ({ id, url, private: isPrivate, pinned, groupId })),
+});
 
 let app;
 try {
@@ -138,6 +145,9 @@ try {
   );
   assert.equal(ready.pending.sourceBrowser, 'safari');
   assert.equal(ready.pending.profileName, 'Personal');
+  const originalWindow = ready.windows[0];
+  const originalTabs = originalWindow.tabs;
+  assert.ok(originalTabs.length > 0, 'cold-start blank tab is retained');
   assert.deepEqual(ready.pending.tabs.map((tab) => [tab.title, tab.domain, tab.active]), [
     ['One', '127.0.0.1', false],
     ['Two', '127.0.0.1', true],
@@ -152,20 +162,26 @@ try {
 
   const accepted = await callTestHook(app, 'acceptTabHandoff');
   assert.equal(accepted.ok, true);
+  assert.equal(accepted.runtimeId, originalWindow.id);
+  assert.equal((await callTestHook(app, 'acceptTabHandoff')).ok, false, 'accept is one-shot');
   const imported = await waitForValue(
     () => callTestHook(app, 'tabHandoffState'),
     (state) => state.windows.find((window) => window.id === accepted.runtimeId)
-      ?.tabs.every((tab) => tab.active ? tab.live && !tab.asleep : !tab.live && tab.asleep),
+      ?.tabs.filter((tab) => accepted.tabIds.includes(tab.id))
+      .every((tab) => tab.active ? tab.live && !tab.asleep : !tab.live && tab.asleep),
     'one live imported tab and quiet background tabs',
     10_000,
   );
   const importedWindow = imported.windows.find((window) => window.id === accepted.runtimeId);
-  assert.deepEqual(importedWindow.tabs.map((tab) => tab.url), [
+  assert.equal(imported.windows.length, ready.windows.length);
+  assert.deepEqual(importedWindow.tabs.slice(0, originalTabs.length).map((tab) => tab.id), originalTabs.map((tab) => tab.id));
+  const importedTabs = importedWindow.tabs.filter((tab) => accepted.tabIds.includes(tab.id));
+  assert.deepEqual(importedTabs.map((tab) => tab.url), [
     `${relayOrigin}/page/one#keep`,
     `${relayOrigin}/page/two`,
     `${relayOrigin}/page/three`,
   ]);
-  assert.equal(importedWindow.tabs.filter((tab) => tab.live).length, 1);
+  assert.equal(importedTabs.filter((tab) => tab.live).length, 1);
   assert.equal(importedWindow.tabs.find((tab) => tab.active)?.url, `${relayOrigin}/page/two`);
   assert.equal(importedWindow.tabs.every((tab) => !tab.private && !tab.pinned && tab.groupId === null), true);
   assert.equal(pageLoads.get('/page/two'), 1);
@@ -175,7 +191,7 @@ try {
   const session = await callTestHook(app, 'persistedSessionData');
   const persisted = session.windows.find((window) => window.id === accepted.runtimeId);
   assert.deepEqual(persisted.urls, importedWindow.tabs.map((tab) => tab.url));
-  assert.equal(persisted.activeIndex, 1);
+  assert.equal(persisted.activeIndex, originalTabs.length + 1);
 
   // Retrying the still-valid second link after the first review completes is
   // claimable, and Cancel removes it without opening another window.
@@ -259,7 +275,7 @@ try {
 
   // Both entry paths coexist in one running app. Replacing either review
   // cancels only that review; the richer local flow still preserves pins and
-  // source groups, while handoff continues to open an isolated scratch window.
+  // source groups, while the handoff appends ungrouped tabs to that window.
   await callTestHook(app, 'focusWindow');
   const stagedLocal = await callTestHook(app, 'applyTabImportFixture', ['merge-existing', { stage: 'review' }]);
   assert.equal(stagedLocal.ok, true);
@@ -289,13 +305,65 @@ try {
   const secondAccepted = await callTestHook(app, 'acceptTabHandoff');
   assert.equal(secondAccepted.ok, true);
   const afterBoth = await callTestHook(app, 'tabHandoffState');
-  const separateWindow = afterBoth.windows.find((window) => window.id === secondAccepted.runtimeId);
-  assert.equal(separateWindow.tabs.length, 1);
-  assert.equal(separateWindow.tabs[0].groupId, null);
-  assert.equal(separateWindow.tabs[0].pinned, false);
+  assert.equal(secondAccepted.runtimeId, originalWindow.id);
+  const mergedWindow = afterBoth.windows.find((window) => window.id === secondAccepted.runtimeId);
+  const appended = mergedWindow.tabs.at(-1);
+  assert.equal(appended.groupId, null);
+  assert.equal(appended.pinned, false);
   const localAfter = await callTestHook(app, 'state');
-  assert.deepEqual(localAfter.tabOrder, localState.tabOrder);
+  assert.deepEqual(localAfter.tabOrder, [...localState.tabOrder, ...secondAccepted.tabIds]);
   assert.deepEqual(localAfter.groups, localState.groups);
+  assert.equal(mergedWindow.tabs.find((tab) => tab.id === localTabs[0].id).pinned, true);
+
+  // A named-profile review owns its destination even after another window
+  // gains focus. Exercise the actual page/preload/IPC acceptance bridge.
+  const named = await callTestHook(app, 'createProfileWindow', ['Handoff test']);
+  assert.equal(named.ok, true);
+  const namedHandoff = await makeHandoff('named-current');
+  await callTestHook(app, 'queueTabHandoff', [deepLinkFor(namedHandoff)]);
+  const namedReady = await waitForValue(() => callTestHook(app, 'tabHandoffState'),
+    (state) => state.pending.state === 'ready', 'named-profile review');
+  assert.equal(namedReady.pending.profileName, 'Handoff test');
+  const reviewContentsId = await waitForValue(() => app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows().find((win) => win.getTitle().includes('Handoff test'));
+    return window?.contentView.children.find((view) => view.webContents?.getURL() === 'blanc://tab-handoff/')?.webContents.id;
+  }), Boolean, 'named profile review document');
+  const reviewDom = (script) => app.evaluate(({ webContents }, { id, script }) =>
+    webContents.fromId(id).executeJavaScript(script), { id: reviewContentsId, script });
+  await waitForValue(() => reviewDom('!document.getElementById("accept").disabled'), Boolean, 'review ready for acceptance');
+  assert.equal(await reviewDom('document.getElementById("newWindow").checked'), false);
+  assert.equal(await reviewDom('document.getElementById("accept").textContent'), 'Open in this window');
+  await reviewDom('document.getElementById("newWindow").click()');
+  assert.equal(await reviewDom('document.getElementById("accept").textContent'), 'Open in new window');
+  assert.match(await reviewDom('document.getElementById("summary").textContent'), /a new Handoff test window/);
+  await reviewDom('document.getElementById("newWindow").click()');
+  await callTestHook(app, 'focusWindow');
+  const namedAccepted = await reviewDom('window.bowserPages.tabHandoff.accept()');
+  assert.equal(namedAccepted.ok, true);
+  assert.equal(namedAccepted.runtimeId, named.runtimeId);
+  const namedAfter = await callTestHook(app, 'tabHandoffState');
+  assert.equal(namedAfter.windows.length, namedReady.windows.length);
+  assert.equal(namedAfter.windows.find((window) => window.id === named.runtimeId).tabs.at(-1).url,
+    `${relayOrigin}/page/named-current`);
+  assert.deepEqual(windowIdentity(namedAfter.windows.find((window) => window.id === originalWindow.id)),
+    windowIdentity(namedReady.windows.find((window) => window.id === originalWindow.id)));
+
+  const explicitNew = await makeHandoff('explicit-new');
+  await callTestHook(app, 'queueTabHandoff', [deepLinkFor(explicitNew)]);
+  const beforeNew = await waitForValue(() => callTestHook(app, 'tabHandoffState'),
+    (state) => state.pending.state === 'ready', 'explicit new-window review');
+  assert.equal((await callTestHook(app, 'acceptTabHandoff', ['unexpected'])).error, 'invalid-destination');
+  assert.equal((await callTestHook(app, 'tabHandoffState')).pending.state, 'ready');
+  const newAccepted = await callTestHook(app, 'acceptTabHandoff', ['new-window']);
+  assert.equal(newAccepted.ok, true);
+  assert.notEqual(newAccepted.runtimeId, named.runtimeId);
+  const afterNew = await callTestHook(app, 'tabHandoffState');
+  assert.equal(afterNew.windows.length, beforeNew.windows.length + 1);
+  const newWindow = afterNew.windows.find((window) => window.id === newAccepted.runtimeId);
+  assert.equal(newWindow.profileId, named.profile.id);
+  assert.deepEqual(newWindow.tabs.map((tab) => tab.url), [`${relayOrigin}/page/explicit-new`]);
+  assert.deepEqual(afterNew.windows.filter((window) => window.id !== newAccepted.runtimeId).map(windowIdentity),
+    beforeNew.windows.map(windowIdentity));
 
   await closeServer();
   assert.equal(await callTestHook(app, 'queueTabHandoff', [deepLinkFor(unrelatedKey)]), true);

--- a/test/unit/tab-handoff-destination.test.js
+++ b/test/unit/tab-handoff-destination.test.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+const batchPolicy = require('../../src/main/tab-import-batch');
+
+const main = fs.readFileSync(path.join(__dirname, '../../src/main/main.js'), 'utf8');
+const between = (start, end) => main.slice(main.indexOf(start), main.indexOf(end, main.indexOf(start)));
+
+// Execute the shipping acceptance and batch functions with native resources
+// replaced by fakes, so failures can be injected after partial creation/wake.
+function harness() {
+  const tabs = new Map();
+  const owners = new Map();
+  const runtimes = [];
+  let current;
+  let serial = 0;
+  const calls = { closes: [], broadcasts: 0, hidden: 0, sheetFocused: 0 };
+  const control = { failCreate: 0, failActivation: false, createCount: 0 };
+  function runtime(id, profileId) {
+    const value = { id, profileId, tabOrder: [], activeTabId: null, groups: [],
+      activationHistory: [], lastActiveByCluster: new Map() };
+    value.window = { destroyed: false, isDestroyed() { return this.destroyed; },
+      show() {}, focus() {}, destroy() { this.destroyed = true; } };
+    runtimes.push(value);
+    return value;
+  }
+  const owner = runtime('review', 'work');
+  owner.tabOrder = ['existing'];
+  owner.activeTabId = 'existing';
+  owner.groups = [{ id: 'group', name: 'project', collapsed: true }];
+  owner.activationHistory = ['existing'];
+  owner.lastActiveByCluster.set('group', 'existing');
+  const existing = { id: 'existing', url: 'https://existing.test', live: true, pinned: true, groupId: 'group' };
+  tabs.set(existing.id, existing);
+  owners.set(existing.id, owner);
+  current = owner;
+  const context = vm.createContext({
+    ...batchPolicy, Map, tabs, popupChildCounts: new Map(),
+    MAX_TAB_IMPORT_TABS: 100, DEFAULT_PROFILE_ID: 'default',
+    sessionPersistenceSuspended: false, tabStateBroadcastSuppressionDepth: 0, tabCreationBatchDepth: 0,
+    pendingTabHandoff: { state: 'ready', runtimeId: owner.id, profileId: 'work', payload: { tabs: [
+      { url: 'https://one.test', title: 'One' }, { url: 'https://two.test', title: 'Two', active: true },
+    ] } },
+    focusedRuntime: runtime('other-focused-window', 'default'),
+    localProfiles: { getLocalProfile: (id) => ['default', 'work'].includes(id) ? { id } : null },
+    profileDeletions: { hasPendingProfileDeletion: () => false },
+    rt: () => current,
+    withWindowRuntime(target, fn) { const previous = current; current = target; try { return fn(); } finally { current = previous; } },
+    windowRuntimes: {
+      createRuntime: ({ id, profileId }) => runtime(id, profileId),
+      runtimeForTab: (id) => owners.get(id), detachTab: (id) => owners.delete(id),
+    },
+    createWindowRuntimeId: () => `new-${++serial}`,
+    createMainWindow() {},
+    forgetTabWebContentsIds() {},
+    createTab(url, options) {
+      if (++control.createCount === control.failCreate) return null;
+      const id = `tab-${++serial}`;
+      tabs.set(id, { id, url, ...options, live: false }); owners.set(id, current); current.tabOrder.push(id);
+      return id;
+    },
+    setActiveTab(id, options) {
+      assert.equal(options.dismissUtilitySheet, false);
+      current.activeTabId = id;
+      tabs.get(id).live = true;
+      current.activationHistory.push(id);
+      current.lastActiveByCluster.set('ungrouped', id);
+      if (control.failActivation && id !== 'existing') throw new Error('native attach failed after wake');
+    },
+    liveContents: (tab) => tab?.live ? {} : null,
+    closeTab(id, options) {
+      calls.closes.push({ id, ...options });
+      tabs.delete(id); owners.delete(id); current.tabOrder = current.tabOrder.filter((value) => value !== id);
+      if (current.activeTabId === id) current.activeTabId = null;
+    },
+    liveUtilitySheet: () => ({ wc: { focus: () => calls.sheetFocused++ } }),
+    setFocusedLocalProfile() {}, buildMenu() {},
+    broadcastTabs: () => calls.broadcasts++,
+    hideUtilitySheet: () => calls.hidden++,
+  });
+  vm.runInContext([
+    between('function destroyQuietTabRecord(', 'function broadcastTabImportSurfaceOnce('),
+    between('function acceptPendingTabHandoff(', "app.on('open-url'"),
+    between('function openTabHandoffWindow(', 'function openNewWindow(options'),
+  ].join('\n'), context);
+  return { context, owner, tabs, runtimes, calls, control, existing,
+    accept: (destination) => context.acceptPendingTabHandoff(destination) };
+}
+
+test('default appends to the review owner, preserving its existing group and pin', () => {
+  const h = harness();
+  const result = h.accept();
+  assert.equal(result.ok, true);
+  assert.equal(result.runtimeId, h.owner.id);
+  assert.equal(h.runtimes.length, 2);
+  assert.deepEqual([...h.owner.tabOrder], ['existing', ...result.tabIds]);
+  assert.equal(h.tabs.get('existing'), h.existing);
+  assert.equal(h.owner.groups[0].collapsed, true);
+  assert.equal(h.owner.activeTabId, result.tabIds[1]);
+  assert.equal(h.tabs.get(result.tabIds[0]).live, false);
+  assert.equal(h.tabs.get(result.tabIds[1]).groupId, null);
+  assert.equal(h.calls.broadcasts, 1);
+  assert.equal(h.context.pendingTabHandoff, null);
+  assert.equal(h.accept().error, 'unavailable');
+});
+
+test('explicit new-window uses the review profile and leaves the owner intact', () => {
+  const h = harness();
+  const result = h.accept('new-window');
+  assert.equal(result.ok, true);
+  assert.notEqual(result.runtimeId, h.owner.id);
+  assert.equal(h.runtimes.at(-1).profileId, 'work');
+  assert.deepEqual(h.owner.tabOrder, ['existing']);
+  assert.equal(h.owner.activeTabId, 'existing');
+});
+
+for (const destination of ['current-window', 'new-window']) {
+  for (const failure of ['insertion', 'activation']) {
+    test(`${destination}: ${failure} failure rolls back and permits a single retry`, () => {
+      const h = harness();
+      if (failure === 'insertion') h.control.failCreate = 2;
+      else h.control.failActivation = true;
+      const pending = h.context.pendingTabHandoff;
+      const result = h.accept(destination);
+      assert.equal(result.ok, false);
+      assert.equal(result.retryable, true);
+      assert.equal(h.context.pendingTabHandoff, pending);
+      assert.equal(h.calls.hidden, 0);
+      assert.equal(h.calls.broadcasts, 0);
+      assert.deepEqual([...h.tabs.keys()], ['existing']);
+      assert.deepEqual([...h.owner.tabOrder], ['existing']);
+      assert.equal(h.owner.activeTabId, 'existing');
+      assert.deepEqual([...h.owner.activationHistory], ['existing']);
+      assert.deepEqual([...h.owner.lastActiveByCluster], [['group', 'existing']]);
+      assert.equal(h.owner.window.destroyed, false);
+      if (destination === 'new-window') assert.equal(h.runtimes.at(-1).window.destroyed, true);
+      for (const close of h.calls.closes) {
+        assert.equal(close.record, false);
+        assert.equal(close.selectReplacement, false);
+      }
+      assert.equal(h.context.sessionPersistenceSuspended, false);
+      assert.equal(h.context.tabStateBroadcastSuppressionDepth, 0);
+      h.control.failCreate = 0;
+      h.control.failActivation = false;
+      const retried = h.accept(destination);
+      assert.equal(retried.ok, true);
+      assert.equal(h.tabs.size, 3);
+      assert.equal(h.accept(destination).error, 'unavailable');
+    });
+  }
+}
+
+test('rejects invalid destinations and closed/mismatched review windows without consuming the handoff', () => {
+  for (const destination of [null, {}, 1, 'other']) {
+    const h = harness();
+    assert.equal(h.accept(destination).error, 'invalid-destination');
+    assert.equal(h.context.pendingTabHandoff.state, 'ready');
+    assert.equal(h.tabs.size, 1);
+  }
+  for (const change of [(owner) => { owner.window.destroyed = true; }, (owner) => { owner.profileId = 'default'; }]) {
+    const h = harness(); change(h.owner);
+    assert.equal(h.accept().error, 'unavailable');
+    assert.equal(h.context.pendingTabHandoff.state, 'ready');
+    assert.equal(h.tabs.size, 1);
+  }
+});

--- a/test/unit/tab-handoff-review.test.js
+++ b/test/unit/tab-handoff-review.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, '../../src/renderer/pages/tab-handoff.js'), 'utf8');
+
+async function review() {
+  function element() {
+    return { checked: false, disabled: true, hidden: true, textContent: '', children: [], events: {},
+      append(...children) { this.children.push(...children); },
+      replaceChildren() { this.children = []; },
+      addEventListener(name, fn) { this.events[name] = fn; } };
+  }
+  const elements = Object.fromEntries(['summary', 'error', 'list', 'skipped', 'accept', 'cancel', 'newWindow']
+    .map((id) => [id, element()]));
+  const calls = [];
+  const control = { result: { ok: true } };
+  vm.runInNewContext(source, {
+    document: { getElementById: (id) => elements[id], createElement: element },
+    window: { bowserPages: { tabHandoff: {
+      get: async () => ({ state: 'ready', sourceBrowser: 'brave', profileName: 'Personal', tabs: [{ title: '<script>untrusted</script>', domain: 'example.test' }] }),
+      accept: async (destination) => { calls.push(destination); return control.result; },
+      cancel() {},
+    } } },
+  });
+  await Promise.resolve();
+  return { elements, calls, control };
+}
+
+test('review defaults to this window, updates destination copy, and sends the selected choice', async () => {
+  const { elements: e, calls } = await review();
+  assert.equal(e.newWindow.checked, false);
+  assert.equal(e.accept.textContent, 'Open in this window');
+  assert.match(e.summary.textContent, /this Personal window/);
+  assert.equal(e.list.children[0].children[0].children[0].textContent, '<script>untrusted</script>');
+  e.newWindow.checked = true;
+  e.newWindow.events.change();
+  assert.equal(e.accept.textContent, 'Open in new window');
+  assert.match(e.summary.textContent, /a new Personal window/);
+  await e.accept.events.click();
+  assert.deepEqual(calls, ['new-window']);
+  assert.equal(e.accept.disabled, true);
+});
+
+test('retryable failures keep the preview and destination usable for retry', async () => {
+  const { elements: e, calls, control } = await review();
+  control.result = { ok: false, retryable: true };
+  await e.accept.events.click();
+  assert.equal(e.error.hidden, false);
+  assert.equal(e.list.hidden, false);
+  assert.equal(e.accept.disabled, false);
+  assert.equal(e.newWindow.disabled, false);
+  assert.equal(e.cancel.disabled, false);
+  assert.equal(e.accept.textContent, 'Open in this window');
+  control.result = { ok: true };
+  await e.accept.events.click();
+  assert.deepEqual(calls, ['current-window', 'current-window']);
+});

--- a/test/unit/tab-import-preload.test.js
+++ b/test/unit/tab-import-preload.test.js
@@ -62,3 +62,14 @@ test('other internal hosts never receive tab-import capabilities', () => {
   assert.equal('tabImport' in bookmarks, false);
   assert.equal(loadForHost('tab-import', 'https:').exposed, null);
 });
+
+test('handoff preload forwards an optional destination without exposing other capabilities', async () => {
+  const loaded = loadForHost('tab-handoff');
+  assert.deepEqual(Object.keys(loaded.exposed.api.tabHandoff).sort(), ['accept', 'cancel', 'get']);
+  await loaded.exposed.api.tabHandoff.accept();
+  await loaded.exposed.api.tabHandoff.accept('new-window');
+  assert.deepEqual(loaded.invocations, [
+    ['pages:tab-handoff:accept', undefined],
+    ['pages:tab-handoff:accept', 'new-window'],
+  ]);
+});


### PR DESCRIPTION
Tab handoffs previously opened a separate Blanc window even when the review was shown in an existing window. Accepting a handoff now appends its tabs to that review window by default. An unchecked “Open in a new window” option preserves the separate-window workflow.

The destination stays bound to the review window and profile when focus changes. Existing tabs, groups, pins, and blank tabs remain intact. Imported tabs keep source order and only the selected imported tab wakes. Failed insertion or activation removes only the attempted imports, restores the prior selection, and keeps the review available for retry.

The acceptance bridge takes an optional validated destination; the relay and encrypted handoff formats are unchanged. The repository plugin description reflects the new default. Cross-window group sharing is outside this change.

Validation:
- 39 focused handoff, batch, and preload unit tests passed, including insertion/activation rollback and retry.
- macOS Electron handoff smoke test passed in an isolated temporary profile, covering cold launch, current-window imports, explicit new-window imports, named profiles, focus changes, cancellation, duplicate acceptance, and session persistence.
- `git diff --check` passed.

This PR does not publish a release or update the installed plugin.
