### PR TITLE
Prepare Blanc 1.16.0 release

### DIFF
--- a/compliance/root-lock-sbom.cdx.json
+++ b/compliance/root-lock-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:root:blanc@1.15.1",
+      "bom-ref": "application:root:blanc@1.16.0",
       "name": "blanc dependency lock",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "description": "Complete root npm supply-chain inventory, including development and optional packages."
     },
     "properties": [
@@ -18197,7 +18197,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:root:blanc@1.15.1",
+      "ref": "application:root:blanc@1.16.0",
       "dependsOn": [
         "pkg:npm/%401password/sdk@0.5.0",
         "pkg:npm/%40cucumber/cucumber@13.2.1",

--- a/compliance/runtime-sbom.cdx.json
+++ b/compliance/runtime-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:runtime:blanc@1.15.1",
+      "bom-ref": "application:runtime:blanc@1.16.0",
       "name": "Blanc",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "description": "Shipped desktop runtime: npm closure, Electron framework, bundled fonts, and blocker data provenance."
     },
     "properties": [
@@ -1704,7 +1704,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:runtime:blanc@1.15.1",
+      "ref": "application:runtime:blanc@1.16.0",
       "dependsOn": [
         "asset:blanc-adblock-seed",
         "asset:inter-font",

--- a/docs/press/release-notes/v1.15.1.md
+++ b/docs/press/release-notes/v1.15.1.md
@@ -1,9 +1,0 @@
-# Blanc 1.15.1
-
-## Security
-
-- **Chromium's actively exploited V8 vulnerability is patched.** Blanc now runs on Electron 44.2.0, which carries the upstream fix for CVE-2026-85046. The flaw allowed a malicious page to execute code inside Chromium's renderer sandbox; it was not itself a sandbox escape. Update promptly.
-
-## Fixed
-
-- Thousands separators on the Mahjong Burst completion score now render cleanly instead of inheriting the score's dimensional text effect.

--- a/docs/press/release-notes/v1.16.0.md
+++ b/docs/press/release-notes/v1.16.0.md
@@ -1,0 +1,20 @@
+# Blanc 1.16.0
+
+## New
+
+- **Share your screen and system audio.** When a website asks to present, Blanc opens its own centered confirmation before any capture begins. Choose a screen or window, decide whether to include computer audio, and stop each active share from the Island even when its tab is in the background. Linux continues from Blanc's confirmation to the system sharing chooser.
+- **Bring Your Tabs opens in the current window.** Import open tabs from a supported browser through Blanc's private handoff, review the proposed organization, and add them to the window you are already using.
+
+## Security
+
+- **Chromium's actively exploited V8 vulnerability is patched.** Blanc now runs on Electron 44.2.0, which carries the upstream fix for CVE-2026-85046. The flaw allowed a malicious page to execute code inside Chromium's renderer sandbox; it was not itself a sandbox escape. Update promptly.
+
+## Improved
+
+- Screen sharing keeps website sessions deny-closed and grants capture only through a trusted Blanc helper after explicit approval. Direct and legacy desktop-capture paths remain blocked.
+- Links handed to Blanc from another app now restore and foreground the browser reliably.
+
+## Fixed
+
+- Thousands separators on the Mahjong Burst completion score now render cleanly instead of inheriting the score's dimensional text effect.
+- Profile settings now converge correctly during sync.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

The pending release grew from a patch into a feature release after secure screen and system-audio sharing landed. This changes the unpublished version from 1.15.1 to 1.16.0 and replaces the pending notes with one consolidated release note covering screen sharing, Bring Your Tabs, the Electron 44.2.0 security update, and accumulated fixes since public 1.15.0.

Public 1.15.0 remains unchanged. This PR does not create a tag, package, draft, or public release.

## Validation

- 34 targeted release, changelog, press, and startup tests passed
- version is 1.16.0 in `package.json` and both root lockfile fields
- `git diff --check` passed
