### PR TITLE
Record v1.16.1 production site deployment

### DIFF
--- a/docs/release-incidents/2026-09-11-v1.16.1.md
+++ b/docs/release-incidents/2026-09-11-v1.16.1.md
@@ -1,8 +1,8 @@
 # v1.16.1 recovery and Sunrise release — 2026-09-11
 
 Status: published at `2026-09-11T19:27:45Z` from immutable source
-`6d1608a92173e8d0ea4a771d7c1d671ede91b39a`. Public artifact checks passed;
-adjacent updater handoffs and canonical site deployment remain pending.
+`6d1608a92173e8d0ea4a771d7c1d671ede91b39a`. Public artifact and canonical
+site deployment checks passed; adjacent updater handoffs remain pending.
 
 Release: <https://github.com/bnfy/blanc/releases/tag/v1.16.1>.
 
@@ -110,3 +110,15 @@ See `docs/verification/2026-09-11-mimestream-recovery.md` and
   passed all three jobs: authenticated published AppImage launch/render and
   Windows/Linux DNS startup. This is distinct from the earlier source-checkout
   smoke <https://github.com/bnfy/blanc/actions/runs/34635942604>.
+
+## Site evidence
+
+- Release-record PR <https://github.com/bnfy/blanc/pull/330> merged as
+  `4684e93e4cf6ab28e7f726df531619e81d7304f3` after every required check passed.
+- `npm run site:deploy` ran from a clean checkout of that exact commit.
+  Cloudflare Pages deployment `e4f7f334-fb5e-46c5-a7cb-9ea1ac8d13c9` is
+  `Production` on branch `main` with source `4684e93`.
+- The canonical homepage reports `softwareVersion: 1.16.1`. The canonical
+  changelog shows v1.16.1 with the session-recovery and theme-aware Sunrise
+  changes. The launch remains stopped because the release missed the cutoff;
+  site publication is not launch approval.


### PR DESCRIPTION
Record the verified production deployment for v1.16.1. Cloudflare deployment e4f7f334-fb5e-46c5-a7cb-9ea1ac8d13c9 is Production on branch main from source 4684e93; the canonical homepage and changelog expose v1.16.1. Adjacent updater handoffs remain pending, and the missed launch cutoff remains explicit.