### PR TITLE
Record the v1.16.0 production site deployment

### DIFF
--- a/docs/release-incidents/2026-09-10-v1.16.0.md
+++ b/docs/release-incidents/2026-09-10-v1.16.0.md
@@ -93,7 +93,14 @@ Blanc v1.16.0 was published from immutable source commit
 
 ## Site evidence
 
-Pending the v1.16.0 release-record deployment.
+- Release-record PR <https://github.com/bnfy/blanc/pull/317> merged as
+  `f1c2c0835f86e6fdecddb39d159fcb4bc9fdace3` after every required check passed.
+- `npm run site:deploy` ran from a clean checkout of that exact commit.
+  Cloudflare Pages deployment `7c606421-2dc2-4ba9-9730-11e993398456` is
+  `Production` on branch `main` with source `f1c2c08`.
+- The canonical homepage reports `softwareVersion: 1.16.0`. The canonical
+  changelog shows v1.16.0 with **Share your screen and system audio** and
+  **Bring Your Tabs opens in the current window**.
 
 ## Updater evidence
 


### PR DESCRIPTION
Records the verified Cloudflare Pages Production deployment from merged main commit f1c2c083 and the canonical homepage/changelog checks. Documentation only; no product or release artifact changes.