### PR TITLE
Record v1.16.2 site deployment

### DIFF
--- a/docs/release-incidents/2026-09-11-v1.16.2.md
+++ b/docs/release-incidents/2026-09-11-v1.16.2.md
@@ -1,9 +1,9 @@
 # v1.16.2 Chrome Web Store crash guard release — 2026-09-11
 
 Status: published at `2026-09-11T21:24:34Z` from immutable source
-`0cced924b458496869295c711162c315a4d5da29`. Public artifact and exact-tag
-smoke checks passed. Canonical site deployment and both adjacent updater
-handoffs remain pending.
+`0cced924b458496869295c711162c315a4d5da29`. Public artifact, exact-tag smoke,
+and canonical site deployment checks passed. Both adjacent updater handoffs
+remain pending.
 
 Release: <https://github.com/bnfy/blanc/releases/tag/v1.16.2>.
 
@@ -81,9 +81,14 @@ the store in another browser until Blanc adopts the upstream fix.
 
 ## Site evidence
 
-- The generated release data includes public v1.16.2 and its fixed/known-
-  limitation notes. Release-record merge, production deployment, exact source
-  verification, and canonical homepage/changelog checks remain pending.
+- Release-record PR <https://github.com/bnfy/blanc/pull/337> merged as
+  `cac2819190e28315c6425a6352f7623d6e6f1c73` after every required check passed.
+- `npm run site:deploy` ran from a clean checkout of that exact commit.
+  Cloudflare Pages deployment `c79e397e-a0a8-4bb0-b97e-cd30355fc72a` is
+  `Production` on branch `main` with source `cac2819`.
+- The canonical homepage reports `softwareVersion: 1.16.2`. The canonical
+  changelog shows the Chrome Web Store crash guard, restored-tab recovery,
+  distinct About build number, and temporary store limitation.
 
 ## Updater evidence
 


### PR DESCRIPTION
Records the completed production site deployment for Blanc 1.16.2.

Cloudflare Pages deployment `c79e397e-a0a8-4bb0-b97e-cd30355fc72a` is Production on `main` from exact source `cac2819`. The canonical homepage reports `softwareVersion: 1.16.2`, and the canonical changelog contains the Chrome Web Store guard, restored-tab recovery, About build-number fix, and temporary store limitation.

Both adjacent v1.16.1 → v1.16.2 updater handoffs remain explicitly pending.
