### PR TITLE
design-sync: v1.16.0 resting island + v1.16.2 app-icon retirement

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -384,7 +384,8 @@ and found nothing). Owner approved the full scope + the push after render proof.
 
 ### Finding only, NOT fixed: pages.css `--shadow-pill` is undefined for internal pages
 `pages.css` referenced `var(--shadow-pill)` twice — `.ob-tile-blanc` and
-`.ob-minipill`, both first-run onboarding — but `tokens.json` scoped the token to
+`.ob-minipill`, both first-run onboarding (**partly overtaken 2026-09-11: PR #327
+deleted `.ob-tile-blanc` outright, so only `.ob-minipill` is still affected**) — but `tokens.json` scoped the token to
 `chrome` only, `pages.css` `:root` never declared it, and internal pages never load
 `styles.css`. With no fallback the declaration was invalid at computed-value time,
 so both elements painted **no shadow at all**. Present since 0fea28e (#140,
@@ -437,3 +438,69 @@ capture-controls popover, retinted theme icons — are still open.
   re-typing it. Verify the transcription before pushing: split the result into
   paragraphs, list the ones you meant to change, and read the rest back against the
   fetched copy — curly apostrophes and em-dashes are where it drifts.
+
+## 2026-09-12 sync (push-drift, v1.16.0 → v1.16.2 — app-icon retirement + doc rot)
+
+Scan c937dcb4 (the squash of the last sync's head) → 534e2cd8. Of the fifteen commits
+only **#327 "Replace legacy app branding with theme-aware Sunrise artwork"** touched a
+DS surface; #325 was startup-recovery CSS on an internal page, and the v1.16.1/v1.16.2
+release train (#328–#339) touched none. **No drift in the three canonical pairs** —
+`styles.css`, `tokens.json` and all four icon sources are untouched — and
+`guidelines/brand-logos.html` needed nothing, since the Sunrise mark itself did not
+change. Owner approved all three tiers below plus the keep-and-relabel call.
+
+- **App icons: four → two (#327).** `settings-schema/schema.json` and
+  `src/main/app-icon-assets.js` now list only **sunrise** (default) and
+  **sunrise-dark**; Paper and Ink joined the monogram set in retirement,
+  `package.json` excludes eleven colorway PNGs from the payload, and a saved retired
+  id falls back to Sunrise on read. `supporterIcons` is `[]`. The owner's rule for
+  this pass: the B is gone from app UI **except inside Mahjong tile artwork**, kept
+  as a nod to Blanc's origins. Mirrored to `guidelines/dock-icon-colorways.html`
+  (rebuilt: a selectable Sunrise pair above, the five monogram tiles below in
+  greyscale at 50% under an explicit "retired — not selectable and not packaged"
+  heading — owner chose keep-and-relabel over deleting the PNGs), and to `DOCK_ICONS`
+  in both `templates/browser/app.jsx` and `ui_kits/browser/pages.jsx`, whose App icon
+  hint now matches the shipped "Follows macOS Icon & Widget Style; Finder uses
+  Sunrise".
+- **`readme.md` had rotted well beyond #327, and part of that was the previous sync's
+  miss.** The 2026-09-11 run pushed thirteen component/token files but never opened
+  the readme, which restates the same facts in prose — so it still described a 64px
+  strip (twice), the resting island "wearing the fitted `--shadow-pill`", "two
+  shadows", "no blur" (the island now carries a 16px backdrop blur), the island under
+  the 999px corners, and "the expanded island panel is the one 10px corner" — 18px
+  since 2026-08-09. Older errors fixed in the same pass, each verified against the
+  app first: private mode was documented with its pre-monochrome green cast
+  (`#0c110e` / `#a8c8b0`) while the same file's VISUAL FOUNDATIONS paragraph already
+  said the green was dropped — real values `#0a0a0a` / `#f5f5f5`; the slash-command
+  list advertised `/adblock` and `/off-leash`, which do not ship (they became
+  `/block-ads` and `/allow-ads`) and omitted eleven that do, against a shipped set of
+  24; and the island was said to name the active group and fold collapsed groups into
+  a "mini-dot capsule" when it does neither — there is no group name in the island
+  (no `pillGroup` element exists) and overflow is a quiet `+N` past `DOT_CAP = 8`.
+- **`github.md` had no entry for the 2026-09-11 sync either** — same miss. Written
+  retroactively alongside today's, and `guidelines/dock-icon-colorways.html` was added
+  to the screen map with `settings-schema/schema.json` + `src/main/app-icon-assets.js`
+  as its sources, so the app-icon set is a tracked input from now on rather than
+  something only noticed when a colorway disappears.
+- Pushed as plan_bee811dfe403446a_d34b471be18e, 5 files + sentinel fenced first and
+  re-armed last. Verified by round-tripping `templates/browser/app.jsx` back
+  byte-identical, and by rendering the rebuilt colorway card (7/7 images decode,
+  2 selectable + 5 retired at 0.5 greyscale, no horizontal overflow).
+- **No app file was touched**, per the standing rule above.
+
+### Lesson: prose surfaces need their own sweep
+A component sync is not a documentation sync. `readme.md` and `github.md` restate in
+prose what the token and component files encode, and the design agent reads the readme
+as fact — so a number corrected in `tokens/layout.css` but left standing in the readme
+is still wrong where it does the most damage. **Every future push-drift run must grep
+`readme.md` for the values it just changed** (strip height, radii, shadow names and
+counts, colour hexes, command names, icon counts) before closing, and add a `github.md`
+entry. The three canonical pairs are the scan's floor, not its ceiling.
+
+### Still open (carried forward)
+- `.ob-minipill` (first-run onboarding) still asks for `--shadow-pill`, still undefined
+  for internal pages, so it still paints no shadow; and it draws a 999px capsule while
+  illustrating an island that is now 44/17. Both are app-side, so both stay findings —
+  see the standing rule.
+- PORT-CHECKLIST's older gaps: the capture-controls popover and retinted theme icons.
+- The display-share picker dialog stays unmodeled (transient in-flow UI).

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -328,3 +328,100 @@ ASSET-LICENSE/README) — it LANDED mid-sync as 5e0964e ("Adopt Sunrise across a
   can be patched with assert-per-replacement scripts.
 - A CSS `mask` on a raster needs the alpha channel: an alpha-EXTRACTED grayscale PNG masks
   as a solid square; keep RGBA (zero RGB, keep alpha) instead.
+
+## 2026-09-11 sync (push-drift, v1.12.0 → v1.16.0 — resting island refresh)
+
+Drift scan from 6469a2f (last sync) to main 5e6de3d, 153 commits. Three touched DS
+surfaces: **ff3eaad1** ("refine resting island and add new tab shortcut"),
+**0093b6c4** ("use Inter in vertical tabs"), **aec328a0** (screen + system-audio
+sharing, #308). Brand scan clean — no `icon.svg` / `sunrise-mark.png` / dock-PNG
+change rode in on an unrelated PR this window (the 2026-08-31 scan lesson applied
+and found nothing). Owner approved the full scope + the push after render proof.
+
+- **Tokens: FIRST REAL DRIFT since this mirror began.** `--strip-h` 64 → **68px**;
+  new `--island-resting-surface` (light `rgba(255,255,255,.94)` / dark
+  `rgba(31,31,31,.94)` / private `rgba(25,25,25,.94)`), `--shadow-island-resting`,
+  `--island-resting-height: 44px`, `--island-resting-radius: 17px`. `--shadow-pill`
+  is NO LONGER the island's shadow — it now dresses the tab dot's favicon peek and
+  the onboarding island illustration; layout.css's long "fades out inside the 64px
+  strip" rationale was rewritten around that. `--control-h` stays 28px but its
+  comment dropped "address input", which is now its own 36px/14px geometry.
+  pages.css `:root` did NOT drift (the mono→Inter churn there is a scoped
+  `.ledger-body` override, not a token).
+- **Island.jsx: the resting material moved to `::after`.** 94% face + 1px border +
+  16px backdrop blur + the website nav's shadow, painted one layer below the
+  content so the resting layer can stay `transform: none` and render crisp; fixed
+  44/17 counter-scaled against `--pill-zoom`; the rise/grow now sits behind a
+  `.proximity-active` class fed by a new `proximity` prop (0→1). Private's dashed
+  edge moved to `::after` with it. Also added the **Slash + Plus shortcut keycaps**
+  (`.bw-pill-shortcuts`, matched 22px targets over 18×17 faces, 4px pair gap,
+  hidden wholesale in vertical-tabs mode) and the **display-share chip**
+  (`displayShares` + `onDisplayShareClick`, window-wide, reuses `.bw-capture-chip`;
+  `.display-share-chip` is a marker class with no declarations in the app).
+- **`box-sizing: border-box` added to `.bw-pill` — the one non-verbatim line.** The
+  app inherits it from a global `* { box-sizing: border-box }` reset that a
+  standalone DS component cannot assume. Irrelevant while the pill's height fell
+  out of padding; now that the height is FIXED, without it the 1px border lands
+  outside and the island renders **46px instead of 44px**. Documented in the file.
+  If a future port of a fixed-size app element looks 2px tall, check this first.
+- **Icons: two added, and the `plus` question settled.** `displayShare` (verbatim
+  from index.html `#pillDisplayShare`). `plusWide` (`M8 3v10M3 8h10`) is NEW: the
+  island's New-tab keycap uses the RAIL's plus drawing, not the DS `plus`
+  (`M8 3.25v9.5…`, still correct for the panel's new-tab buttons). Owner chose to
+  carry both rather than pick a winner — same rule as pin/pinned and mute/audible.
+  The old "two plus drawings coexist, left as-is" non-sync is therefore SUPERSEDED:
+  both are now named glyphs. `reopen` remains a deliberate non-sync; `extensions`
+  remains retired.
+- Guidelines refreshed: `metrics.html` (68px strip, 44/17 island, 36/14 address
+  input, 18px panel radius — that last one had been stale at 10px since the
+  2026-08-09 softening), `elevation.html` (now THREE shadows; the island swatch
+  carries the real face + blur, and `--shadow-pill` is relabelled as the peek
+  disc's), `vertical-tabs.html` (rail typography mono→Inter in all four places
+  0093b6c4 touched, 68px strip, and the stand-in minipill rebuilt as the 44/17
+  material instead of the retired capsule).
+- Pushed as plan_bee811dfe403446a_e97afb2cfd05, 13 files + sentinel fenced first
+  and re-armed last. Verified: `tokens/layout.css` round-trips byte-identical.
+
+### Repo fix made alongside (NOT a DS push, NOT yet committed): pages.css `--shadow-pill` was undefined
+`pages.css` referenced `var(--shadow-pill)` twice — `.ob-tile-blanc` and
+`.ob-minipill`, both first-run onboarding — but `tokens.json` scoped the token to
+`chrome` only, `pages.css` `:root` never declared it, and internal pages never load
+`styles.css`. With no fallback the declaration was invalid at computed-value time,
+so both elements painted **no shadow at all**. Present since 0fea28e (#140,
+2026-08-16); unrelated to this drift window, found while rewriting the layout.css
+shadow comment. Fixed by adding `pages` to the token's consumers and declaring it
+in `pages.css` `:root` (exact `tokens.json` value — the checker compares strings, so
+the unspaced `rgba(255,255,255,0.65)` form is required). Proved with a positive
+control: the pre-fix stylesheet computes `box-shadow: none` on both elements, the
+fixed one resolves all six layers. `npm run substrate:check` and 1770 unit tests pass.
+
+**Left UNCOMMITTED in the shared checkout, deliberately.** A concurrent session was
+mid-edit on `src/renderer/pages/pages.css` (its own `#startupCard` recovery rules,
+alongside uncommitted `main.js`/`newtab.html`/`package.json` and two new
+`test/desktop/*-smoke.mjs` files), so that file carries two unrelated hunks and could
+not be staged wholesale. `tokens.json` and `pages.css` must land in the SAME commit
+or `tokens:check` fails both ways (the checker flags a token in the source that the
+CSS lacks, and a token in the CSS the source lacks), so splitting them was not an
+option either. The three files — `tokens/tokens.json`, `tokens/generated/tokens.css`,
+and the `:root` hunk of `pages.css` — are in the working tree awaiting the owner.
+
+**Still open / deliberately not done:** the onboarding `.ob-minipill` now draws a
+999px capsule wearing `--shadow-pill` — it illustrates the RESTING ISLAND, which is
+no longer either of those things. Restoring its shadow was a bug fix; restyling it
+to the 44/17 island material is a design change and needs the owner's call. The
+display-share PICKER dialog stays unmodeled (transient in-flow UI, same class as the
+fill-status capsule and the Patron gate). PORT-CHECKLIST's two older gaps —
+capture-controls popover, retinted theme icons — are still open.
+
+### Gotchas learned
+- The DS component CSS is written one rule per line inside a JS template literal, so
+  a naive `indexOf("\n}")` block extractor swallows dozens of following rules and
+  "compares" the wrong thing. Use brace counting. Likewise `indexOf(sel + " {")`
+  matches a longer selector that merely ENDS with your selector
+  (`#strip.glance-open #islandPill` before `#islandPill`) — anchor on the newline.
+- Never put a backtick inside Island.jsx's `css` template literal; it terminates the
+  literal and the whole bundle silently renders nothing.
+- `get_file` on a file under ~50 KB is not persisted to disk, so patching one means
+  re-typing it. Verify the transcription before pushing: split the result into
+  paragraphs, list the ones you meant to change, and read the rest back against the
+  fetched copy — curly apostrophes and em-dashes are where it drifts.

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -382,33 +382,45 @@ and found nothing). Owner approved the full scope + the push after render proof.
 - Pushed as plan_bee811dfe403446a_e97afb2cfd05, 13 files + sentinel fenced first
   and re-armed last. Verified: `tokens/layout.css` round-trips byte-identical.
 
-### Repo fix made alongside (NOT a DS push, NOT yet committed): pages.css `--shadow-pill` was undefined
+### Finding only, NOT fixed: pages.css `--shadow-pill` is undefined for internal pages
 `pages.css` referenced `var(--shadow-pill)` twice — `.ob-tile-blanc` and
 `.ob-minipill`, both first-run onboarding — but `tokens.json` scoped the token to
 `chrome` only, `pages.css` `:root` never declared it, and internal pages never load
 `styles.css`. With no fallback the declaration was invalid at computed-value time,
 so both elements painted **no shadow at all**. Present since 0fea28e (#140,
 2026-08-16); unrelated to this drift window, found while rewriting the layout.css
-shadow comment. Fixed by adding `pages` to the token's consumers and declaring it
-in `pages.css` `:root` (exact `tokens.json` value — the checker compares strings, so
-the unspaced `rgba(255,255,255,0.65)` form is required). Proved with a positive
-control: the pre-fix stylesheet computes `box-shadow: none` on both elements, the
-fixed one resolves all six layers. `npm run substrate:check` and 1770 unit tests pass.
+shadow comment. Confirmed with a positive control: the stylesheet computes
+`box-shadow: none` on both elements, and adding the token to `pages.css` `:root`
+(plus `pages` to its `tokens.json` consumers) resolves all six layers.
 
-**Left UNCOMMITTED in the shared checkout, deliberately.** A concurrent session was
-mid-edit on `src/renderer/pages/pages.css` (its own `#startupCard` recovery rules,
-alongside uncommitted `main.js`/`newtab.html`/`package.json` and two new
-`test/desktop/*-smoke.mjs` files), so that file carries two unrelated hunks and could
-not be staged wholesale. `tokens.json` and `pages.css` must land in the SAME commit
-or `tokens:check` fails both ways (the checker flags a token in the source that the
-CSS lacks, and a token in the CSS the source lacks), so splitting them was not an
-option either. The three files — `tokens/tokens.json`, `tokens/generated/tokens.css`,
-and the `:root` hunk of `pages.css` — are in the working tree awaiting the owner.
+**A fix was written, then REVERTED on the owner's instruction — see the standing
+rule below.** The app is byte-identical to before this sync. Anyone picking this up
+later: the two halves must land in ONE commit or `tokens:check` fails both ways (it
+flags a token the source has and the CSS lacks, and vice versa), and `pages.css`
+needs the exact unspaced `rgba(255,255,255,0.65)` form because the checker compares
+strings, not colours.
 
-**Still open / deliberately not done:** the onboarding `.ob-minipill` now draws a
-999px capsule wearing `--shadow-pill` — it illustrates the RESTING ISLAND, which is
-no longer either of those things. Restoring its shadow was a bug fix; restyling it
-to the 44/17 island material is a design change and needs the owner's call. The
+## STANDING RULE (owner, 2026-09-11): /design-sync never changes the app
+
+This mode is a ONE-WAY mirror: the app is the source of truth and the Design System
+is what gets updated. Do not edit app code during a sync — not a token, not a
+stylesheet, not a "bug fix" — even when a repo change is approved earlier in the
+same conversation, and even when the defect is real and provable. Anything found in
+the app gets WRITTEN DOWN here and handed to the owner as a separate decision; it
+never rides along with a sync.
+
+The `--shadow-pill` fix above is the case that produced this rule: it was a genuine
+bug with a verified positive control, and it still changed what the app renders
+(onboarding tiles gaining a shadow they had not been drawing), which is a design
+change. Restoring intended behaviour is not a licence to alter shipped appearance.
+The fix and its `tokens.json`/`tokens/generated` half were reverted; only this record
+remains. The same rule retires the `.ob-minipill` restyle floated below — do not act
+on it, just leave it documented.
+
+**Still open / deliberately not done:** the onboarding `.ob-minipill` draws a 999px
+capsule asking for `--shadow-pill` — it illustrates the RESTING ISLAND, which is no
+longer either of those things (and, per the finding above, it gets no shadow at all).
+Restyling it to the 44/17 island material is the owner's call, not a sync's. The
 display-share PICKER dialog stays unmodeled (transient in-flow UI, same class as the
 fill-status capsule and the Patron gate). PORT-CHECKLIST's two older gaps —
 capture-controls popover, retinted theme icons — are still open.


### PR DESCRIPTION
Documentation only — `.design-sync/NOTES.md`, no app or site code touched.

Covers **two** `/design-sync` push-drift runs against the Blanc Design System.

## 2026-09-11 — resting island refresh (v1.12.0 → v1.16.0)

Scan `6469a2f` → `5e6de3d`, 153 commits. Thirteen files pushed to the DS.

- **First real token drift since this mirror began:** `--strip-h` 64 → 68px, plus new
  `--island-resting-surface`, `--shadow-island-resting`, `--island-resting-height: 44px`,
  `--island-resting-radius: 17px`. `--shadow-pill` stopped being the island's shadow.
- The Island's material moved onto an `::after` so the resting content layer can stay at
  `transform: none`; rise/grow now sits behind a `proximity` prop. Added the Slash + Plus
  shortcut keycaps and the window-wide display-share chip.
- `plusWide` settles the long-standing two-plus question by carrying both drawings.

## 2026-09-12 — app-icon retirement (v1.16.0 → v1.16.2)

Scan `c937dcb4` → `534e2cd8`. Of fifteen commits only **#327** touched a DS surface;
the three canonical pairs show **no drift at all** this round. Five files pushed.

- Settings → App icon went from four choices to **Sunrise and Sunrise Dark**. The legacy
  B is gone from app UI everywhere except Mahjong tile artwork, kept deliberately.
- The colorway guideline was rebuilt as a selectable pair above an explicitly-labelled,
  greyed-out retired row; the monogram PNGs stay as brand history (owner's call).
- Both `DOCK_ICONS` lists cut to two, with the shipped Finder hint.

### The readme work was not all #327

The 2026-09-11 run pushed component and token files but never opened `readme.md`, which
restates the same facts in prose — so the DS kept telling the design agent the strip was
64px, the island a capsule wearing `--shadow-pill`, and the panel corner 10px. Older
errors went with it: the pre-monochrome private palette (`#0c110e`/`#a8c8b0` vs the real
`#0a0a0a`/`#f5f5f5`), two slash commands that don't ship, and an island that neither
names its group nor folds one into a "mini-dot capsule". Each was verified against the
app before being called wrong. `github.md` had no entry for that run either; it now has
both, and the colorway guideline's source files are in its screen map.

NOTES records the lesson: **a component sync is not a documentation sync** — every future
run sweeps `readme.md` for the values it just changed.

## Also recorded: an app bug, deliberately not fixed

`pages.css` asks for `var(--shadow-pill)` in first-run onboarding while the token is
scoped chrome-only, so it paints no shadow. A fix was written on 2026-09-11 and
**reverted** — `/design-sync` is a one-way mirror, and restoring intended behaviour still
changes what the app renders. PR #327 has since deleted one of the two affected rules on
its own. The finding keeps its evidence and the gotchas a later fix would need.

## Verification

- No app file touched by either run; `substrate:check` and 1770 unit tests passed on the day the revert landed
- Both DS pushes verified by round-tripping a file back byte-identical (`tokens/layout.css`, then `templates/browser/app.jsx`)
- Rebuilt colorway card rendered: 7/7 images decode, 2 selectable + 5 retired, no overflow
- Island states measured against the app's own QA figures — 44×17px, 25.30px keycap targets, 18×17 faces, `matrix(1.02,0,0,1.02,0,-2)` at full proximity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALvDt5kqgR88ZKWadj1Two