### PR TITLE
Handle restored Chrome Web Store tabs

### DIFF
--- a/docs/verification/2026-09-11-chrome-web-store-crash.md
+++ b/docs/verification/2026-09-11-chrome-web-store-crash.md
@@ -45,8 +45,9 @@ Chrome Web Store page no longer exposes the unsupported API.
   delegation.
 - `npm run test:web-store-guard` launches Electron 44.3.0 with an isolated
   profile and Blanc Blocker disabled, navigates the active tab to a Chrome Web
-  Store detail URL, observes the local explanation page, and confirms the
-  browser process remains alive with no uncaught main-process exception.
+  Store detail URL, then repeats from a saved session whose selected Store tab
+  is born quiet. Both paths must show the local explanation page, hide Retry,
+  and keep the browser process alive with no uncaught main-process exception.
 - The smoke is part of `release:verify:press` so a future release cannot omit
   this gate while the workaround remains.
 

--- a/src/main/chrome-web-store-guard.js
+++ b/src/main/chrome-web-store-guard.js
@@ -19,6 +19,16 @@ function shouldBlockChromeWebStoreRequest(details) {
     && isChromeWebStoreUrl(details?.url);
 }
 
+function chromeWebStoreErrorPageUrl(value, code) {
+  if (!isChromeWebStoreUrl(value)) return null;
+  const query = new URLSearchParams({
+    kind: 'chrome-web-store',
+    url: value,
+    code: String(code),
+  });
+  return `blanc://error/?${query}`;
+}
+
 /**
  * Own the session's single onBeforeRequest listener. The Web Store crash guard
  * always wins; ordinary requests delegate to the blocker only while it is on.
@@ -41,5 +51,6 @@ module.exports = {
   CHROME_WEB_STORE_HOST,
   isChromeWebStoreUrl,
   shouldBlockChromeWebStoreRequest,
+  chromeWebStoreErrorPageUrl,
   createBeforeRequestPolicy,
 };

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -34,6 +34,7 @@ const {
   onRequestBlocked,
 } = require('./adblock');
 const { blockableHostname, resolveBlockAdsCommand } = require('./adblock-exceptions');
+const { chromeWebStoreErrorPageUrl } = require('./chrome-web-store-guard');
 const islandProximity = require('./island-proximity');
 const {
   recordActivation,
@@ -2119,17 +2120,21 @@ function commitWake(tab, generation) {
   return true;
 }
 
-async function failWake(tab, generation) {
+async function failWake(tab, generation, { failedUrl = tab.url } = {}) {
   if (tab.wakeGeneration !== generation) return false;
   const wc = liveContents(tab);
   if (wc) {
-    const q = new URLSearchParams({
-      url: tab.url ?? '',
-      code: 'wake-failed',
-      desc: 'The page could not be reloaded',
-      title: tab.title ?? '',
-    });
-    await wc.loadURL(`blanc://error/?${q}`).catch(() => {});
+    let destination = chromeWebStoreErrorPageUrl(failedUrl ?? '', 'wake-failed');
+    if (!destination) {
+      const q = new URLSearchParams({
+        url: failedUrl ?? '',
+        code: 'wake-failed',
+        desc: 'The page could not be reloaded',
+        title: tab.title ?? '',
+      });
+      destination = `blanc://error/?${q}`;
+    }
+    await wc.loadURL(destination).catch(() => {});
   }
   if (tab.wakeGeneration !== generation) return false;
   tab.asleep = false;
@@ -2244,7 +2249,9 @@ async function wakeTab(id, { navigateTo = null, atIndex = null } = {}) {
     // Exactly one fallback, only after restore rejects. A rejected plain load
     // gets its error page, not an unbounded retry loop.
     const canFallBack = !navigateTo && !!snapshot?.entries.length;
-    if (!canFallBack) return failWake(tab, generation);
+    if (!canFallBack) {
+      return failWake(tab, generation, { failedUrl: navigateTo ?? tab.url });
+    }
     const live = liveContents(tab);
     if (!live) return failWake(tab, generation);
     try {

--- a/src/main/tab-view.js
+++ b/src/main/tab-view.js
@@ -24,7 +24,7 @@ const {
 } = require('./favicon-policy');
 const { blockableHostname } = require('./adblock-exceptions');
 const { isForbiddenTopLevelUrl } = require('./top-level-url-policy');
-const { isChromeWebStoreUrl } = require('./chrome-web-store-guard');
+const { chromeWebStoreErrorPageUrl } = require('./chrome-web-store-guard');
 
 let deps = null;
 
@@ -322,13 +322,9 @@ function wireTabView(tab, view, { owner, adopted }) {
     if (tab.sleeping || tab.view?.webContents !== wc) return;
     if (noteWakeSuppressed(tab)) return;
     if (!isMainFrame || !validatedURL) return;
-    if (isChromeWebStoreUrl(validatedURL)) {
-      const q = new URLSearchParams({
-        kind: 'chrome-web-store',
-        url: validatedURL,
-        code: String(errorCode),
-      });
-      wc.loadURL(`blanc://error/?${q}`).catch(() => {});
+    const guardedErrorUrl = chromeWebStoreErrorPageUrl(validatedURL, errorCode);
+    if (guardedErrorUrl) {
+      wc.loadURL(guardedErrorUrl).catch(() => {});
       return;
     }
     if (errorCode === -3) return;

--- a/test/desktop/chrome-web-store-guard-smoke.mjs
+++ b/test/desktop/chrome-web-store-guard-smoke.mjs
@@ -9,41 +9,63 @@ import poll from './support/poll.js';
 const { callTestHook } = testHookCall;
 const { waitForValue } = poll;
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'blanc-web-store-guard-'));
-const userDataDir = path.join(root, 'profile');
-const profile = `${userDataDir}-Dev`;
-fs.mkdirSync(profile);
-fs.writeFileSync(path.join(profile, 'settings.json'), JSON.stringify({
-  onboardingVersion: 1,
-  adblockEnabled: false,
-  usagePing: false,
-  searchSuggestions: false,
-}));
 const uncaughtLog = path.join(root, 'uncaught.log');
 const { ELECTRON_RUN_AS_NODE: ignored, ...env } = process.env;
 const storeUrl = 'https://chromewebstore.google.com/detail/example/abcdefghijklmnop';
-let app;
-try {
-  app = await _electron.launch({
-    args: [path.resolve('.'), `--user-data-dir=${userDataDir}`],
-    env: { ...env, BLANC_TEST: '1', BLANC_TEST_UNCAUGHT_LOG: uncaughtLog },
-  });
-  await app.firstWindow();
-  await waitForValue(() => callTestHook(app, 'startupReady'), Boolean, 'startup release');
-  const before = await callTestHook(app, 'state');
-  await callTestHook(app, 'navigateTab', [before.activeTabId, storeUrl]).catch(() => false);
+const prepareProfile = (name, { restored = false } = {}) => {
+  const userDataDir = path.join(root, name);
+  const profile = `${userDataDir}-Dev`;
+  fs.mkdirSync(profile);
+  fs.writeFileSync(path.join(profile, 'settings.json'), JSON.stringify({
+    onboardingVersion: 1,
+    adblockEnabled: false,
+    usagePing: false,
+    searchSuggestions: false,
+  }));
+  if (restored) {
+    fs.writeFileSync(path.join(profile, 'session.json'), JSON.stringify({
+      urls: [storeUrl],
+      activeIndex: 0,
+    }));
+  }
+  return userDataDir;
+};
 
+const launch = (userDataDir) => _electron.launch({
+  args: [path.resolve('.'), `--user-data-dir=${userDataDir}`],
+  env: { ...env, BLANC_TEST: '1', BLANC_TEST_UNCAUGHT_LOG: uncaughtLog },
+});
+
+const expectExplanation = async (app, label) => {
   const state = await waitForValue(() => callTestHook(app, 'state'), (candidate) => {
     const active = candidate.tabs.find((tab) => tab.id === candidate.activeTabId);
     return active?.url.startsWith('blanc://error/?kind=chrome-web-store');
-  }, 'Web Store navigation replaced by local error page');
+  }, `${label} replaced by local error page`);
   const active = state.tabs.find((tab) => tab.id === state.activeTabId);
   const page = await waitForValue(async () => (await app.windows()).find((candidate) =>
-    candidate.url() === active.url), Boolean, 'local Web Store explanation page');
+    candidate.url() === active.url), Boolean, `${label} explanation page`);
   assert.equal(await page.locator('#errorTitle').textContent(), 'Chrome Web Store is temporarily unavailable');
   assert.match(await page.locator('#errorDetail').textContent(), /prevent a browser crash/);
   assert.equal(await page.locator('#retryLink').isVisible(), false);
   assert.equal(await app.evaluate(({ app }) => app.isReady()), true, 'browser process remains alive');
-  console.log('chrome-web-store-guard-smoke PASS: unsafe document blocked before load; local explanation rendered; browser process alive');
+};
+
+let app;
+try {
+  app = await launch(prepareProfile('direct'));
+  await app.firstWindow();
+  await waitForValue(() => callTestHook(app, 'startupReady'), Boolean, 'startup release');
+  const before = await callTestHook(app, 'state');
+  await callTestHook(app, 'navigateTab', [before.activeTabId, storeUrl]).catch(() => false);
+  await expectExplanation(app, 'direct Web Store navigation');
+  await app.close();
+  app = null;
+
+  app = await launch(prepareProfile('restored', { restored: true }));
+  await app.firstWindow();
+  await waitForValue(() => callTestHook(app, 'startupReady'), Boolean, 'restored startup release');
+  await expectExplanation(app, 'restored quiet Web Store tab');
+  console.log('chrome-web-store-guard-smoke PASS: direct and restored unsafe documents blocked; local explanation rendered; browser process alive');
 } finally {
   if (app) await app.close();
   const errors = fs.existsSync(uncaughtLog) ? fs.readFileSync(uncaughtLog, 'utf8').trim() : '';

--- a/test/unit/chrome-web-store-guard.test.js
+++ b/test/unit/chrome-web-store-guard.test.js
@@ -5,6 +5,7 @@ const test = require('node:test');
 const {
   isChromeWebStoreUrl,
   shouldBlockChromeWebStoreRequest,
+  chromeWebStoreErrorPageUrl,
   createBeforeRequestPolicy,
 } = require('../../src/main/chrome-web-store-guard');
 
@@ -38,6 +39,21 @@ test('the guard blocks Web Store documents but leaves non-document resources alo
       url: 'https://chromewebstore.google.com/detail/example/abc',
     }), false);
   }
+});
+
+test('the guarded error URL is shared by ordinary failures and quiet-tab wake failures', () => {
+  const source = 'https://chromewebstore.google.com/detail/example/abc';
+  const direct = new URL(chromeWebStoreErrorPageUrl(source, -3));
+  assert.equal(direct.protocol, 'blanc:');
+  assert.equal(direct.hostname, 'error');
+  assert.equal(direct.searchParams.get('kind'), 'chrome-web-store');
+  assert.equal(direct.searchParams.get('url'), source);
+  assert.equal(direct.searchParams.get('code'), '-3');
+
+  const wake = new URL(chromeWebStoreErrorPageUrl(source, 'wake-failed'));
+  assert.equal(wake.searchParams.get('kind'), 'chrome-web-store');
+  assert.equal(wake.searchParams.get('code'), 'wake-failed');
+  assert.equal(chromeWebStoreErrorPageUrl('https://example.com/', -3), null);
 });
 
 test('the Web Store guard outranks blocker state and site exceptions', () => {


### PR DESCRIPTION
A selected Chrome Web Store tab restored from disk wakes under Blanc's quiet-tab suppression flag, so its blocked load bypassed the Store-specific failure handler and fell through to the generic reload error with Retry still visible. This change shares the Store error URL builder with wake failures and preserves the attempted target URL when a quiet tab is redirected during wake.

The Electron smoke now exercises both direct navigation and a selected Store tab loaded from `session.json`; each must show the dedicated explanation, hide Retry, and leave the browser process alive.

Validation:
- `npm run test:unit` — 1,779 passed
- `npm run test:web-store-guard` — direct and restored scenarios passed
- `npm run substrate:check` — passed
- `npm run test:startup-layout` — passed
