### PR TITLE
Prepare v1.16.1 recovery and Sunrise release

### DIFF
--- a/compliance/THIRD_PARTY_NOTICES.txt
+++ b/compliance/THIRD_PARTY_NOTICES.txt
@@ -41,7 +41,7 @@ RUNTIME NPM COMPONENTS
 
 EMBEDDED FRAMEWORK
 
-- Electron 44.2.0 — MIT — https://github.com/electron/electron
+- Electron 44.3.0 — MIT — https://github.com/electron/electron
   Electron embeds Chromium, Node.js, V8, and other upstream work. LICENSE.electron.txt and
   LICENSES.chromium.html are copied beside this notice in every packaged application.
 

--- a/compliance/root-lock-sbom.cdx.json
+++ b/compliance/root-lock-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:root:blanc@1.16.0",
+      "bom-ref": "application:root:blanc@1.16.1",
       "name": "blanc dependency lock",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "description": "Complete root npm supply-chain inventory, including development and optional packages."
     },
     "properties": [
@@ -7629,14 +7629,14 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/electron@44.2.0",
+      "bom-ref": "pkg:npm/electron@44.3.0",
       "name": "electron",
-      "version": "44.2.0",
+      "version": "44.3.0",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "a0ad6272385aa69df1b1467270ef5665a2e67778499c0ee27a86c2e26a5db4ed6910df8f3c65a90379b5320cf3b9cd70cd20f659a8b8cdc1f8c9fa4626ac4530"
+          "content": "4adf4457b17656d61a6160f6a9a0230705202b1c77f5e24e52c509e7eff5d75deca9b55f36abf80db9bf5b5acdeea99848f6be996c11eb2afe6fb31f8238157d"
         }
       ],
       "licenses": [
@@ -7646,7 +7646,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/electron@44.2.0",
+      "purl": "pkg:npm/electron@44.3.0",
       "properties": [
         {
           "name": "blanc:development",
@@ -7668,7 +7668,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/electron/-/electron-44.2.0.tgz"
+          "url": "https://registry.npmjs.org/electron/-/electron-44.3.0.tgz"
         }
       ]
     },
@@ -18197,7 +18197,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:root:blanc@1.16.0",
+      "ref": "application:root:blanc@1.16.1",
       "dependsOn": [
         "pkg:npm/%401password/sdk@0.5.0",
         "pkg:npm/%40cucumber/cucumber@13.2.1",
@@ -18206,7 +18206,7 @@
         "pkg:npm/%40ghostery/adblocker@2.18.2",
         "pkg:npm/electron-builder@26.15.3",
         "pkg:npm/electron-updater@6.8.9",
-        "pkg:npm/electron@44.2.0",
+        "pkg:npm/electron@44.3.0",
         "pkg:npm/playwright@1.62.1",
         "pkg:npm/sharp@0.35.3"
       ]
