### PR TITLE
Restore and foreground Blanc for external links

### DIFF
--- a/docs/release-incidents/2026-09-09-external-link-activation-verification-deferral.md
+++ b/docs/release-incidents/2026-09-09-external-link-activation-verification-deferral.md
@@ -1,0 +1,34 @@
+# External-link activation merge verification deferral
+
+**Date:** 2026-09-09
+**Scope:** [PR #312](https://github.com/bnfy/blanc/pull/312)
+**Decision:** Squash merge may proceed after CI passes; the remaining native
+verification is deferred for merging, not waived for release.
+
+The owner requested “squash merge” after the PR summary explicitly identified
+the fresh signed-candidate and affected-Mac checks as pending. This records that
+merge authorization without treating the missing checks as passed.
+
+## Verified evidence
+
+- On the rebased source with Electron 44.2.0, all 1,609 unit tests passed.
+- The Electron external-link lifecycle and shared tab-handoff smokes passed,
+  including delayed-chrome hide/minimize cancellation and profile routing.
+- An earlier signed candidate, before the rebase, passed the standard macOS
+  LaunchServices matrix with ten hidden and ten minimized repetitions.
+
+## Deferred evidence and risk
+
+- Build and verify a fresh signed candidate from the merged source.
+- Confirm an actual email-link click on the affected Mac and delivery from
+  another desktop/full-screen Space. The owner's exact hidden/minimized
+  failure was not reproduced in the isolated baseline.
+- Complete the background-only LaunchServices matrix on the fresh candidate;
+  the earlier repeat was interrupted when Terminal became foreground.
+
+The exact reported failure or a native timing regression could remain despite
+the passing isolated checks. These cases remain unverified. Merging does not
+authorize a release, and this record does not waive the ordinary release gates.
+Complete the deferred checks before tagging or publishing a release containing
+the fix. Detailed prior evidence is in the
+[verification record](../verification/2026-09-09-external-link-activation.md).

--- a/docs/verification/2026-09-09-external-link-activation.md
+++ b/docs/verification/2026-09-09-external-link-activation.md
@@ -104,6 +104,9 @@ remain pending; no claim is made that these manual cases passed.
 The rebuilt artifact's complete background-only LaunchServices repeat also
 remains pending after the Terminal interruption described above.
 
-Do not merge, tag, or publish a release until the affected-Mac confirmation is
-recorded against a fresh signed candidate from the rebased PR head. The ordinary
-release protocol remains applicable.
+The owner subsequently authorized squash merge with these checks deferred for
+merging, as recorded in the
+[dated verification deferral](../release-incidents/2026-09-09-external-link-activation-verification-deferral.md).
+Before tagging or publishing a release, record the affected-Mac confirmation
+against a fresh signed candidate from the merged source. The ordinary release
+protocol remains applicable.

--- a/docs/verification/2026-09-09-external-link-activation.md
+++ b/docs/verification/2026-09-09-external-link-activation.md
@@ -1,0 +1,71 @@
+# External-link window activation — September 9, 2026
+
+Local implementation on `codex/fix-external-link-activation`, based on
+`c3a3eb44`. This is a signed local candidate, not a published release or an
+installation over the owner's existing Blanc.
+
+## Change
+
+External HTTP(S) handoffs explicitly unhide macOS Blanc and restore/focus the
+receiving window, with bounded native restore/activation follow-up. Pending
+focus is canceled on another handoff, window hide/minimize/close, app resignation,
+selection of another browser window, quit, or the two-second deadline.
+
+Warm URL requests retain their receiving window/profile while chrome loads.
+Cold requests wait for startup release and resolve against the restored window.
+An incoming URL recreates a closed browser window without depending on a
+separate app activation event. App activation preserves the last focused
+runtime instead of resetting it to primary. Chrome readiness no longer releases
+the startup URL gate before session restore and the blocker decision.
+
+## Evidence
+
+Host: macOS 27.0, build 26A5425a; Electron 44.1.1; macOS arm64.
+
+- Full unit suite: **1,583 passed, zero failed**. After that run, the additional
+  no-active-tab chrome-readiness test and the full focused activation/handoff/
+  Dock set passed (**35 tests**).
+- New Electron lifecycle smoke: **passed** cold launch, hidden, minimized,
+  combined hidden/minimized, no-window reopen without an `activate` event,
+  named-profile routing, and second-instance multi-URL selection.
+- Existing cold-launch focus smoke: **passed**.
+- Existing tab-import handoff smoke, which shares the activation helper: **passed**.
+- Acceptance dry run: **141 scenarios / 865 steps resolved**, no undefined steps;
+  this is a definition check, not execution of those scenarios.
+- Public `/Applications/Blanc.app` v1.15.0: native LaunchServices tests passed
+  background, hidden **10/10**, minimized **10/10**, and combined states, but
+  **failed after the last browser window was closed**. The requested URL never
+  appeared in a selected tab and no chrome window was available.
+- Signed candidate: the same native matrix **passed**, including closed-window
+  reopening and the check that later background reloads leave Finder frontmost.
+- Both baseline and candidate matrices were also run with `open -g`, which
+  delivers through LaunchServices without independently bringing Blanc forward.
+  The baseline again failed closed-window reopening; the candidate passed the
+  entire matrix, including **10 hidden and 10 minimized repetitions**.
+- Native assertions use AppKit's frontmost process ID and WindowServer's
+  onscreen browser window, in addition to the selected URL/tab. Foreground state
+  must remain stable for 500 ms. These are not renderer-focus proxies.
+- Candidate build completed the pinned signing/profile/entitlements verification,
+  all eight hardened fuses, packaged blocker byte checks, and packaged compliance
+  checks. Deep strict codesign verification passed outside the sandbox.
+
+Candidate: `dist/mac-arm64/Blanc.app` (local package version remains 1.15.0).
+The packaged main process files were byte-compared with this working tree.
+
+`app.asar` SHA-256:
+`d1991406642517c1aa900defa34a02e52e88aa9e8490d16e88c0db0a6bc58ffd`
+
+Signing identity: Developer ID Application: Anthony Loria (XYGUCY4498), pinned
+certificate SHA-1 `55283A84D3706D5A22386D5F002A0CD4845ECFD4`.
+This private candidate was not notarized or published.
+
+## Still pending
+
+The owner's exact hidden/minimized email-app failure was **not reproduced** in
+the isolated baseline. The email application and precise hide/minimize action
+have been requested so that path can be reproduced or owner-confirmed against
+the candidate. Actual email-link and other desktop/full-screen Space confirmation
+remain pending; no claim is made that these manual cases passed.
+
+Do not merge, tag, or publish a release until the affected-Mac confirmation is
+recorded. The ordinary release protocol remains applicable.

--- a/docs/verification/2026-09-09-external-link-activation.md
+++ b/docs/verification/2026-09-09-external-link-activation.md
@@ -1,8 +1,10 @@
 # External-link window activation — September 9, 2026
 
-Local implementation on `codex/fix-external-link-activation`, based on
-`c3a3eb44`. This is a signed local candidate, not a published release or an
-installation over the owner's existing Blanc.
+The original signed local candidate was built from `dc1b4b21`, based on
+`c3a3eb44`. It was not published or installed over the owner's existing Blanc.
+For the pull request, only the two activation-fix commits were rebased onto
+`1198878d` on `main` (version 1.15.1, Electron 44.2.0). The signed-candidate
+evidence below refers to the original base, not the rebased PR head.
 
 ## Change
 
@@ -21,7 +23,22 @@ separate app activation event. App activation preserves the last focused
 runtime instead of resetting it to primary. Chrome readiness no longer releases
 the startup URL gate before session restore and the blocker decision.
 
-## Evidence
+## PR validation after rebase
+
+Base: `1198878d`; Electron 44.2.0, with dependencies installed from the current
+lockfile. The main-process conflict resolution reapplied only the activation
+hunks and preserved upstream tab-handoff behavior.
+
+- Full unit suite: **1,609 passed, zero failed**.
+- Electron external-link lifecycle smoke: **passed**, including delayed-chrome
+  hide/minimize cancellation, cold startup, windowless reopening, profile
+  routing, and second-instance batches.
+- Shared tab-handoff smoke: **passed** on macOS.
+- The first lifecycle run could not establish the combined hidden/minimized
+  precondition. The test now waits for native minimization before hiding the
+  app, matching the packaged smoke's sequence; the complete rerun passed.
+
+## Original candidate evidence
 
 Host: macOS 27.0, build 26A5425a; Electron 44.1.1; macOS arm64.
 
@@ -66,8 +83,9 @@ Host: macOS 27.0, build 26A5425a; Electron 44.1.1; macOS arm64.
   all eight hardened fuses, packaged blocker byte checks, and packaged compliance
   checks. Deep strict codesign verification passed outside the sandbox.
 
-Candidate: `dist/mac-arm64/Blanc.app` (local package version remains 1.15.0).
-The packaged main process files were byte-compared with this working tree.
+Original candidate: `dist/mac-arm64/Blanc.app` (local package version 1.15.0).
+The packaged main process files were byte-compared with source at `dc1b4b21`.
+This artifact predates the PR rebase and does not certify the rebased head.
 
 `app.asar` SHA-256:
 `2574141de087a814702cc03edd1a044dd6ac04aa8cf168a73000555cf3c231f0`
@@ -87,4 +105,5 @@ The rebuilt artifact's complete background-only LaunchServices repeat also
 remains pending after the Terminal interruption described above.
 
 Do not merge, tag, or publish a release until the affected-Mac confirmation is
-recorded. The ordinary release protocol remains applicable.
+recorded against a fresh signed candidate from the rebased PR head. The ordinary
+release protocol remains applicable.

--- a/docs/verification/2026-09-09-external-link-activation.md
+++ b/docs/verification/2026-09-09-external-link-activation.md
@@ -10,6 +10,9 @@ External HTTP(S) handoffs explicitly unhide macOS Blanc and restore/focus the
 receiving window, with bounded native restore/activation follow-up. Pending
 focus is canceled on another handoff, window hide/minimize/close, app resignation,
 selection of another browser window, quit, or the two-second deadline.
+Cancellation also covers the queue's wait for chrome readiness: a later user
+hide/minimize cancels activation without dropping the URL. A fresh external
+handoff creates new foreground intent, including when Blanc is already hidden.
 
 Warm URL requests retain their receiving window/profile while chrome loads.
 Cold requests wait for startup release and resolve against the restored window.
@@ -22,12 +25,18 @@ the startup URL gate before session restore and the blocker decision.
 
 Host: macOS 27.0, build 26A5425a; Electron 44.1.1; macOS arm64.
 
-- Full unit suite: **1,583 passed, zero failed**. After that run, the additional
-  no-active-tab chrome-readiness test and the full focused activation/handoff/
-  Dock set passed (**35 tests**).
+- Full unit suite after the review correction: **1,594 passed, zero failed**.
+  The focused activation/handoff/Dock set passed (**45 tests**). The new
+  readiness-cancellation tests failed against the original implementation
+  before the correction.
 - New Electron lifecycle smoke: **passed** cold launch, hidden, minimized,
   combined hidden/minimized, no-window reopen without an `activate` event,
   named-profile routing, and second-instance multi-URL selection.
+- Review regression: reproduced hide/minimize being undone while recreated
+  chrome was delayed. Both deterministic Electron cases now **pass**: the
+  delivered URL appears exactly once, selection stays unchanged, the newer
+  hidden/minimized state survives readiness plus 2.2 seconds, and a fresh
+  external link restores the window normally.
 - Existing cold-launch focus smoke: **passed**.
 - Existing tab-import handoff smoke, which shares the activation helper: **passed**.
 - Acceptance dry run: **141 scenarios / 865 steps resolved**, no undefined steps;
@@ -38,10 +47,18 @@ Host: macOS 27.0, build 26A5425a; Electron 44.1.1; macOS arm64.
   appeared in a selected tab and no chrome window was available.
 - Signed candidate: the same native matrix **passed**, including closed-window
   reopening and the check that later background reloads leave Finder frontmost.
-- Both baseline and candidate matrices were also run with `open -g`, which
+- The candidate rebuilt after the review correction passed that matrix again.
+  Its first run stopped during Finder foreground setup before delivering the
+  seventh minimized-case URL; a complete rerun passed all cases. That stopped
+  run is not counted as a successful matrix.
+- The original baseline and candidate matrices were also run with `open -g`, which
   delivers through LaunchServices without independently bringing Blanc forward.
   The baseline again failed closed-window reopening; the candidate passed the
   entire matrix, including **10 hidden and 10 minimized repetitions**.
+- The rebuilt candidate's `open -g` repeat was **interrupted**, after background
+  and nine hidden cases passed: Terminal (PID 78831, independently identified
+  by process name) became frontmost during the tenth hidden case's stability
+  assertion. This is not counted as a completed matrix for the rebuilt artifact.
 - Native assertions use AppKit's frontmost process ID and WindowServer's
   onscreen browser window, in addition to the selected URL/tab. Foreground state
   must remain stable for 500 ms. These are not renderer-focus proxies.
@@ -53,7 +70,7 @@ Candidate: `dist/mac-arm64/Blanc.app` (local package version remains 1.15.0).
 The packaged main process files were byte-compared with this working tree.
 
 `app.asar` SHA-256:
-`d1991406642517c1aa900defa34a02e52e88aa9e8490d16e88c0db0a6bc58ffd`
+`2574141de087a814702cc03edd1a044dd6ac04aa8cf168a73000555cf3c231f0`
 
 Signing identity: Developer ID Application: Anthony Loria (XYGUCY4498), pinned
 certificate SHA-1 `55283A84D3706D5A22386D5F002A0CD4845ECFD4`.
@@ -66,6 +83,8 @@ the isolated baseline. The email application and precise hide/minimize action
 have been requested so that path can be reproduced or owner-confirmed against
 the candidate. Actual email-link and other desktop/full-screen Space confirmation
 remain pending; no claim is made that these manual cases passed.
+The rebuilt artifact's complete background-only LaunchServices repeat also
+remains pending after the Terminal interruption described above.
 
 Do not merge, tag, or publish a release until the affected-Mac confirmation is
 recorded. The ordinary release protocol remains applicable.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "test:tab-handoff": "node test/desktop/tab-handoff-smoke.mjs",
     "test:packaged:tab-handoff-protocol": "node test/desktop/packaged-tab-handoff-protocol-smoke.mjs",
     "test:cold-launch": "node test/desktop/cold-launch-smoke.mjs",
+    "test:external-links": "node test/desktop/external-links-smoke.mjs",
+    "test:packaged:external-links": "node test/desktop/packaged-external-links-smoke.mjs",
     "test:packaged:first-run": "node test/desktop/packaged-first-run-smoke.mjs",
     "test:packaged:migration": "node test/desktop/packaged-migration-smoke.mjs",
     "test:packaged:regressions": "node test/desktop/release-regressions-smoke.mjs",

--- a/src/main/dock-reopen.js
+++ b/src/main/dock-reopen.js
@@ -79,9 +79,10 @@ function createDockReopenLifecycle({
         liveContents,
       });
       if (!id && ensureStartTab) id = createStartTab();
-      if (!id) return null;
-      runtime.activeTabId = null; // force activation to perform a fresh attach
-      activateTab(id);
+      if (id) {
+        runtime.activeTabId = null; // force activation to perform a fresh attach
+        activateTab(id);
+      }
       flushExternalUrls();
       return id;
     },

