### PR TITLE
Prepare Blanc 1.16.2 release

### DIFF
--- a/compliance/root-lock-sbom.cdx.json
+++ b/compliance/root-lock-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:root:blanc@1.16.1",
+      "bom-ref": "application:root:blanc@1.16.2",
       "name": "blanc dependency lock",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "description": "Complete root npm supply-chain inventory, including development and optional packages."
     },
     "properties": [
@@ -18197,7 +18197,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:root:blanc@1.16.1",
+      "ref": "application:root:blanc@1.16.2",
       "dependsOn": [
         "pkg:npm/%401password/sdk@0.5.0",
         "pkg:npm/%40cucumber/cucumber@13.2.1",

--- a/compliance/runtime-sbom.cdx.json
+++ b/compliance/runtime-sbom.cdx.json
@@ -5,9 +5,9 @@
   "metadata": {
     "component": {
       "type": "application",
-      "bom-ref": "application:runtime:blanc@1.16.1",
+      "bom-ref": "application:runtime:blanc@1.16.2",
       "name": "Blanc",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "description": "Shipped desktop runtime: npm closure, Electron framework, bundled fonts, and blocker data provenance."
     },
     "properties": [
@@ -1704,7 +1704,7 @@
   ],
   "dependencies": [
     {
-      "ref": "application:runtime:blanc@1.16.1",
+      "ref": "application:runtime:blanc@1.16.2",
       "dependsOn": [
         "asset:blanc-adblock-seed",
         "asset:inter-font",

--- a/docs/press/release-notes/v1.16.2.md
+++ b/docs/press/release-notes/v1.16.2.md
@@ -1,0 +1,11 @@
+# Blanc 1.16.2
+
+## Fixed
+
+- Opening or restoring a Chrome Web Store page no longer crashes Blanc. Until Electron ships its upstream correction, Blanc shows a local explanation page before the affected site can trigger the native crash.
+- Restored Chrome Web Store tabs now recover safely without preventing the rest of the saved session from opening.
+- The macOS About panel now displays a distinct build number instead of repeating the public version.
+
+## Known limitation
+
+- Chrome Web Store pages are temporarily unavailable inside Blanc. Use another browser to browse the store until Blanc can adopt Electron's upstream fix.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blanc",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blanc",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blanc",
   "productName": "Blanc",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Minimal Electron browser shell: custom chrome UI + built-in ad/tracker blocking, no extension-store dependency.",
   "main": "src/main/main.js",
   "type": "commonjs",
@@ -132,7 +132,7 @@
     "afterPack": "scripts/after-pack-app-icons.js",
     "afterSign": "scripts/after-sign-verify.js",
     "mac": {
-      "bundleVersion": "1161",
+      "bundleVersion": "1162",
       "category": "public.app-category.productivity",
       "icon": "build/app-icons/Icon.icon",
       "hardenedRuntime": true,


### PR DESCRIPTION
Public v1.16.1 can still crash its browser process when a page on the Chrome Web Store invokes Electron's unsupported `chrome.webstorePrivate` API. The crash guard and restored-tab recovery have since landed on `main`; this patch release packages those fixes and gives macOS a distinct build number.

This prepares v1.16.2 with macOS bundle build 1162, refreshed version-bound SBOMs, and checked-in release notes. Migration testing remains pinned to public v1.16.1.

Validation:
- `npm run release:verify:press`
- 1,780 unit tests passed
- 141 desktop scenarios and 865 steps passed
- cold launch, direct/restored Chrome Web Store guard, OAuth, DNS, security audit, substrate, site build, and SEO checks passed