@@ -19280,7 +19280,7 @@
       ]
     },
     {
-      "ref": "pkg:npm/electron@44.2.0",
+      "ref": "pkg:npm/electron@44.3.0",
       "dependsOn": [
         "pkg:npm/%40electron-internal/extract-zip@1.0.4",
         "pkg:npm/%40electron/get@5.0.0",

--- a/compliance/runtime-sbom.cdx.json
+++ b/compliance/runtime-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:runtime:blanc@1.16.0",
+      "bom-ref": "application:runtime:blanc@1.16.1",
       "name": "Blanc",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "description": "Shipped desktop runtime: npm closure, Electron framework, bundled fonts, and blocker data provenance."
     },
     "properties": [
@@ -1036,14 +1036,14 @@
     },
     {
       "type": "framework",
-      "bom-ref": "pkg:npm/electron@44.2.0",
+      "bom-ref": "pkg:npm/electron@44.3.0",
       "name": "electron",
-      "version": "44.2.0",
+      "version": "44.3.0",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "a0ad6272385aa69df1b1467270ef5665a2e67778499c0ee27a86c2e26a5db4ed6910df8f3c65a90379b5320cf3b9cd70cd20f659a8b8cdc1f8c9fa4626ac4530"
+          "content": "4adf4457b17656d61a6160f6a9a0230705202b1c77f5e24e52c509e7eff5d75deca9b55f36abf80db9bf5b5acdeea99848f6be996c11eb2afe6fb31f8238157d"
         }
       ],
       "licenses": [
@@ -1053,7 +1053,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/electron@44.2.0",
+      "purl": "pkg:npm/electron@44.3.0",
       "properties": [
         {
           "name": "blanc:declaration",
@@ -1067,7 +1067,7 @@
       "externalReferences": [
         {
           "type": "distribution",
-          "url": "https://registry.npmjs.org/electron/-/electron-44.2.0.tgz"
+          "url": "https://registry.npmjs.org/electron/-/electron-44.3.0.tgz"
         }
       ]
     },
@@ -1704,7 +1704,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:runtime:blanc@1.16.0",
+      "ref": "application:runtime:blanc@1.16.1",
       "dependsOn": [
         "asset:blanc-adblock-seed",
         "asset:inter-font",
@@ -1712,7 +1712,7 @@
         "pkg:npm/%401password/sdk@0.5.0",
         "pkg:npm/%40ghostery/adblocker-electron@2.18.2",
         "pkg:npm/electron-updater@6.8.9",
-        "pkg:npm/electron@44.2.0"
+        "pkg:npm/electron@44.3.0"
       ]
     },
     {
@@ -1856,7 +1856,7 @@
       ]
     },
     {
-      "ref": "pkg:npm/electron@44.2.0",
+      "ref": "pkg:npm/electron@44.3.0",
       "dependsOn": []
     },
     {

--- a/docs/press/release-notes/v1.16.1.md
+++ b/docs/press/release-notes/v1.16.1.md
@@ -1,0 +1,16 @@
+# Blanc 1.16.1
+
+## Fixed
+
+- Session recovery is visible in every New Tab layout. Links opened from email or another app can continue after you choose whether to restore your saved tabs.
+- Restoring tabs after closing and reopening the recovery window from the Dock no longer waits indefinitely. Recovery also keeps named profiles separate and avoids restoring tabs into windows closed during startup.
+
+## Improved
+
+- Onboarding now uses Sunrise artwork, with Sunrise Dark in dark mode.
+- Retired B-monogram app icons have been removed from Settings and packaged internal pages. Existing retired icon choices fall back to Sunrise. The B motif in Mahjong tiles remains as a nod to Blanc's origins.
+- Updated to Electron 44.3.0 and Chromium 152.0.7977.78 for upstream fixes.
+
+## Known issue
+
+- Opening some Chrome Web Store pages can still crash the browser because of an upstream Electron issue. This release fixes session recovery, but does not include the pending upstream Chrome Web Store fix.

--- a/docs/release-incidents/2026-09-11-v1.16.1.md
+++ b/docs/release-incidents/2026-09-11-v1.16.1.md
@@ -26,6 +26,9 @@ See `docs/verification/2026-09-11-mimestream-recovery.md` and
   checks passed with Electron 44.3.0 using isolated profiles.
 - The production dependency audit reported zero vulnerabilities.
 - The complete site build and SEO checks passed for 25 pages and 24 sitemap URLs.
+- The first desktop acceptance run found a stale scenario selecting retired
+  Ink. Updated the scenario to select the supported Sunrise Dark icon; the
+  application's fallback to Sunrise was correct.
 
 ## Pending evidence
 

--- a/docs/release-incidents/2026-09-11-v1.16.1.md
+++ b/docs/release-incidents/2026-09-11-v1.16.1.md
@@ -1,0 +1,36 @@
+# v1.16.1 recovery and Sunrise release — 2026-09-11
+
+Status: preparation; no publication or platform verification claimed yet.
+
+## Scope
+
+- Recovery visibility and lifecycle fixes from PR #325.
+- Theme-aware Sunrise onboarding, retirement of legacy B app-icon choices and
+  packaged page assets, and the intentional Mahjong B-tile exception from PR #327.
+- Electron 44.3.0 (Chromium 152.0.7977.78), with regenerated compliance inputs.
+- Migration baseline remains public v1.16.0.
+
+## Known limitation
+
+The Chrome Web Store native crash diagnosed during the recovery investigation
+is separate from Blanc's recovery fixes. Electron's 44.x backport
+<https://github.com/electron/electron/pull/53776> remained open during preparation
+and is absent from the 44.3.0 release notes. No fix for that crash is claimed.
+See `docs/verification/2026-09-11-mimestream-recovery.md` and
+`docs/verification/2026-09-11-ui-brand-audit.md` for the source-change evidence.
+
+## Preparation evidence
+
+- All 1,773 unit tests passed on the finalized release inputs.
+- Startup layout, recovery-window reopening, and recovery lifecycle desktop
+  checks passed with Electron 44.3.0 using isolated profiles.
+- The production dependency audit reported zero vulnerabilities.
+- The complete site build and SEO checks passed for 25 pages and 24 sitemap URLs.
+
+## Pending evidence
+
+- Exact-source release verification, signing/notarization, packaged checks,
+  native Windows/Linux builds, manifest authentication, and public smoke.
+- Adjacent public v1.16.0 → v1.16.1 macOS and Windows in-app updater handoffs.
+- Canonical site deployment and release-backed launch disposition. Publication
+  alone does not establish a launch freeze or shorten the required soak.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18,7 +18,7 @@
         "@cucumber/cucumber": "^13.2.1",
         "@electron/asar": "4.3.0",
         "@ghostery/adblocker": "^2.18.2",
-        "electron": "^44.2.0",
+        "electron": "^44.3.0",
         "electron-builder": "^26.15.3",
         "playwright": "^1.62.1",
         "sharp": "^0.35.3"
@@ -2594,9 +2594,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "44.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-44.2.0.tgz",
-      "integrity": "sha512-oK1icjhapp3xsUZycO9WZaLmd3hJnA7ieobC4mpdtO1pEN+PPGWpA3m1Mgzzuc1wzSD2Wai4zcH4yfpGJqxFMA==",
+      "version": "44.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-44.3.0.tgz",
+      "integrity": "sha512-St9EV7F2VtYaYWD2qaAjBwUgKxx39eJOUsUJ5+/1113sqbVfNqv4Dbm/W1rN7qmYSPa+mWwR6yr+b7MfgjgVfQ==",
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",
@@ -69,7 +69,7 @@
     "@cucumber/cucumber": "^13.2.1",
     "@electron/asar": "4.3.0",
     "@ghostery/adblocker": "^2.18.2",
-    "electron": "^44.2.0",
+    "electron": "^44.3.0",
     "electron-builder": "^26.15.3",
     "playwright": "^1.62.1",
     "sharp": "^0.35.3"

--- a/spec/acceptance/supporter-and-session.feature
+++ b/spec/acceptance/supporter-and-session.feature
@@ -5,8 +5,8 @@ Feature: App icon catalog, Patron, and session restore
 
   @F17-1 @F17 @all @D6
   Scenario: A current app icon can be selected
-    When I choose the app icon "ink"
-    Then the app icon "ink" is applied
+    When I choose the app icon "sunrise-dark"
+    Then the app icon "sunrise-dark" is applied
 
   @F17-2 @F17 @all
   Scenario: A retired icon cannot be restored by an active Patron

--- a/test/unit/compliance-model.test.js
+++ b/test/unit/compliance-model.test.js
@@ -29,7 +29,7 @@ test('runtime SBOM covers npm closure, Electron, fonts, and blocker provenance',
 
   assert.equal(generated.runtime.runtimePackages.length, 32);
   assert.equal(sbom.components.length, 39);
-  assert.ok(refs.has('pkg:npm/electron@44.2.0'));
+  assert.ok(refs.has('pkg:npm/electron@44.3.0'));
   assert.ok(refs.has('pkg:npm/%401password/sdk@0.5.0'));
   assert.ok(refs.has('pkg:npm/%401password/sdk-core@0.5.0'));
   assert.ok(refs.has('asset:inter-font'));
@@ -42,7 +42,7 @@ test('runtime SBOM covers npm closure, Electron, fonts, and blocker provenance',
   assert.equal([...refs].some((ref) => ref.includes('electron-builder@')), false);
 
   const root = sbom.dependencies.find((item) => item.ref.startsWith('application:runtime:'));
-  assert.ok(root.dependsOn.includes('pkg:npm/electron@44.2.0'));
+  assert.ok(root.dependsOn.includes('pkg:npm/electron@44.3.0'));
   assert.ok(root.dependsOn.includes('asset:blanc-adblock-seed'));
   const seed = sbom.dependencies.find((item) => item.ref === 'asset:blanc-adblock-seed');
   assert.deepEqual(seed.dependsOn, [


### PR DESCRIPTION
Prepare v1.16.1 to ship the merged startup recovery and Sunrise branding fixes. Bump Electron to 44.3.0, regenerate compliance inputs, update the runtime assertion, and add release notes plus a pending release-evidence record.

The separate upstream Chrome Web Store crash remains explicitly documented as a known issue. Mahjong B tiles remain preserved. This preparation does not claim publication, updater handoffs, or a launch freeze.

Validation: 1,773 unit tests passed; substrate checks, all three recovery desktop checks on Electron 44.3.0, production dependency audit (zero vulnerabilities), and the full site/SEO build passed. The signed release workflow will rerun the complete press and packaged gates before publication.

The full desktop acceptance suite also passed (141 scenarios, 865 steps), followed by cold-launch, OAuth, and DNS checks. Updated the stale acceptance scenario from retired Ink to supported Sunrise Dark.