--- a/src/main/external-url-handoff.js
+++ b/src/main/external-url-handoff.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { externalUrlActivationPlan, webUrlsFromArgv } = require('./startup-urls');
+
+/** OS URL delivery is independent of app activation and chrome loading.
+ * Pin each warm request to its receiving runtime; cold requests resolve only
+ * after session restore has chosen the startup window/profile. No page-load
+ * await belongs here: a selected tab should be visible while it loads. */
+function createExternalUrlHandoff({
+  isReady, isQuitting, getRuntime, ensureWindow, isWindowReady, withRuntime,
+  createTab, activateTab, revealWindow,
+}) {
+  let pending = [];
+  let generation = 0;
+  let flushing = false;
+
+  function flush() {
+    if (flushing || !isReady() || isQuitting()) return;
+    flushing = true;
+    try {
+      const entries = pending;
+      pending = [];
+      for (const entry of entries) {
+        const runtime = getRuntime(entry.runtime);
+        entry.runtime = runtime;
+        ensureWindow(runtime);
+        if (!isWindowReady(runtime)) {
+          pending.push(entry);
+          continue;
+        }
+        withRuntime(runtime, () => {
+          const id = createTab(entry.url);
+          if (id == null || !entry.activate || entry.generation !== generation) return;
+          activateTab(id);
+          revealWindow(runtime.window);
+        });
+      }
+    } finally {
+      flushing = false;
+    }
+  }
+
+  function open(urls) {
+    if (isQuitting()) return;
+    const plan = externalUrlActivationPlan(webUrlsFromArgv(urls));
+    if (!plan.length) return;
+    generation += 1;
+    const runtime = isReady() ? getRuntime() : null;
+    pending.push(...plan.map((entry) => ({ ...entry, runtime, generation })));
+    flush();
+  }
+
+  return { open, flush };
+}
+
+module.exports = { createExternalUrlHandoff };

