### PR TITLE
Stabilize packaged release smoke navigation and cleanup

### DIFF
--- a/.github/workflows/release-windows-linux.yml
+++ b/.github/workflows/release-windows-linux.yml
@@ -146,6 +146,19 @@ jobs:
           PRODUCT_NAME=$(node -p "require('./package.json').productName")
           node scripts/verify-electron-fuses.mjs "dist/win-unpacked/$PRODUCT_NAME.exe"
 
+      # Build inputs remain pinned to the release tag. After packaging, use
+      # the workflow commit's test harness so infrastructure-only fixes can
+      # verify an immutable draft without rebuilding its other native assets.
+      - name: Load smoke harness from workflow commit
+        shell: bash
+        env:
+          VERIFICATION_SHA: ${{ github.sha }}
+        run: |
+          git fetch --no-tags origin "$VERIFICATION_SHA"
+          for smoke in packaged-media-smoke.mjs packaged-tab-handoff-protocol-smoke.mjs; do
+            git show "$VERIFICATION_SHA:test/desktop/$smoke" > "test/desktop/$smoke"
+          done
+
       - name: Verify packaged microphone and camera permissions and live tracks
         shell: pwsh
         run: |
@@ -329,6 +342,19 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes dbus-x11 desktop-file-utils libfuse2 xdg-utils xvfb
+
+      # Build inputs remain pinned to the release tag. After packaging, use
+      # the workflow commit's test harness so infrastructure-only fixes can
+      # verify an immutable draft without rebuilding its other native assets.
+      - name: Load smoke harness from workflow commit
+        shell: bash
+        env:
+          VERIFICATION_SHA: ${{ github.sha }}
+        run: |
+          git fetch --no-tags origin "$VERIFICATION_SHA"
+          for smoke in packaged-media-smoke.mjs packaged-tab-handoff-protocol-smoke.mjs; do
+            git show "$VERIFICATION_SHA:test/desktop/$smoke" > "test/desktop/$smoke"
+          done
 
       - name: Verify packaged microphone and camera permissions and live tracks
         run: |

--- a/docs/release-incidents/2026-09-11-v1.16.1.md
+++ b/docs/release-incidents/2026-09-11-v1.16.1.md
@@ -1,6 +1,7 @@
 # v1.16.1 recovery and Sunrise release — 2026-09-11
 
-Status: preparation; no publication or platform verification claimed yet.
+Status: immutable draft at `6d1608a92173e8d0ea4a771d7c1d671ede91b39a`;
+macOS and Linux verified, Windows harness recovery in progress. Unpublished.
 
 ## Scope
 
@@ -37,3 +38,34 @@ See `docs/verification/2026-09-11-mimestream-recovery.md` and
 - Adjacent public v1.16.0 → v1.16.1 macOS and Windows in-app updater handoffs.
 - Canonical site deployment and release-backed launch disposition. Publication
   alone does not establish a launch freeze or shorten the required soak.
+
+## Build and native recovery
+
+- The first local build stopped before signing because the shell selected
+  Command Line Tools, which lack the required icon compiler. No tag or draft
+  existed. The successful restart selected installed Xcode 27 with the
+  process-local `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer`.
+- The complete press gate passed: 1,773 unit tests, 141 desktop scenarios and
+  865 steps, cold launch, OAuth, DNS, substrate, dependency audit, and site/SEO.
+- The macOS arm64 app passed signing, notarization, strict deep verification,
+  entitlements/profile verification, hardened fuses, blocker/compliance payloads,
+  packaged first run and regressions, both live favicon matrices, and migration
+  from public v1.16.0. Separate signed-package native checks observed live
+  microphone input and a 640×480 camera frame without saving media.
+- Actual `app.asar` inspection confirmed retired icon assets absent and both
+  Sunrise variants plus Mahjong retained.
+- Native run <https://github.com/bnfy/blanc/actions/runs/34637464540> completed
+  Linux packaging, media/protocol checks, upload, and provenance successfully.
+  Windows attempt 1 passed its media and signature checks but the protocol
+  harness read a document during navigation (`Execution context was destroyed`).
+  Attempt 2 passed its media assertions, then cleanup hit a transient Windows
+  cache-file `EBUSY`. Neither Windows attempt uploaded release assets.
+- Recovery keeps the application source tag and completed native assets
+  unchanged. The harness retries only navigation-destroyed evaluations within
+  its existing deadline and retries filesystem cleanup for at most 3 seconds;
+  other errors and persistent failures remain fatal. Native workflows load
+  these two harness files from their immutable workflow commit only after
+  packaging the application from the release tag.
+- The September 11, 3 p.m. ET launch-readiness cutoff passed with this release
+  still unpublished. The existing four-day launch sequence cannot proceed on
+  that cutoff, and neither publication nor recovery waives the required soak.

--- a/test/desktop/packaged-media-smoke.mjs
+++ b/test/desktop/packaged-media-smoke.mjs
@@ -145,5 +145,7 @@ try {
   }
   server.closeAllConnections?.();
   await new Promise((resolve) => server.close(resolve));
-  fs.rmSync(userDataDir, { recursive: true, force: true });
+  // Windows can retain a child-process cache handle briefly after app exit.
+  // A persistent lock still fails the gate after this bounded cleanup retry.
+  fs.rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
 }

--- a/test/desktop/packaged-tab-handoff-protocol-smoke.mjs
+++ b/test/desktop/packaged-tab-handoff-protocol-smoke.mjs
@@ -7,6 +7,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { promisify } from 'node:util';
 import { launchPackagedOverCdp } from './support/packaged-cdp.mjs';
+import { isTransientElectronEvaluationError } from './support/electron-evaluate.mjs';
 
 const execFileAsync = promisify(execFile);
 const pkg = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf8'));
@@ -31,7 +32,15 @@ const poll = async (read, predicate, message, timeoutMs = 20_000) => {
   const deadline = Date.now() + timeoutMs;
   let value;
   while (Date.now() < deadline) {
-    value = await read();
+    try {
+      value = await read();
+    } catch (error) {
+      // The sheet's URL can become visible before its new document is ready.
+      // Retry only that navigation race within the existing overall deadline.
+      if (!isTransientElectronEvaluationError(error)) throw error;
+      await delay(100);
+      continue;
+    }
     if (predicate(value)) return value;
     await delay(100);
   }
@@ -207,5 +216,5 @@ try {
   console.log(`packaged-tab-handoff-protocol-smoke OK on ${process.platform}`);
 } finally {
   if (app) await app.close().catch(() => {});
-  fs.rmSync(runtimeRoot, { recursive: true, force: true });
+  fs.rmSync(runtimeRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
 }


### PR DESCRIPTION
Windows release verification can fail before judging the app: the handoff harness may read a document during navigation, and media cleanup may race a briefly retained Chromium cache handle. Retry only navigation-destroyed evaluations within the existing deadline, and use bounded filesystem cleanup retries that still fail on persistent locks.

Native workflows load these two smoke harnesses from the workflow commit after packaging the application from the release tag. This permits infrastructure-only recovery of the existing v1.16.1 draft without changing its source tag or replacing the completed Mac/Linux assets. All protocol, permission, live-track, signing, and artifact assertions remain required.

Validation: 21 focused unit tests passed. Corrected packaged media and installed handoff harnesses both passed against the signed v1.16.1 Mac binary. The Windows recovery run remains required before publication. The incident records both failed Windows attempts and the missed launch-readiness cutoff.