--- a/src/main/external-url-handoff.js
+++ b/src/main/external-url-handoff.js
@@ -7,12 +7,61 @@ const { externalUrlActivationPlan, webUrlsFromArgv } = require('./startup-urls')
  * after session restore has chosen the startup window/profile. No page-load
  * await belongs here: a selected tab should be visible while it loads. */
 function createExternalUrlHandoff({
-  isReady, isQuitting, getRuntime, ensureWindow, isWindowReady, withRuntime,
+  application, isReady, isQuitting, getRuntime, ensureWindow, isWindowReady, withRuntime,
   createTab, activateTab, revealWindow,
 }) {
   let pending = [];
-  let generation = 0;
+  let activeIntent = null;
   let flushing = false;
+
+  // Cancellation must start at delivery, including the wait for new chrome.
+  // Cancel only foreground intent: every delivered URL still gets its tab.
+  function createRevealIntent() {
+    activeIntent?.cancel();
+    const initiallyHidden = application.isHidden?.() === true;
+    const listeners = [];
+    let cancelled = false;
+    let window = null;
+    const dispose = () => {
+      for (const remove of listeners) remove();
+      listeners.length = 0;
+      if (activeIntent === intent) activeIntent = null;
+    };
+    const cancel = () => {
+      cancelled = true;
+      dispose();
+    };
+    const listen = (emitter, event, callback = cancel) => {
+      emitter.on(event, callback);
+      listeners.push(() => emitter.removeListener(event, callback));
+    };
+    const intent = {
+      cancel,
+      trackWindow(target) {
+        if (cancelled || target === window) return;
+        // A replacement can receive the URL, but cannot inherit permission
+        // to foreground a window that the user has already closed.
+        if (window || !target || target.isDestroyed()) return cancel();
+        window = target;
+        for (const event of ['hide', 'minimize', 'closed']) listen(window, event);
+      },
+      consume() {
+        // Hiding an already inactive macOS app need not emit resignation or
+        // BrowserWindow.hide. Detect that transition before releasing chrome.
+        if (!initiallyHidden && application.isHidden?.()) cancel();
+        dispose();
+        return !cancelled;
+      },
+    };
+    for (const event of ['did-resign-active', 'before-quit', 'will-quit']) {
+      listen(application, event);
+    }
+    listen(application, 'browser-window-focus', (_event, focused) => {
+      if (window && focused !== window) cancel();
+    });
+    activeIntent = intent;
+    return intent;
+  }
 
   function flush() {
     if (flushing || !isReady() || isQuitting()) return;
@@ -24,13 +73,15 @@ function createExternalUrlHandoff({
         const runtime = getRuntime(entry.runtime);
         entry.runtime = runtime;
         ensureWindow(runtime);
+        entry.intent?.trackWindow(runtime.window);
         if (!isWindowReady(runtime)) {
           pending.push(entry);
           continue;
         }
         withRuntime(runtime, () => {
           const id = createTab(entry.url);
-          if (id == null || !entry.activate || entry.generation !== generation) return;
+          const shouldReveal = entry.intent?.consume();
+          if (id == null || !shouldReveal) return;
           activateTab(id);
           revealWindow(runtime.window);
         });
@@ -44,9 +95,9 @@ function createExternalUrlHandoff({
     if (isQuitting()) return;
     const plan = externalUrlActivationPlan(webUrlsFromArgv(urls));
     if (!plan.length) return;
-    generation += 1;
+    const intent = createRevealIntent();
     const runtime = isReady() ? getRuntime() : null;
-    pending.push(...plan.map((entry) => ({ ...entry, runtime, generation })));
+    pending.push(...plan.map(({ url, activate }) => ({ url, runtime, intent: activate ? intent : null })));
     flush();
   }
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1182,6 +1182,7 @@ if (!(acceptanceTestMode || app.requestSingleInstanceLock())) {
 // the command line, at startup or through 'second-instance'.
 let externalUrlsFlushable = false;
 const externalUrlHandoff = createExternalUrlHandoff({
+  application: app,
   isReady: () => externalUrlsFlushable,
   isQuitting: () => isQuitting,
   getRuntime: resolveExternalRuntime,

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -207,8 +207,9 @@ const {
   popupPlatformMainMenu,
 } = require('./platform-main-menu');
 const { showAboutPanel } = require('./about-panel');
-const { externalUrlActivationPlan, webUrlsFromArgv } = require('./startup-urls');
-const { bringExternalWindowToFront } = require('./window-activation');
+const { webUrlsFromArgv } = require('./startup-urls');
+const { bringExternalWindowToFront, externalWindowRuntime } = require('./window-activation');
+const { createExternalUrlHandoff } = require('./external-url-handoff');
 const { isForbiddenTopLevelUrl } = require('./top-level-url-policy');
 const { createTabImportSessionStore, SESSION_TTL_MS } = require('./tab-import-session');
 const {
@@ -1142,11 +1143,11 @@ if (!(acceptanceTestMode || app.requestSingleInstanceLock())) {
 } else {
   diagnostics.start();
   app.on('second-instance', (_e, commandLine) => {
-    const runtime = focusedRuntime ?? primaryRuntime;
+    const runtime = resolveExternalRuntime();
     withWindowRuntime(runtime, () => {
       openExternalUrls(urlsFromArgv(commandLine));
       for (const url of tabImportUrlsFromArgv(commandLine)) queueTabHandoff(url);
-      if (rt().window && !rt().window.isDestroyed()) {
+      if (!urlsFromArgv(commandLine).length && rt().window && !rt().window.isDestroyed()) {
         bringExternalWindowToFront(app, rt().window);
       }
     });
@@ -1179,8 +1180,19 @@ if (!(acceptanceTestMode || app.requestSingleInstanceLock())) {
 // delivers them via 'open-url' (which can fire before 'ready' — those queue
 // until the window and session restore are up); Windows/Linux pass them on
 // the command line, at startup or through 'second-instance'.
-const pendingExternalUrls = [];
 let externalUrlsFlushable = false;
+const externalUrlHandoff = createExternalUrlHandoff({
+  isReady: () => externalUrlsFlushable,
+  isQuitting: () => isQuitting,
+  getRuntime: resolveExternalRuntime,
+  ensureWindow: (runtime) => createMainWindow(runtime, { ensureStartTab: true }),
+  isWindowReady: (runtime) => runtime.chromeReady && !runtime.closing
+    && runtime.window && !runtime.window.isDestroyed(),
+  withRuntime: withWindowRuntime,
+  createTab: (url) => createTab(url),
+  activateTab: (id) => setActiveTab(id),
+  revealWindow: (window) => bringExternalWindowToFront(app, window),
+});
 const pendingTabHandoffUrls = [];
 let tabHandoffsFlushable = false;
 let pendingTabHandoff = null;
@@ -1276,22 +1288,12 @@ function maybeSendProductUsage(wc, report) {
 // page, even when its renderer is sandboxed.
 const urlsFromArgv = webUrlsFromArgv;
 
-function openExternalUrl(url, { activate = true } = {}) {
-  if (!externalUrlsFlushable || !hasLiveWindow()) {
-    pendingExternalUrls.push(url);
-    return;
-  }
-  const id = createTab(url);
-  if (activate) {
-    setActiveTab(id);
-    bringExternalWindowToFront(app, rt().window);
-  }
+function resolveExternalRuntime(preferred = focusedRuntime) {
+  return externalWindowRuntime(windowRuntimes.all(), preferred ?? focusedRuntime, primaryRuntime, focusedRuntime);
 }
 
 function openExternalUrls(urls) {
-  for (const entry of externalUrlActivationPlan(urls)) {
-    openExternalUrl(entry.url, { activate: entry.activate });
-  }
+  externalUrlHandoff.open(urls);
 }
 
 // Protocols handed off to the OS instead of navigated — a mailto: click
@@ -1335,8 +1337,7 @@ function handOffToOs(url, { trusted = false } = {}) {
 }
 
 function flushExternalUrls() {
-  externalUrlsFlushable = true;
-  openExternalUrls(pendingExternalUrls.splice(0));
+  externalUrlHandoff.flush();
 }
 
 function acceptPendingTabHandoff(destination = 'current-window') {
@@ -1362,10 +1363,10 @@ function acceptPendingTabHandoff(destination = 'current-window') {
 
 app.on('open-url', (event, url) => {
   event.preventDefault();
-  const runtime = focusedRuntime ?? primaryRuntime;
+  const runtime = resolveExternalRuntime();
   withWindowRuntime(runtime, () => {
     if (queueTabHandoff(url)) return;
-    if (urlsFromArgv([url]).length) openExternalUrl(url);
+    openExternalUrls([url]);
   });
 });
 
@@ -7076,6 +7077,7 @@ function profileWindowTitle(profile) {
 function createMainWindowForRuntime(runtime, { ensureStartTab = false } = {}) {
   if (runtime.window && !runtime.window.isDestroyed()) return runtime;
   runtime.closing = false;
+  runtime.chromeReady = false;
   installProfileSessionPolicies(runtime.profileId);
   const localProfile = localProfiles.getLocalProfile(runtime.profileId);
   // Packaged Windows builds inherit the multi-resolution icon embedded in
@@ -7212,7 +7214,10 @@ function createMainWindowForRuntime(runtime, { ensureStartTab = false } = {}) {
   // First launch has no activeTabId yet — app.whenReady handles that one.
   rt().window.webContents.once('did-finish-load', bindWindowRuntime(
     runtime,
-    dockReopenLifecycle.onChromeReady
+    () => {
+      runtime.chromeReady = true;
+      dockReopenLifecycle.onChromeReady();
+    }
   ));
   return runtime;
 }
@@ -9017,8 +9022,9 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
 
     // Cold-start URL handoff waits until the blocker decision and session
     // restore are both complete.
-    pendingExternalUrls.push(...urlsFromArgv(process.argv.slice(1)));
+    openExternalUrls(urlsFromArgv(process.argv.slice(1)));
     pendingTabHandoffUrls.push(...tabImportUrlsFromArgv(process.argv.slice(1)));
+    externalUrlsFlushable = true;
     withWindowRuntime(focusedRuntime, flushExternalUrls);
     tabHandoffsFlushable = true;
     withWindowRuntime(focusedRuntime, flushTabHandoffs);
@@ -9098,14 +9104,15 @@ app.whenReady().then(bindWindowRuntime(primaryRuntime, async () => {
   setupAutoUpdater();
 
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      createMainWindow(primaryRuntime, { ensureStartTab: true });
-    }
-    focusedRuntime = primaryRuntime;
-    setFocusedLocalProfile(primaryRuntime.profileId);
+    if (isQuitting) return;
+    const runtime = resolveExternalRuntime();
+    createMainWindow(runtime, { ensureStartTab: true });
+    focusedRuntime = runtime;
+    setFocusedLocalProfile(runtime.profileId);
     refreshDockMenu();
-    withWindowRuntime(primaryRuntime, refocusAddressBarIfWanted);
-    withWindowRuntime(primaryRuntime, flushTabHandoffs);
+    withWindowRuntime(runtime, refocusAddressBarIfWanted);
+    withWindowRuntime(runtime, flushExternalUrls);
+    withWindowRuntime(runtime, flushTabHandoffs);
   });
 }));
 

--- a/src/main/window-activation.js
+++ b/src/main/window-activation.js
@@ -1,20 +1,107 @@
 'use strict';
 
-/** Bring the target browser window in front for an explicit OS handoff.
- *
- * BrowserWindow.focus() makes a window key only after its application is
- * active. On macOS, another app opening an HTTP(S) URL can leave Blanc behind
- * that app unless the application itself is activated with `steal: true`.
- * Keep that stronger behavior confined to default-browser/second-instance
- * handoffs; ordinary background tab work must never pull Blanc forward. */
+const pendingActivations = new WeakMap();
+const ACTIVATION_DEADLINE_MS = 2_000;
+
+/** Select a browser runtime, never an auxiliary popup. A closed primary is
+ * reusable, but a live most-recently-focused profile/window takes precedence. */
+function externalWindowRuntime(runtimes, preferred, primary, lastFocused = preferred) {
+  const live = (runtime) => runtimes.includes(runtime) && !runtime.closing
+    && runtime.window && !runtime.window.isDestroyed();
+  return [preferred, lastFocused, ...runtimes].find(live) ?? primary;
+}
+
+/** Request foreground presentation for an explicit OS handoff. The boolean
+ * acknowledges a live target, not proof that macOS has completed activation.
+ * Unhiding the application and deminiaturizing a window are separate native
+ * transitions. Finish focusing the captured window when those transitions
+ * settle; ordinary background page activity never enters this helper. */
 function bringExternalWindowToFront(application, window, { platform = process.platform } = {}) {
+  pendingActivations.get(application)?.();
   if (!window || window.isDestroyed?.()) return false;
-  if (window.isMinimized?.()) window.restore();
-  window.show?.();
-  window.moveTop?.();
-  if (platform === 'darwin') application?.focus?.({ steal: true });
-  window.focus?.();
+
+  if (platform !== 'darwin') {
+    if (window.isMinimized?.()) window.restore();
+    window.show?.();
+    window.moveTop?.();
+    window.focus?.();
+    return true;
+  }
+
+  let finished = false;
+  let requesting = true;
+  let focusing = false;
+  let immediate;
+  let deadline;
+  const listeners = [];
+  const listen = (emitter, event, fn) => {
+    emitter.on(event, fn);
+    listeners.push(() => emitter.removeListener(event, fn));
+  };
+  const cancel = () => {
+    if (finished) return;
+    finished = true;
+    clearImmediate(immediate);
+    clearTimeout(deadline);
+    for (const remove of listeners) remove();
+    if (pendingActivations.get(application) === cancel) pendingActivations.delete(application);
+  };
+  const isComplete = () => !window.isDestroyed() && !application.isHidden()
+    && !window.isMinimized() && application.isActive() && window.isFocused();
+  const check = () => {
+    if (!requesting && !finished && isComplete()) cancel();
+  };
+  const finishFocus = () => {
+    if (finished || requesting || focusing) return;
+    if (window.isDestroyed() || application.isHidden()) return cancel();
+    if (isComplete()) return cancel();
+    if (window.isMinimized()) return;
+    focusing = true;
+    try {
+      if (!application.isActive()) application.focus({ steal: true });
+      if (!finished) {
+        window.moveTop();
+        window.focus();
+        check();
+      }
+    } finally {
+      focusing = false;
+    }
+  };
+  pendingActivations.set(application, cancel);
+  listen(window, 'restore', finishFocus);
+  listen(application, 'did-become-active', finishFocus);
+  listen(window, 'focus', check);
+  listen(window, 'hide', cancel);
+  listen(window, 'minimize', cancel);
+  listen(window, 'closed', cancel);
+  listen(application, 'before-quit', cancel);
+  listen(application, 'will-quit', cancel);
+  listen(application, 'did-resign-active', cancel);
+  // Selecting another Blanc window is also an explicit change of intent.
+  listen(application, 'browser-window-focus', (_event, focused) => {
+    if (!requesting && focused !== window) cancel();
+  });
+  deadline = setTimeout(cancel, ACTIVATION_DEADLINE_MS);
+  deadline.unref?.();
+
+  try {
+    if (application.isHidden()) application.show();
+    if (window.isMinimized()) window.restore();
+    window.show();
+    application.focus({ steal: true });
+    window.moveTop();
+    window.focus();
+  } catch (error) {
+    cancel();
+    throw error;
+  } finally {
+    requesting = false;
+  }
+  // Always give native callbacks one turn to settle, even if the synchronous
+  // focus call appeared to succeed. Further attempts are event-driven only.
+  if (!finished) immediate = setImmediate(finishFocus);
   return true;
 }
 
-module.exports = { bringExternalWindowToFront };
+module.exports = { bringExternalWindowToFront, externalWindowRuntime };

--- a/src/main/window-runtime-registry.js
+++ b/src/main/window-runtime-registry.js
@@ -29,6 +29,7 @@ function createRuntime({ id = null, profileId = DEFAULT_PROFILE_ID } = {}) {
     profileId,
     closing: false,
     window: null,
+    chromeReady: false,
     tabOrder: [],
     activeTabId: null,
     groups: [],
@@ -174,6 +175,7 @@ function detachWindow(runtime) {
     if (owner === runtime) auxiliaryOwner.delete(wcId);
   }
   runtime.window = null;
+  runtime.chromeReady = false;
   runtime.overlayView = null;
   runtime.overlayMode = null;
   runtime.workspaceSwitcherOpen = false;

--- a/test/desktop/README.md
+++ b/test/desktop/README.md
@@ -52,6 +52,8 @@ npm run test:acceptance:desktop      # execute the runnable scenarios against th
 xvfb-run -a npm run test:acceptance:desktop   # ...on a headless Linux/CI box
 
 npm run test:packaged:regressions    # deterministic signed-build release regressions
+npm run test:external-links          # isolated Electron URL/window lifecycle
+npm run test:packaged:external-links # interactive macOS LaunchServices + native foreground gate
 node test/desktop/packaged-media-smoke.mjs  # cross-platform packaged site grants + live fake audio/video tracks
 npm run test:packaged:native-media   # macOS-only real device/TCC check; records no audio
 npm run test:packaged:native-camera  # macOS-only real camera/TCC check; records/uploads no frames
@@ -113,6 +115,30 @@ groups, by what they additionally need:
    navigations.
 3. **OS-level behaviour** — OS URI hand-off, telemetry ping capture, the desktop
    updater. Need process/network mocking.
+
+### External-link activation gate (macOS)
+
+`npm run test:external-links` exercises the real Electron lifecycle in a
+throwaway development profile, including startup, hidden/minimized windows,
+windowless reopen, profile selection, and second-instance URL batches.
+
+Run `npm run test:packaged:external-links` against a signed candidate on an
+interactive macOS desktop. Set `BLANC_PACKAGED_EXECUTABLE` to its absolute
+executable path when it is outside `dist/mac-arm64`. Quit other Blanc instances
+first and leave focus to the test while it runs: it alternates Finder and the
+isolated candidate without changing the default browser or your saved profile.
+It uses real LaunchServices URL delivery and checks the selected tab plus
+AppKit's frontmost PID and WindowServer's onscreen browser window. Hidden and
+minimized cases repeat ten times each; background, combined hidden/minimized,
+closed-window, and background reload behavior are checked as well.
+Repeat with `npm run test:packaged:external-links -- --background-delivery`
+to check activation when LaunchServices only delivers the URL and does not
+bring the app forward on the test's behalf.
+
+Before release, separately record an actual email-link click on the affected
+Mac and a handoff from another desktop/full-screen Space. Neither synthetic
+Electron events nor a renderer's `document.hasFocus()` substitute for that
+evidence. This interactive gate is separate from unattended release tests.
 
 ### Deliberate proxies
 

--- a/test/desktop/README.md
+++ b/test/desktop/README.md
@@ -120,7 +120,10 @@ groups, by what they additionally need:
 
 `npm run test:external-links` exercises the real Electron lifecycle in a
 throwaway development profile, including startup, hidden/minimized windows,
-windowless reopen, profile selection, and second-instance URL batches.
+windowless reopen, profile selection, and second-instance URL batches. It also
+holds a recreated chrome document until after a user hide/minimize, checking
+that readiness delivers the link once without undoing that action, and that a
+fresh handoff restores normally.
 
 Run `npm run test:packaged:external-links` against a signed candidate on an
 interactive macOS desktop. Set `BLANC_PACKAGED_EXECUTABLE` to its absolute

--- a/test/desktop/external-links-smoke.mjs
+++ b/test/desktop/external-links-smoke.mjs
@@ -70,6 +70,72 @@ try {
     await deliver(`${origin}/closed`);
     const after = await selected(`${origin}/closed`);
     assert.equal(after.tabs.length, before.tabs.length + 1);
+
+    // Hold only the recreated chrome document so a later user hide/minimize
+    // deterministically lands between delivery and native-window readiness.
+    await app.evaluate(({ session, net }, root) => {
+      const require = process.getBuiltinModule('module').createRequire(`${root}/package.json`);
+      const { createChromeProtocolHandler } = require('./src/main/chrome-protocol');
+      const original = createChromeProtocolHandler({ net });
+      const chrome = session.fromPartition('blanc-chrome');
+      chrome.protocol.unhandle('blanc-chrome');
+      chrome.protocol.handle('blanc-chrome', async (request) => {
+        if (request.url === 'blanc-chrome://index/') {
+          await new Promise((resolve) => { globalThis.releaseExternalLinkChrome = resolve; });
+        }
+        return original(request);
+      });
+    }, path.resolve('.'));
+    try {
+      for (const mode of ['hidden', 'minimized']) {
+        await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].close());
+        await waitForValue(() => app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length),
+          (count) => count === 0, 'close before delayed chrome');
+        const before = await read();
+        const url = `${origin}/cancel-during-chrome-${mode}`;
+        await deliver(url);
+        await waitForValue(() => app.evaluate(() => !!globalThis.releaseExternalLinkChrome),
+          Boolean, 'chrome request held');
+        assert.equal((await read()).tabs.length, before.tabs.length, 'URL waits for chrome readiness');
+        await app.evaluate(({ app, BrowserWindow }, mode) => {
+          if (mode === 'hidden') app.hide();
+          else BrowserWindow.getAllWindows()[0].minimize();
+        }, mode);
+        const nativeState = () => app.evaluate(({ app, BrowserWindow }) => ({
+          hidden: app.isHidden(), minimized: BrowserWindow.getAllWindows()[0].isMinimized(),
+        }));
+        await waitForValue(nativeState, (s) => mode === 'hidden' ? s.hidden : s.minimized,
+          `user ${mode} during initialization`);
+        await app.evaluate(() => {
+          globalThis.releaseExternalLinkChrome();
+          delete globalThis.releaseExternalLinkChrome;
+        });
+        const after = await waitForValue(read, (state) => state.tabs.some((tab) => tab.url === url),
+          'canceled activation still delivers the URL');
+        assert.equal(after.tabs.length, before.tabs.length + 1);
+        assert.equal(after.activeTabId, before.activeTabId, 'Canceled handoff must not change selection');
+        await new Promise((resolve) => setTimeout(resolve, 2_200));
+        const state = await nativeState();
+        assert.equal(mode === 'hidden' ? state.hidden : state.minimized, true,
+          'Chrome readiness and later callbacks must respect the newer user action');
+        console.log(`external-links cancel during chrome ${mode} PASS`);
+        // A fresh link, including one delivered while already hidden or
+        // minimized, grants new permission to reveal the receiving window.
+        await deliver(`${url}/new-handoff`);
+        await selected(`${url}/new-handoff`);
+        await waitForValue(nativeState, (s) => !s.hidden && !s.minimized, 'new handoff restores normally');
+      }
+    } finally {
+      await app.evaluate(({ session, net }, root) => {
+        globalThis.releaseExternalLinkChrome?.();
+        delete globalThis.releaseExternalLinkChrome;
+        const require = process.getBuiltinModule('module').createRequire(`${root}/package.json`);
+        const { setupChromeProtocol } = require('./src/main/chrome-protocol');
+        const chrome = session.fromPartition('blanc-chrome');
+        chrome.protocol.unhandle('blanc-chrome');
+        setupChromeProtocol({ session: chrome, net });
+      }, path.resolve('.'));
+    }
   }
   const profile = await callTestHook(app, 'createProfileWindow', ['External links work']);
   assert.equal(profile.ok, true);
@@ -89,7 +155,7 @@ try {
   const batchReceiver = final.find((rt) => rt.id === receiver.id);
   assert.equal(batchReceiver.tabs.filter((tab) => tab.url === `${origin}/batch-a`).length, 1);
   assert.equal(batchReceiver.tabs.filter((tab) => tab.url === `${origin}/batch-b`).length, 1);
-  console.log('external-links-smoke PASS: cold launch, hidden/minimized restore, windowless reopen, profile routing, second-instance batch');
+  console.log('external-links-smoke PASS: cold launch, hidden/minimized restore, readiness cancellation, windowless reopen, profile routing, second-instance batch');
 } finally {
   if (app) await app.close();
   await new Promise((resolve) => server.close(resolve));

--- a/test/desktop/external-links-smoke.mjs
+++ b/test/desktop/external-links-smoke.mjs
@@ -1,0 +1,99 @@
+// Real Electron lifecycle coverage. Packaged LaunchServices/WindowServer proof
+// lives separately in packaged-external-links-smoke.mjs (no packaged test hook).
+import { _electron } from 'playwright';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import testHookCall from './support/test-hook-call.js';
+import poll from './support/poll.js';
+
+const { callTestHook } = testHookCall;
+const { waitForValue } = poll;
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-external-lifecycle-'));
+const userDataDir = path.join(root, 'profile');
+fs.mkdirSync(`${userDataDir}-Dev`);
+fs.writeFileSync(path.join(`${userDataDir}-Dev`, 'settings.json'), JSON.stringify({
+  onboardingVersion: 1, adblockEnabled: false, usagePing: false, searchSuggestions: false,
+}));
+const server = http.createServer((_req, res) => {
+  res.end('<!doctype html><title>External lifecycle</title><main>External lifecycle</main>');
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+const { ELECTRON_RUN_AS_NODE: ignored, ...env } = process.env;
+const uncaughtLog = path.join(root, 'uncaught.log');
+let app;
+try {
+  app = await _electron.launch({
+    args: [path.resolve('.'), `--user-data-dir=${userDataDir}`, `${origin}/cold-start`],
+    env: { ...env, BLANC_TEST: '1', BLANC_TEST_UNCAUGHT_LOG: uncaughtLog },
+  });
+  await app.firstWindow();
+  await waitForValue(() => callTestHook(app, 'startupReady'), Boolean, 'startup release');
+  const read = () => callTestHook(app, 'state');
+  const selected = (url) => waitForValue(read, (state) => state.tabs.some((tab) =>
+    tab.id === state.activeTabId && tab.url === url), `selected ${url}`);
+  await selected(`${origin}/cold-start`);
+  const deliver = (url) => app.evaluate(({ app }, url) => {
+    app.emit('open-url', { preventDefault() {} }, url);
+  }, url);
+  if (process.platform === 'darwin') {
+    for (const mode of ['hidden', 'minimized', 'hidden-minimized']) {
+      await app.evaluate(({ app, BrowserWindow }, mode) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        if (mode.includes('minimized')) window.minimize();
+        if (mode.includes('hidden')) app.hide();
+      }, mode);
+      await waitForValue(() => app.evaluate(({ app, BrowserWindow }) => ({
+        hidden: app.isHidden(), minimized: BrowserWindow.getAllWindows()[0].isMinimized(),
+      })), (s) => (!mode.includes('hidden') || s.hidden)
+        && (!mode.includes('minimized') || s.minimized), `prepare ${mode}`);
+      const before = await read();
+      await deliver(`${origin}/${mode}`);
+      const after = await selected(`${origin}/${mode}`);
+      assert.equal(after.tabs.length, before.tabs.length + 1);
+      await waitForValue(() => app.evaluate(({ app, BrowserWindow }) => ({
+        hidden: app.isHidden(), active: app.isActive(),
+        minimized: BrowserWindow.getAllWindows()[0].isMinimized(),
+        focused: BrowserWindow.getAllWindows()[0].isFocused(),
+      })), (s) => !s.hidden && s.active && !s.minimized && s.focused, `restore ${mode}`);
+      console.log(`external-links ${mode} PASS`);
+    }
+    await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].close());
+    await waitForValue(() => app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length),
+      (count) => count === 0, 'last window closed');
+    // No app.activate event accompanies this injection: URL handling itself
+    // must create chrome and flush the queued URL exactly once.
+    const before = await read();
+    await deliver(`${origin}/closed`);
+    const after = await selected(`${origin}/closed`);
+    assert.equal(after.tabs.length, before.tabs.length + 1);
+  }
+  const profile = await callTestHook(app, 'createProfileWindow', ['External links work']);
+  assert.equal(profile.ok, true);
+  await app.evaluate(({ app }) => app.emit('activate', {}, true));
+  await deliver(`${origin}/work`);
+  const runtimes = await waitForValue(() => callTestHook(app, 'windowRuntimes'), (runtimes) =>
+    runtimes.some((rt) => rt.tabs.some((tab) => tab.url === `${origin}/work`)), 'profile URL delivery');
+  const receiver = runtimes.find((rt) => rt.tabs.some((tab) => tab.url === `${origin}/work`));
+  assert.notEqual(receiver.profileId, 'personal');
+  assert.equal(receiver.tabs.find((tab) => tab.url === `${origin}/work`).id, receiver.activeTabId);
+  // Windows/Linux second-instance handoff opens all URLs and selects the last.
+  await app.evaluate(({ app }, urls) => app.emit('second-instance', {}, ['Blanc', ...urls]),
+    [`${origin}/batch-a`, `${origin}/batch-b`]);
+  const final = await waitForValue(() => callTestHook(app, 'windowRuntimes'), (runtimes) =>
+    runtimes.some((rt) => rt.id === receiver.id && rt.tabs.some((tab) =>
+      tab.id === rt.activeTabId && tab.url === `${origin}/batch-b`)), 'selected batch in receiving profile');
+  const batchReceiver = final.find((rt) => rt.id === receiver.id);
+  assert.equal(batchReceiver.tabs.filter((tab) => tab.url === `${origin}/batch-a`).length, 1);
+  assert.equal(batchReceiver.tabs.filter((tab) => tab.url === `${origin}/batch-b`).length, 1);
+  console.log('external-links-smoke PASS: cold launch, hidden/minimized restore, windowless reopen, profile routing, second-instance batch');
+} finally {
+  if (app) await app.close();
+  await new Promise((resolve) => server.close(resolve));
+  const errors = fs.existsSync(uncaughtLog) ? fs.readFileSync(uncaughtLog, 'utf8').trim() : '';
+  fs.rmSync(root, { recursive: true, force: true });
+  assert.equal(errors, '', 'No uncaught main-process exceptions');
+}

--- a/test/desktop/external-links-smoke.mjs
+++ b/test/desktop/external-links-smoke.mjs
@@ -41,11 +41,14 @@ try {
   }, url);
   if (process.platform === 'darwin') {
     for (const mode of ['hidden', 'minimized', 'hidden-minimized']) {
-      await app.evaluate(({ app, BrowserWindow }, mode) => {
-        const window = BrowserWindow.getAllWindows()[0];
-        if (mode.includes('minimized')) window.minimize();
-        if (mode.includes('hidden')) app.hide();
-      }, mode);
+      if (mode.includes('minimized')) {
+        await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].minimize());
+        // Hiding during the native minimize animation can cancel that
+        // transition. Establish each precondition before requesting the next.
+        await waitForValue(() => app.evaluate(({ BrowserWindow }) =>
+          BrowserWindow.getAllWindows()[0].isMinimized()), Boolean, 'native minimize completed');
+      }
+      if (mode.includes('hidden')) await app.evaluate(({ app }) => app.hide());
       await waitForValue(() => app.evaluate(({ app, BrowserWindow }) => ({
         hidden: app.isHidden(), minimized: BrowserWindow.getAllWindows()[0].isMinimized(),
       })), (s) => (!mode.includes('hidden') || s.hidden)

--- a/test/desktop/packaged-external-links-smoke.mjs
+++ b/test/desktop/packaged-external-links-smoke.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { launchPackagedOverCdp } from './support/packaged-cdp.mjs';
+
+if (process.platform !== 'darwin') throw new Error('This gate requires an interactive macOS desktop.');
+const run = promisify(execFile);
+const nativeScript = fileURLToPath(new URL('./support/macos-activation-state.jxa', import.meta.url));
+const native = async (action, pid = '') => JSON.parse((await run('/usr/bin/osascript',
+  ['-l', 'JavaScript', nativeScript, action, String(pid)])).stdout);
+const executablePath = path.resolve(process.env.BLANC_PACKAGED_EXECUTABLE
+  || 'dist/mac-arm64/Blanc.app/Contents/MacOS/Blanc');
+// This variant checks Blanc's own activation: LaunchServices delivers the URL
+// without independently foregrounding the app on the test's behalf.
+const backgroundDelivery = process.argv.includes('--background-delivery');
+const bundlePath = executablePath.slice(0, executablePath.lastIndexOf('.app/') + 4);
+assert.ok(fs.existsSync(executablePath) && bundlePath.endsWith('.app'), 'Packaged Blanc executable required');
+const inventory = await native('inventory');
+assert.ok(!inventory.some((app) => app.bundleId === 'me.bnfy.bowser'),
+  'Quit other Blanc instances first: LaunchServices must deliver only to this isolated test process.');
+const finderPid = inventory.find((app) => app.bundleId === 'com.apple.finder')?.pid;
+assert.ok(finderPid, 'A logged-in macOS desktop with Finder is required');
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+async function poll(read, matches, label, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  let value;
+  do {
+    let timer;
+    try {
+      value = await Promise.race([
+        read(),
+        new Promise((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error(`${label}: observation timed out`)),
+            Math.max(1, deadline - Date.now()));
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+    if (matches(value)) return value;
+    await delay(100);
+  } while (Date.now() < deadline);
+  assert.fail(`${label}; last observation: ${JSON.stringify(value)}`);
+}
+
+const server = http.createServer((_request, response) => {
+  response.setHeader('Content-Type', 'text/html');
+  response.end('<!doctype html><title>External link activation</title><main>External link activation</main>');
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-external-links-'));
+fs.writeFileSync(path.join(userDataDir, 'settings.json'), JSON.stringify({
+  adblockEnabled: false, onboardingVersion: 1, searchSuggestions: false, usagePing: false,
+}));
+let browser;
+let targetPid;
+try {
+  console.log(`external-links launch ${bundlePath} (background delivery: ${backgroundDelivery})`);
+  browser = await launchPackagedOverCdp({
+    executablePath,
+    args: [`--user-data-dir=${userDataDir}`],
+    env: { ...process.env, BLANC_TEST: '0' },
+  });
+  console.log('external-links connected to packaged chrome');
+  const instance = await poll(() => native('inventory'), (apps) =>
+    apps.some((app) => app.path === bundlePath), 'Launched bundle must appear in native process inventory');
+  targetPid = instance.find((app) => app.path === bundlePath).pid;
+  const chrome = () => browser.pages().find((page) => page.url() === 'blanc-chrome://index/');
+  const tabs = () => chrome()?.evaluate(() => window.browserAPI.getAllTabs()) ?? null;
+  await poll(tabs, (state) => state?.tabs?.length > 0, 'Initial window ready');
+  const checkFront = async () => {
+    const state = await poll(() => native('state', targetPid), (value) =>
+      value.frontmostPid === targetPid && value.active && !value.hidden && value.windows.length === 1,
+    'Blanc must be frontmost with its restored browser window onscreen', 5_000);
+    // A transient activation that falls back behind the sender is a failure.
+    await delay(500);
+    assert.deepEqual(await native('state', targetPid), state, 'Native foreground state must remain stable');
+  };
+  for (const mode of ['background', 'hidden', 'minimized', 'hidden-minimized', 'closed']) {
+    const repeats = mode === 'hidden' || mode === 'minimized' ? 10 : 1;
+    for (let i = 0; i < repeats; i++) {
+      const before = await tabs();
+      if (mode.includes('minimized')) {
+        await chrome().evaluate(() => window.browserAPI.minimizeWindow());
+        await poll(() => native('state', targetPid), (state) => state.windows.length === 0,
+          'Window must actually minimize before link delivery');
+      }
+      if (mode.includes('hidden')) {
+        await native('hide', targetPid);
+        await poll(() => native('state', targetPid), (state) => state.hidden, 'App must actually hide');
+      }
+      if (mode === 'closed') {
+        await chrome().evaluate(() => window.browserAPI.closeWindow());
+        await poll(() => native('state', targetPid), (state) => state.windows.length === 0, 'Window must close');
+      }
+      await native('activate', finderPid);
+      await poll(() => native('state', targetPid), (state) => state.frontmostPid === finderPid,
+        'Another application must own foreground before link delivery');
+      const url = `${origin}/${mode}/${i}`;
+      // Real LaunchServices handoff, not app.emit('open-url') or renderer IPC.
+      await run('/usr/bin/open', [...(backgroundDelivery ? ['-g'] : []), '-a', bundlePath, url]);
+      const after = await poll(tabs, (state) => state?.tabs?.some((tab) =>
+        tab.id === state.activeTabId && tab.url === url), 'Delivered URL must be the selected tab');
+      assert.equal(after.tabs.length, before.tabs.length + 1, 'Each delivered URL opens exactly once');
+      await checkFront();
+      console.log(`external-links ${mode} ${i + 1}/${repeats} PASS`);
+    }
+  }
+  // Background page activity after a completed handoff must not reactivate Blanc.
+  const background = browser.pages().find((page) => page.url() === `${origin}/background/0`);
+  assert.ok(background);
+  await native('activate', finderPid);
+  await background.reload();
+  await delay(2_200);
+  assert.equal((await native('state', targetPid)).frontmostPid, finderPid);
+  console.log('external-links background reload PASS');
+  console.log('packaged-external-links-smoke PASS (other-Space and actual email click require separate owner evidence)');
+} catch (error) {
+  console.error(error);
+  throw error;
+} finally {
+  if (browser) await browser.close();
+  await new Promise((resolve) => server.close(resolve));
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+}

--- a/test/desktop/support/macos-activation-state.jxa
+++ b/test/desktop/support/macos-activation-state.jxa
@@ -1,0 +1,37 @@
+// Run with osascript -l JavaScript. AppKit/WindowServer observations require a
+// logged-in desktop, but no accessibility scripting or screen-recording grant.
+ObjC.import('AppKit');
+ObjC.import('CoreGraphics');
+
+function run(argv) {
+  const [action, rawPid] = argv;
+  const pid = Number(rawPid);
+  const workspace = $.NSWorkspace.sharedWorkspace;
+  const apps = workspace.runningApplications;
+  const inventory = [];
+  for (let i = 0; i < apps.count; i++) {
+    const app = apps.objectAtIndex(i);
+    inventory.push({
+      pid: Number(app.processIdentifier),
+      bundleId: ObjC.unwrap(app.bundleIdentifier) || null,
+      path: ObjC.unwrap(app.bundleURL.path) || null,
+    });
+  }
+  if (action === 'inventory') return JSON.stringify(inventory);
+  if (!inventory.some((app) => app.pid === pid)) throw new Error('Target process is not running');
+  const target = $.NSRunningApplication.runningApplicationWithProcessIdentifier(pid);
+  if (action === 'hide') target.hide;
+  if (action === 'activate') target.activateWithOptions(2);
+  if (!['hide', 'activate', 'state'].includes(action)) throw new Error('Unknown action');
+  const windows = ObjC.deepUnwrap(ObjC.castRefToObject($.CGWindowListCopyWindowInfo(1, 0)));
+  return JSON.stringify({
+    pid,
+    hidden: Boolean(target.hidden),
+    active: Boolean(target.active),
+    frontmostPid: Number(workspace.frontmostApplication.processIdentifier),
+    windows: windows.filter((window) => window.kCGWindowOwnerPID === pid
+      && window.kCGWindowLayer === 0
+      && window.kCGWindowBounds.Width >= 640 && window.kCGWindowBounds.Height >= 480)
+      .map((window) => ({ id: window.kCGWindowNumber, bounds: window.kCGWindowBounds })),
+  });
+}

--- a/test/unit/dock-reopen.test.js
+++ b/test/unit/dock-reopen.test.js
@@ -183,6 +183,18 @@ test('Dock reopen creates and activates a start tab when no document is reusable
   assert.deepEqual(activated, ['start']);
 });
 
+test('chrome readiness flushes pending handoffs even without a reusable tab', () => {
+  let flushes = 0;
+  const runtime = { activeTabId: null };
+  const lifecycle = createDockReopenLifecycle({
+    runtime, tabs: new Map(), liveContents: () => null,
+    activateTab() { assert.fail('there is no existing tab to activate'); },
+    flushExternalUrls() { flushes += 1; },
+  });
+  assert.equal(lifecycle.onChromeReady(), null);
+  assert.equal(flushes, 1);
+});
+
 test('main installs both handlers from the tested Dock-reopen lifecycle', () => {
   const fs = require('node:fs');
   const path = require('node:path');

--- a/test/unit/external-url-handoff.test.js
+++ b/test/unit/external-url-handoff.test.js
@@ -2,18 +2,22 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
+const { EventEmitter } = require('node:events');
 const fs = require('node:fs');
 const vm = require('node:vm');
 const { createExternalUrlHandoff } = require('../../src/main/external-url-handoff');
 const { externalWindowRuntime } = require('../../src/main/window-activation');
 
 function harness({ ready = true, chromeReady = true } = {}) {
-  const primary = { profileId: 'personal', chromeReady, window: { isDestroyed: () => false } };
-  const work = { profileId: 'work', chromeReady, window: { isDestroyed: () => false } };
+  const makeWindow = () => Object.assign(new EventEmitter(), { isDestroyed: () => false });
+  const primary = { profileId: 'personal', chromeReady, window: makeWindow() };
+  const work = { profileId: 'work', chromeReady, window: makeWindow() };
   const runtimes = [primary, work];
-  const state = { ready, quitting: false, focused: primary, current: null };
+  const state = { ready, quitting: false, hidden: false, focused: primary, current: null };
+  const application = Object.assign(new EventEmitter(), { isHidden: () => state.hidden });
   const created = [], activated = [], revealed = [], rebuilt = [];
   const handler = createExternalUrlHandoff({
+    application,
     isReady: () => state.ready,
     isQuitting: () => state.quitting,
     getRuntime: (preferred) => externalWindowRuntime(runtimes, preferred ?? state.focused, primary, state.focused),
@@ -21,7 +25,7 @@ function harness({ ready = true, chromeReady = true } = {}) {
       if (runtime.window) return;
       rebuilt.push(runtime);
       runtime.chromeReady = false;
-      runtime.window = { isDestroyed: () => false };
+      runtime.window = makeWindow();
     },
     isWindowReady: (runtime) => runtime.chromeReady,
     withRuntime(runtime, fn) { state.current = runtime; try { fn(); } finally { state.current = null; } },
@@ -33,8 +37,111 @@ function harness({ ready = true, chromeReady = true } = {}) {
     activateTab(id) { activated.push(id); },
     revealWindow(window) { revealed.push(window); },
   });
-  return { handler, primary, work, runtimes, state, created, activated, revealed, rebuilt };
+  const noListeners = () => {
+    assert.deepEqual(application.eventNames(), []);
+    for (const runtime of runtimes) assert.deepEqual(runtime.window?.eventNames() ?? [], []);
+  };
+  return { handler, application, primary, work, runtimes, state, created, activated, revealed, rebuilt, noListeners };
 }
+
+for (const event of ['hide', 'minimize']) {
+  test(`${event} during chrome initialization preserves every URL without reactivation`, () => {
+    const f = harness();
+    f.runtimes.splice(1);
+    f.primary.window = null;
+    f.handler.open(['https://one.test/', 'https://two.test/']);
+    f.primary.window.emit(event);
+    // Cancellation stays effective even if native state changes again.
+    f.primary.window.emit('restore');
+    f.primary.chromeReady = true;
+    f.handler.flush();
+    f.handler.flush();
+    assert.deepEqual(f.created.map((tab) => tab.url), ['https://one.test/', 'https://two.test/']);
+    assert.deepEqual(f.activated, []);
+    assert.deepEqual(f.revealed, []);
+    f.noListeners();
+  });
+}
+
+test('hiding an already inactive app while chrome loads cancels reveal without a resign event', () => {
+  const f = harness({ chromeReady: false });
+  f.handler.open(['https://example.test/']);
+  f.state.hidden = true;
+  f.primary.chromeReady = true;
+  f.handler.flush();
+  assert.equal(f.created.length, 1);
+  assert.deepEqual(f.revealed, []);
+  assert.deepEqual(f.activated, []);
+  f.noListeners();
+});
+
+test('a handoff received while already hidden still reveals after readiness', () => {
+  const f = harness({ chromeReady: false });
+  f.state.hidden = true;
+  f.handler.open(['https://example.test/']);
+  f.primary.chromeReady = true;
+  f.handler.flush();
+  assert.deepEqual(f.activated, [1]);
+  assert.deepEqual(f.revealed, [f.primary.window]);
+  f.noListeners();
+});
+
+test('another explicit handoff renews activation after an earlier minimize', () => {
+  const f = harness({ chromeReady: false });
+  f.handler.open(['https://old.test/']);
+  f.primary.window.emit('minimize');
+  f.handler.open(['https://new.test/']);
+  f.primary.chromeReady = true;
+  f.handler.flush();
+  assert.equal(f.created.length, 2);
+  assert.deepEqual(f.activated, [2]);
+  assert.equal(f.revealed.length, 1);
+  f.noListeners();
+});
+
+for (const event of ['did-resign-active', 'before-quit', 'will-quit']) {
+  test(`${event} removes queued activation listeners immediately`, () => {
+    const f = harness({ chromeReady: false });
+    f.handler.open(['https://example.test/']);
+    assert.equal(f.primary.window.listenerCount('minimize'), 1);
+    f.application.emit(event);
+    f.noListeners();
+    if (event.includes('quit')) f.state.quitting = true;
+    f.primary.chromeReady = true;
+    f.handler.flush();
+    assert.equal(f.created.length, f.state.quitting ? 0 : 1);
+    assert.deepEqual(f.revealed, []);
+  });
+}
+
+test('closing the queued target removes its listeners and keeps fallback delivery in the background', () => {
+  const f = harness({ chromeReady: false });
+  f.state.focused = f.work;
+  f.handler.open(['https://example.test/']);
+  f.work.window.emit('closed');
+  f.noListeners();
+  f.runtimes.splice(1);
+  f.state.focused = f.primary;
+  f.primary.chromeReady = true;
+  f.handler.flush();
+  assert.equal(f.created[0].profileId, 'personal');
+  assert.deepEqual(f.revealed, []);
+});
+
+test('superseding a queued target removes its listeners without canceling the new request', () => {
+  const f = harness({ chromeReady: false });
+  f.handler.open(['https://old.test/']);
+  f.state.focused = f.work;
+  f.handler.open(['https://new.test/']);
+  assert.deepEqual(f.primary.window.eventNames(), []);
+  assert.equal(f.work.window.listenerCount('minimize'), 1);
+  f.primary.window.emit('minimize');
+  f.work.chromeReady = true;
+  f.handler.flush();
+  assert.deepEqual(f.created.map((tab) => tab.url), ['https://new.test/']);
+  assert.deepEqual(f.revealed, [f.work.window]);
+  f.noListeners();
+});
 
 test('cold handoffs wait for startup release and target the restored profile', () => {
   const f = harness({ ready: false });

--- a/test/unit/external-url-handoff.test.js
+++ b/test/unit/external-url-handoff.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const { createExternalUrlHandoff } = require('../../src/main/external-url-handoff');
+const { externalWindowRuntime } = require('../../src/main/window-activation');
+
+function harness({ ready = true, chromeReady = true } = {}) {
+  const primary = { profileId: 'personal', chromeReady, window: { isDestroyed: () => false } };
+  const work = { profileId: 'work', chromeReady, window: { isDestroyed: () => false } };
+  const runtimes = [primary, work];
+  const state = { ready, quitting: false, focused: primary, current: null };
+  const created = [], activated = [], revealed = [], rebuilt = [];
+  const handler = createExternalUrlHandoff({
+    isReady: () => state.ready,
+    isQuitting: () => state.quitting,
+    getRuntime: (preferred) => externalWindowRuntime(runtimes, preferred ?? state.focused, primary, state.focused),
+    ensureWindow(runtime) {
+      if (runtime.window) return;
+      rebuilt.push(runtime);
+      runtime.chromeReady = false;
+      runtime.window = { isDestroyed: () => false };
+    },
+    isWindowReady: (runtime) => runtime.chromeReady,
+    withRuntime(runtime, fn) { state.current = runtime; try { fn(); } finally { state.current = null; } },
+    createTab(url) {
+      const entry = { id: created.length + 1, url, profileId: state.current.profileId };
+      created.push(entry);
+      return url === 'https://refused.test/' ? null : entry.id;
+    },
+    activateTab(id) { activated.push(id); },
+    revealWindow(window) { revealed.push(window); },
+  });
+  return { handler, primary, work, runtimes, state, created, activated, revealed, rebuilt };
+}
+
+test('cold handoffs wait for startup release and target the restored profile', () => {
+  const f = harness({ ready: false });
+  f.handler.open(['https://one.test/']);
+  f.handler.open(['https://two.test/']);
+  f.handler.flush(); // chrome readiness must not bypass startup restore/blocker
+  assert.deepEqual(f.created, []);
+  f.state.focused = f.work;
+  f.state.ready = true;
+  f.handler.flush();
+  assert.deepEqual(f.created.map((tab) => [tab.url, tab.profileId]), [
+    ['https://one.test/', 'work'], ['https://two.test/', 'work'],
+  ]);
+  assert.deepEqual(f.activated, [2]);
+  f.handler.flush();
+  assert.equal(f.created.length, 2);
+});
+
+test('warm URL delivery stays pinned while its chrome loads and focus changes', () => {
+  const f = harness({ chromeReady: false });
+  f.state.focused = f.work;
+  f.handler.open(['https://work.test/']);
+  f.state.focused = f.primary;
+  f.primary.chromeReady = true;
+  f.handler.flush();
+  assert.deepEqual(f.created, []);
+  f.work.chromeReady = true;
+  f.handler.flush();
+  assert.equal(f.created[0].profileId, 'work');
+  assert.deepEqual(f.revealed, [f.work.window]);
+});
+
+test('windowless handoff recreates primary and drains once without an app activate event', () => {
+  const f = harness();
+  f.runtimes.splice(1);
+  f.primary.window = null;
+  f.handler.open(['https://first.test/', 'https://second.test/']);
+  assert.deepEqual(f.rebuilt, [f.primary]);
+  assert.deepEqual(f.created, []);
+  f.primary.chromeReady = true;
+  f.handler.flush();
+  f.handler.flush();
+  assert.equal(f.created.length, 2);
+  assert.deepEqual(f.activated, [2]);
+  assert.equal(f.revealed.length, 1);
+});
+
+test('a later handoff supersedes foreground intent from an older loading window', () => {
+  const f = harness();
+  f.primary.chromeReady = false;
+  f.handler.open(['https://old.test/']);
+  f.state.focused = f.work;
+  f.handler.open(['https://new.test/']);
+  f.primary.chromeReady = true;
+  f.handler.flush();
+  assert.deepEqual(f.created.map((tab) => tab.url), ['https://new.test/', 'https://old.test/']);
+  assert.deepEqual(f.activated, [1]);
+  assert.deepEqual(f.revealed, [f.work.window]);
+});
+
+test('discarded receiving runtime falls back to the current live window', () => {
+  const f = harness();
+  f.work.chromeReady = false;
+  f.state.focused = f.work;
+  f.handler.open(['https://example.test/']);
+  f.runtimes.splice(1);
+  f.state.focused = f.primary;
+  f.handler.flush();
+  assert.equal(f.created[0].profileId, 'personal');
+});
+
+test('rejected/non-web URLs and quit never activate windows', () => {
+  const f = harness();
+  f.handler.open(['file:///tmp/local', 'blanc://settings/', '--flag']);
+  assert.deepEqual(f.created, []);
+  f.handler.open(['https://refused.test/']);
+  assert.deepEqual(f.activated, []);
+  f.state.quitting = true;
+  f.handler.open(['https://late.test/']);
+  f.handler.flush();
+  assert.equal(f.created.length, 1);
+  assert.deepEqual(f.revealed, []);
+});
+
+test('app activate preserves the chosen runtime/profile and flushes its pending work', () => {
+  // Execute the production root to catch a future unconditional primary reset.
+  const main = fs.readFileSync(require.resolve('../../src/main/main'), 'utf8');
+  const source = main.slice(main.lastIndexOf("  app.on('activate',"), main.lastIndexOf("\n}));"));
+  const primary = {}, secondary = { profileId: 'work' };
+  const calls = [];
+  const context = {
+    app: { on(event, fn) { assert.equal(event, 'activate'); this.activate = fn; } },
+    isQuitting: false, focusedRuntime: secondary, primaryRuntime: primary,
+    resolveExternalRuntime: () => secondary,
+    createMainWindow: (rt, options) => calls.push(['window', rt, options.ensureStartTab]),
+    setFocusedLocalProfile: (id) => calls.push(['profile', id]),
+    refreshDockMenu() {},
+    withWindowRuntime: (rt, fn) => { assert.equal(rt, secondary); fn(); },
+    refocusAddressBarIfWanted() {}, flushExternalUrls: () => calls.push(['flush']), flushTabHandoffs() {},
+  };
+  vm.runInNewContext(source, context);
+  context.app.activate();
+  assert.equal(context.focusedRuntime, secondary);
+  assert.deepEqual(calls, [['window', secondary, true], ['profile', 'work'], ['flush']]);
+  context.isQuitting = true;
+  context.app.activate();
+  assert.equal(calls.length, 3);
+});

--- a/test/unit/window-activation.test.js
+++ b/test/unit/window-activation.test.js
@@ -1,54 +1,200 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
 const test = require('node:test');
-const { bringExternalWindowToFront } = require('../../src/main/window-activation');
+const { bringExternalWindowToFront, externalWindowRuntime } = require('../../src/main/window-activation');
 
-function fixture({ minimized = false, destroyed = false } = {}) {
+function fixture(t, options = {}) {
+  t.mock.timers.enable({ apis: ['setImmediate', 'setTimeout'] });
+  const state = {
+    minimized: false, hidden: false, active: false, focused: false, destroyed: false,
+    deferRestore: false, deferActivation: false, deferFocus: false, ...options,
+  };
   const calls = [];
-  const application = {
-    focus(options) { calls.push(['app.focus', options]); },
+  const application = Object.assign(new EventEmitter(), {
+    isHidden: () => state.hidden,
+    isActive: () => state.active,
+    show() { calls.push('unhide'); state.hidden = false; },
+    focus(options) {
+      calls.push(['app.focus', options]);
+      if (!state.deferActivation) {
+        state.active = true;
+        this.emit('did-become-active');
+      }
+    },
+  });
+  const window = Object.assign(new EventEmitter(), {
+    isDestroyed: () => state.destroyed,
+    isMinimized: () => state.minimized,
+    isFocused: () => state.focused,
+    restore() {
+      calls.push('restore');
+      if (!state.deferRestore) { state.minimized = false; this.emit('restore'); }
+    },
+    show() { calls.push('show'); },
+    moveTop() { calls.push('moveTop'); },
+    focus() {
+      calls.push('window.focus');
+      if (state.active && !state.hidden && !state.minimized && !state.deferFocus) {
+        state.focused = true;
+        this.emit('focus');
+        application.emit('browser-window-focus', {}, this);
+      }
+    },
+  });
+  const activate = () => bringExternalWindowToFront(application, window, { platform: 'darwin' });
+  const noListeners = () => {
+    assert.deepEqual(application.eventNames(), []);
+    assert.deepEqual(window.eventNames(), []);
   };
-  const window = {
-    isDestroyed: () => destroyed,
-    isMinimized: () => minimized,
-    restore: () => calls.push(['restore']),
-    show: () => calls.push(['show']),
-    moveTop: () => calls.push(['moveTop']),
-    focus: () => calls.push(['window.focus']),
-  };
-  return { application, window, calls };
+  return { application, window, calls, state, activate, noListeners };
 }
 
-test('macOS external URL handoff restores, raises, activates, and focuses Blanc', () => {
-  const { application, window, calls } = fixture({ minimized: true });
-  assert.equal(
-    bringExternalWindowToFront(application, window, { platform: 'darwin' }),
-    true,
-  );
-  assert.deepEqual(calls, [
-    ['restore'],
-    ['show'],
-    ['moveTop'],
-    ['app.focus', { steal: true }],
-    ['window.focus'],
-  ]);
+for (const [name, options] of Object.entries({
+  background: {}, hidden: { hidden: true }, minimized: { minimized: true },
+  'hidden and minimized': { hidden: true, minimized: true },
+})) {
+  test(`macOS ${name} handoff unhides/restores before focusing and removes listeners`, (t) => {
+    const f = fixture(t, options);
+    assert.equal(f.activate(), true);
+    t.mock.timers.tick(0);
+    assert.equal(f.state.hidden, false);
+    assert.equal(f.state.minimized, false);
+    assert.equal(f.state.active, true);
+    assert.equal(f.state.focused, true);
+    assert.deepEqual(f.calls, [
+      ...(options.hidden ? ['unhide'] : []), ...(options.minimized ? ['restore'] : []),
+      'show', ['app.focus', { steal: true }], 'moveTop', 'window.focus',
+    ]);
+    f.noListeners();
+    const calls = f.calls.length;
+    t.mock.timers.tick(2_000);
+    assert.equal(f.calls.length, calls);
+  });
+}
+
+for (const order of [['restore', 'activate'], ['activate', 'restore']]) {
+  test(`native completions in order ${order.join(', ')}`, (t) => {
+    const f = fixture(t, { minimized: true, deferRestore: true, deferActivation: true });
+    f.activate();
+    t.mock.timers.tick(0);
+    assert.equal(f.state.focused, false);
+    for (const event of order) {
+      if (event === 'restore') { f.state.minimized = false; f.window.emit('restore'); }
+      else { f.state.active = true; f.application.emit('did-become-active'); }
+    }
+    assert.equal(f.state.focused, true);
+    f.noListeners();
+  });
+}
+
+test('the next-turn check repairs focus requested before native readiness', (t) => {
+  const f = fixture(t, { deferFocus: true });
+  f.activate();
+  assert.equal(f.state.focused, false);
+  f.state.deferFocus = false;
+  t.mock.timers.tick(0);
+  assert.equal(f.state.focused, true);
+  f.noListeners();
 });
 
-test('other platforms raise the handoff window without macOS steal activation', () => {
-  const { application, window, calls } = fixture();
-  assert.equal(
-    bringExternalWindowToFront(application, window, { platform: 'win32' }),
-    true,
-  );
-  assert.deepEqual(calls, [['show'], ['moveTop'], ['window.focus']]);
+test('a newer handoff cancels the earlier window before its delayed restore', (t) => {
+  const f = fixture(t, { minimized: true, deferRestore: true });
+  f.activate();
+  const other = Object.assign(new EventEmitter(), {
+    isDestroyed: () => false, isMinimized: () => false, isFocused: () => true,
+    show() {}, focus() {}, moveTop() {},
+  });
+  bringExternalWindowToFront(f.application, other, { platform: 'darwin' });
+  const count = f.calls.length;
+  f.state.minimized = false;
+  f.window.emit('restore');
+  t.mock.timers.tick(0);
+  assert.equal(f.calls.length, count);
+  f.noListeners();
+  assert.deepEqual(other.eventNames(), []);
 });
 
-test('a destroyed handoff window is a safe no-op', () => {
-  const { application, window, calls } = fixture({ destroyed: true });
-  assert.equal(
-    bringExternalWindowToFront(application, window, { platform: 'darwin' }),
-    false,
-  );
-  assert.deepEqual(calls, []);
+for (const [owner, event] of [
+  ['window', 'hide'], ['window', 'minimize'], ['window', 'closed'],
+  ['application', 'before-quit'], ['application', 'will-quit'],
+  ['application', 'did-resign-active'],
+]) {
+  test(`${event} cancels pending focus without pulling the app back`, (t) => {
+    const f = fixture(t, { deferFocus: true });
+    f.activate();
+    f[owner].emit(event);
+    const count = f.calls.length;
+    f.window.emit('restore');
+    f.application.emit('did-become-active');
+    t.mock.timers.tick(2_000);
+    assert.equal(f.calls.length, count);
+    f.noListeners();
+  });
+}
+
+test('changing to another Blanc window cancels the pending target', (t) => {
+  const f = fixture(t, { deferFocus: true });
+  f.activate();
+  f.application.emit('browser-window-focus', {}, {});
+  const count = f.calls.length;
+  t.mock.timers.tick(0);
+  assert.equal(f.calls.length, count);
+  f.noListeners();
+});
+
+test('a hidden app detected on the follow-up is left hidden', (t) => {
+  const f = fixture(t, { deferFocus: true });
+  f.activate();
+  f.state.hidden = true;
+  t.mock.timers.tick(0);
+  assert.equal(f.state.hidden, true);
+  f.noListeners();
+});
+
+test('a missing native completion expires after two seconds without polling', (t) => {
+  const f = fixture(t, { minimized: true, deferRestore: true });
+  f.activate();
+  t.mock.timers.tick(0);
+  const count = f.calls.length;
+  t.mock.timers.tick(1_999);
+  assert.ok(f.window.listenerCount('restore'));
+  t.mock.timers.tick(1);
+  f.noListeners();
+  assert.equal(f.calls.length, count);
+});
+
+test('destroyed targets and native call failures leave no activation listeners', (t) => {
+  const f = fixture(t, { destroyed: true });
+  assert.equal(f.activate(), false);
+  assert.deepEqual(f.calls, []);
+  f.state.destroyed = false;
+  f.window.show = () => { throw new Error('closed during show'); };
+  assert.throws(f.activate, /closed during show/);
+  f.noListeners();
+});
+
+test('Windows/Linux retain synchronous restoration without macOS app operations', (t) => {
+  const f = fixture(t, { minimized: true });
+  for (const platform of ['win32', 'linux']) {
+    f.state.minimized = true;
+    f.calls.length = 0;
+    assert.equal(bringExternalWindowToFront(f.application, f.window, { platform }), true);
+    assert.deepEqual(f.calls, ['restore', 'show', 'moveTop', 'window.focus']);
+    f.noListeners();
+  }
+});
+
+test('routing prefers the remembered live profile/window and skips closing or discarded runtimes', () => {
+  const primary = { profileId: 'personal', window: null };
+  const work = { profileId: 'work', window: { isDestroyed: () => false } };
+  const spare = { profileId: 'spare', window: { isDestroyed: () => false } };
+  const runtimes = [primary, spare, work];
+  assert.equal(externalWindowRuntime(runtimes, work, primary), work);
+  assert.equal(externalWindowRuntime(runtimes, primary, primary, work), work);
+  assert.equal(externalWindowRuntime(runtimes, { window: {} }, primary, work), work);
+  work.closing = true;
+  assert.equal(externalWindowRuntime(runtimes, work, primary), spare);
+  assert.equal(externalWindowRuntime([primary], null, primary), primary);
 });


### PR DESCRIPTION
External HTTP(S) links can be accepted without revealing Blanc, including after its last browser window is closed. This change recreates or restores the receiving window, unhides and activates macOS Blanc, and selects the requested tab as soon as chrome is ready, without waiting for the website to load.

The receiving window and profile survive app activation. Native focus recovery is bounded to two seconds, and a later hide/minimize, window change, superseding handoff, destruction, or shutdown cancels it. Cancellation also covers the wait for chrome initialization: the URL still opens once, but the canceled handoff does not select its tab or pull Blanc forward. Startup blocking and session-restore gates remain intact.

Validation on the rebased branch, using current main's Electron 44.2.0:

- Full unit suite: **1,609 passed**.
- Electron external-link smoke: passed cold startup, hidden/minimized/combined states, windowless reopening, profile routing, multi-link delivery, and the delayed-chrome cancellation regressions.
- Shared tab-handoff smoke: passed on macOS.

The earlier signed candidate passed the standard LaunchServices matrix, including ten hidden and ten minimized repetitions, native foreground assertions, closed-window reopening, and background activity. Its source predates this rebase. The public v1.15.0 baseline reproduced the closed-window failure; the owner's exact hidden/minimized email-app failure was not reproduced in isolation.

The owner has requested squash merge with the remaining native verification deferred for merging, as recorded in the [dated verification deferral](https://github.com/bnfy/blanc/blob/fea8a811/docs/release-incidents/2026-09-09-external-link-activation-verification-deferral.md). Before release, build and validate a fresh signed candidate from the merged source, confirm an actual email-link click and another Space on the affected Mac, and complete the background-only LaunchServices repeat. These checks remain unverified; merge authorization does not waive release gates.

[Detailed verification evidence and artifact provenance](https://github.com/bnfy/blanc/blob/fea8a811/docs/verification/2026-09-09-external-link-activation.md).
